### PR TITLE
Sync git submodules before updating them

### DIFF
--- a/templates/server/post-receive.erb
+++ b/templates/server/post-receive.erb
@@ -77,6 +77,7 @@ $stdin.each_line do |line|
             FileUtils.rm_rf $1, :secure => true
           end
         end
+        %x{git submodule sync}
         %x{git submodule update --init --recursive}
       end
     else


### PR DESCRIPTION
From the git submodule manpage under sync:
   Synchronizes submodules' remote URL configuration setting to the
   value specified in .gitmodules. It will only affect those submodules
   which already have an url entry in .git/config (that is the case when
   they are initialized or freshly added). This is useful when submodule
   URLs change upstream and you need to update your local repositories
   accordingly.
