### PR TITLE
Push to a mirror if it's defined

### DIFF
--- a/templates/server/post-receive.erb
+++ b/templates/server/post-receive.erb
@@ -88,3 +88,8 @@ $stdin.each_line do |line|
     end
   end
 end
+
+# If we have a remote named mirror we push there as well
+if %x{git remote} =~ /^mirror$/
+  %x{git push mirror --mirror}
+end


### PR DESCRIPTION
The use case is that we have a central git server with a webinterface.
The easiest solution is to make one push to the other and disallow
commits from anyone on the mirror. Since we have multiple smart proxies
and only a single git server I think the easiest solution is to make
each smart proxy push instead of the other way around.

By using a non-standard remote name the chance of breaking an existing
setup is very small. The user is assumed to set up the remote and
authentication.
