### PR TITLE
Correctly determine the puppet command on old and new puppet systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,7 @@ class puppet::params {
   $app_root            = "${dir}/rack"
   $ssl_dir             = '/var/lib/puppet/ssl'
 
-  $master_package      = $::operatingsystem ? {
+  $master_package     =  $::operatingsystem ? {
     /(Debian|Ubuntu)/ => ['puppetmaster'],
     default           => ['puppet-server'],
   }
@@ -45,4 +45,19 @@ class puppet::params {
   # This only applies to puppet::cron
   $cron_range          = 60 # the maximum value for our cron
   $cron_interval       = 2  # the amount of values within the $cron_range
+
+  # Puppet cert / ca commands are all over the place...
+  if versioncmp($puppetversion, '2.6') < 0 {
+    $puppetca_bin = 'puppetca'
+  } else {
+    $puppetca_bin = 'puppet cert'
+  }
+
+  $puppetca_path      =  $::operatingsystem ? {
+    /(Debian|Ubuntu)/ => '/usr/bin',
+    default           => '/usr/sbin',
+  }
+
+  $puppetca_cmd = "${puppetca_path}/${puppetca_bin}"
+
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -18,7 +18,7 @@ class puppet::server::config inherits puppet::config {
 
   exec {'generate_ca_cert':
     creates => "${puppet::server::ssl_dir}/certs/${::fqdn}.pem",
-    command => "puppetca --generate ${::fqdn}",
+    command => "${puppet::params::puppetca_bin} --generate ${::fqdn}",
     path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
   }
 


### PR DESCRIPTION
This supercedes theforeman/puppet-puppet/pull/14. I prefer the versioncmp to a regex, it's more readable. 

Once this is merged (and 14 closed) we can update foreman-proxy to use the $puppetca_cmd variable (as discussed in the comments at theforeman/puppet-foreman_proxy/pull/23)
