### PR TITLE
Bug 2306 - Check for a nil/empty puppetmaster var, and fall back to fqdn. 

### DIFF
--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -97,7 +97,7 @@ allow *
 path /run
 auth any
 method save
-allow <% if puppetmaster.nil? || puppetmaster.empty? %><%= fqdn %><% else %><%= puppetmaster %><% end %>
+allow <%= if ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>
 
 <% end -%>
 # this one is not stricly necessary, but it has the merit

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -35,9 +35,9 @@
     report      = true
     pluginsync  = <%= scope.lookupvar('::puppet::pluginsync') %>
     masterport  = <%= scope.lookupvar("::puppet::port") rescue 8140 %>
-    environment = <%= environment %>
-    certname    = <%= clientcert %>
-    server      = <% if puppetmaster.nil? || puppetmaster.empty? %><%= fqdn %><% else %><%= puppetmaster %><% end %>
+    environment = <%= @environment %>
+    certname    = <%= @clientcert %>
+    server      = <%= if ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>
     listen      = <%= scope.lookupvar('::puppet::listen') %>
     splay       = <%= scope.lookupvar('::puppet::splay') %>
     runinterval = <%= scope.lookupvar('::puppet::runinterval') %>


### PR DESCRIPTION
Check if puppetmaster var is nil or empty when configuring puppet agent, and fall back to fqdn where appropriate. 
