### PR TITLE
set recursive ownership to puppet

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -27,16 +27,18 @@ class puppet::server::config inherits puppet::config {
 
     # location where our puppet environments are located
     file { $puppet::server::envs_dir:
-      ensure => directory,
-      owner  => $puppet::server::user,
+      ensure  => directory,
+      owner   => $puppet::server::user,
+      recurse => true,
     }
 
     # need to chown the $vardir before puppet does it, or else
     # we can't write puppet.git/ on the first run
 
     file { '/var/lib/puppet':
-      ensure => directory,
-      owner  => $puppet::server::user,
+      ensure  => directory,
+      owner   => $puppet::server::user,
+      recurse => true,
     }
 
     include git


### PR DESCRIPTION
If a user pushes as root, ownership will be incorrect. Making sure that puppet
remains owner prevents problems when pushing as the puppet user.
