### PR TITLE
Allow for different possible locations of the puppet binary inside the cronjob

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -6,7 +6,7 @@ class puppet::cron inherits puppet::service {
   }
 
   cron { 'puppet':
-    command => "sleep $((RANDOM%59)) && /usr/sbin/puppet agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize",
+    command => "/usr/bin/env puppet agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize",
     user    => root,
     minute  => ip_to_cron($puppet::cron_interval, $puppet::cron_range),
   }


### PR DESCRIPTION
Also drop the sleep as it doesn't work on all shells
