### PR TITLE
Run post-receive as the file owner

### DIFF
--- a/templates/server/post-receive.erb
+++ b/templates/server/post-receive.erb
@@ -27,6 +27,12 @@ unless File.directory? ENVIRONMENT_BASEDIR
   exit 1
 end
 
+# If we're running as root we change our UID to the owner of this file.
+file_uid = File.stat($0).uid
+if file_uid != Process.uid and Process.uid == 0
+  Process::UID.change_privilege(file_uid)
+end
+
 # You can push multiple refspecs at once, like 'git push origin branch1 branch2',
 # so we need to handle each one.
 $stdin.each_line do |line|


### PR DESCRIPTION
It's possible to run the git hook as user puppet, but anther user could
push as root and this will create files with owner root. The next user
could push again as puppet and get errors. After some discussion in
https://github.com/theforeman/puppet-puppet/pull/30 a conclusion was
reached that it's desired to run the hook as the file owner.

This patch adds setuid like behavior. It checks if we're running as a
different user than the file owner and root if that user is root. If so
we change the uid to the file owner.
