### PR TITLE
Move puppet user creation to install

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -75,10 +75,6 @@ class puppet::server::config inherits puppet::config {
       require => Git::Repo['puppet_repo'],
     }
 
-    user { $puppet::server::user:
-      shell => '/usr/bin/git-shell',
-    }
-
   }
   else
   {

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -5,4 +5,9 @@ class puppet::server::install {
     ensure => $::puppet::server::version,
   }
 
+  if $puppet::server::git_repo {
+    user { $puppet::server::user:
+      shell => '/usr/bin/git-shell',
+    }
+  }
 }


### PR DESCRIPTION
Defining the user puppet in config causes a dependency cycle if the user is
using git_repo=true:

(Exec[restart_puppet] => Class[Puppet::Server::Passenger] => Class[Puppet::Server::Config] => User[puppet] => File[/etc/puppet/rack/config.ru] => Class[Puppet::Server::Passenger])

By moving it to install we ensure it's already there.
