### PR TITLE
Allow specifying what puppet version to use. Defaults to "present".

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,8 @@ class puppet (
   $post_hook_content   = $puppet::params::post_hook_content,
   $post_hook_name      = $puppet::params::post_hook_name,
   $agent_template      = $puppet::params::agent_template,
-  $master_template     = $puppet::params::master_template
+  $master_template     = $puppet::params::master_template,
+  $version             = $puppet::params::version
 ) inherits puppet::params {
   class { 'puppet::install': }~>
   class { 'puppet::config': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,3 +1,5 @@
 class puppet::install {
-  package { 'puppet': ensure => installed }
+
+  package { $puppet::params::client_package: ensure => $::puppet::version }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class puppet::params {
   include foreman::params
 
   # Basic config
+  $version             = 'present'
   $user                = 'puppet'
   $dir                 = '/etc/puppet'
   $ca                  = true
@@ -40,8 +41,12 @@ class puppet::params {
   $ssl_dir             = '/var/lib/puppet/ssl'
 
   $master_package     =  $::operatingsystem ? {
-    /(Debian|Ubuntu)/ => ['puppetmaster'],
+    /(Debian|Ubuntu)/ => ['puppetmaster-common','puppetmaster'],
     default           => ['puppet-server'],
+  }
+  $client_package     = $::operatingsystem ? {
+    /(Debian|Ubuntu)/ => ['puppet-common','puppet'],
+    default           => ['puppet'],
   }
 
   # This only applies to puppet::cron

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -22,7 +22,8 @@ class puppet::server (
   $post_hook_content   = $puppet::params::post_hook_content,
   $post_hook_name      = $puppet::params::post_hook_name,
   $agent_template      = $puppet::params::agent_template,
-  $master_template     = $puppet::params::master_template
+  $master_template     = $puppet::params::master_template,
+  $version             = $puppet::params::version
 ) inherits puppet::params {
   class { 'puppet::server::install': }~>
   class { 'puppet::server::config': }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,5 +1,5 @@
 class puppet::server::install {
 
-  package { $puppet::server::master_package: ensure => installed }
+  package { $puppet::server::master_package: ensure => $::puppet::server::version  }
 
 }


### PR DESCRIPTION
Split out pull request #19.

This required including both puppet and puppet-common for debian. Same
for puppetmaster and puppetmaster-common.
