### PR TITLE
Added ca_server to params and puppet.conf template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class puppet (
   $dir                 = $puppet::params::dir,
   $vardir              = $puppet::params::vardir,
   $ca                  = $puppet::params::ca,
+  $ca_server           = $puppet::params::ca_server,
   $passenger           = $puppet::params::passenger,
   $port                = $puppet::params::port,
   $listen              = $puppet::params::listen,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class puppet::params {
   $dir                 = '/etc/puppet'
   $vardir              = '/var/lib/puppet'
   $ca                  = true
+  $ca_server           = false
   $passenger           = true
   $port                = 8140
   $listen              = false

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -5,6 +5,7 @@ class puppet::server (
   $dir                 = $puppet::params::dir,
   $vardir              = $puppet::params::vardir,
   $ca                  = $puppet::params::ca,
+  $ca_server           = $puppet::params::ca_server,
   $passenger           = $puppet::params::passenger,
   $port                = $puppet::params::port,
   $environments        = $puppet::params::environments,

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -20,6 +20,11 @@
     # Puppet 3.0.x requires this in both [main] and [master] - harmless on agents
     autosign       = $confdir/autosign.conf { mode = 664 }
 
+<% if scope.lookupvar("puppet::ca_server") %>
+    # Use the specified central CA server
+    ca_server = <%= ca_server %>
+<% end -%>
+
 [agent]
     # The file in which puppetd stores a list of the classes
     # associated with the retrieved configuratiion.  Can be loaded in


### PR DESCRIPTION
We are using distributed puppet masters with a central one acting as CA. Need to be able to specify ca_server in puppet.conf on all agents.
