### PR TITLE
allow passing extra_params to puppet agent

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -21,7 +21,8 @@ class puppet::server (
   $post_hook_content   = $puppet::params::post_hook_content,
   $post_hook_name      = $puppet::params::post_hook_name,
   $agent_template      = $puppet::params::agent_template,
-  $master_template     = $puppet::params::master_template
+  $master_template     = $puppet::params::master_template,
+  $agent_params        = undef
 ) inherits puppet::params {
   class { 'puppet::server::install': }~>
   class { 'puppet::server::config': }

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -29,3 +29,8 @@
     environment = <%= environment %>
     certname    = <%= clientcert %>
     server      = <%= puppetmaster rescue fqdn %>
+<% if has_variable?("agent_params") and agent_params != :undef -%>
+  <% agent_params.each do |param| -%>
+    <%= param %>
+  <% end -%>
+<% end -%>


### PR DESCRIPTION
Pass an array of configuration lines to add to the [agent] section of
puppet.conf:

$agent_params = ["splay = true"]

class {'::puppet':
  agent_params => $agent_params,
}
