### PR TITLE
Update config.ru for Puppet 3.0 masters

### DIFF
--- a/files/config.ru
+++ b/files/config.ru
@@ -2,14 +2,35 @@
 # SSL needs to be handled outside this, though.
 
 # if puppet is not in your RUBYLIB:
-# $:.unshift('/opt/puppet/lib')
+# $LOAD_PATH.unshift('/opt/puppet/lib')
+
 $0 = "master"
 
 # if you want debugging:
-#ARGV << "--debug"
+# ARGV << "--debug"
 
 ARGV << "--rack"
-require 'puppet/application/master'
+
+# Rack applications typically don't start as root.  Set --confdir and --vardir
+# to prevent reading configuration from ~puppet/.puppet/puppet.conf and writing
+# to ~puppet/.puppet
+ARGV << "--confdir" << "/etc/puppet"
+ARGV << "--vardir"  << "/var/lib/puppet"
+
+# NOTE: it's unfortunate that we have to use the "CommandLine" class
+#  here to launch the app, but it contains some initialization logic
+#  (such as triggering the parsing of the config file) that is very
+#  important.  We should do something less nasty here when we've
+#  gotten our API and settings initialization logic cleaned up.
+#
+# Also note that the "$0 = master" line up near the top here is
+#  the magic that allows the CommandLine class to know that it's
+#  supposed to be running master.
+#
+# --cprice 2012-05-22
+
+require 'puppet/util/command_line'
 # we're usually running inside a Rack::Builder.new {} block,
 # therefore we need to call run *here*.
-run Puppet::Application[:master].run
+run Puppet::Util::CommandLine.new.execute
+

--- a/files/config.ru.2
+++ b/files/config.ru.2
@@ -1,0 +1,15 @@
+# a config.ru, for use with every rack-compatible webserver.
+# SSL needs to be handled outside this, though.
+
+# if puppet is not in your RUBYLIB:
+# $:.unshift('/opt/puppet/lib')
+$0 = "master"
+
+# if you want debugging:
+#ARGV << "--debug"
+
+ARGV << "--rack"
+require 'puppet/application/master'
+# we're usually running inside a Rack::Builder.new {} block,
+# therefore we need to call run *here*.
+run Puppet::Application[:master].run

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -32,10 +32,15 @@ class puppet::server::passenger {
       ensure => directory,
       owner  => $puppet::params::user,
   }
+
+  $configru_version = $puppetversion ? {
+    /^2.*/  => "config.ru.2",
+    default => "config.ru"
+  }
   file {
     "${puppet::params::app_root}/config.ru":
       owner  => $puppet::params::user,
-      source => 'puppet:///modules/puppet/config.ru',
+      source => "puppet:///modules/puppet/${configru_version}",
       notify => Exec['restart_puppet'],
   }
 


### PR DESCRIPTION
Now provides two config.ru files, one for 3.0 up and one for 2.*.  Greg was testing the new config.ru on Ubuntu 12.04.  I've tested on RHEL with 2.7 and 3.0.
