### PR TITLE
Convert to using puppetlabs-apache/puppetlabs-passenger

### DIFF
--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -24,7 +24,7 @@ class puppet::server::passenger {
   }
 
   file {'puppet_vhost':
-    path    => "${apache::params::configdir}/puppet.conf",
+    path    => "${apache::params::vdir}/puppet.conf",
     content => template('puppet/server/puppet-vhost.conf.erb'),
     mode    => '0644',
     notify  => Service['httpd'],


### PR DESCRIPTION
This is part 1 of 2 pull requests - the other will be against puppet-foreman.

In order for this PR to work the following modules need to be replaced in foreman installer:

apache -> puppetlabs-apache
passenger -> puppetlabs-passenger
stdlib -> puppetlabs-stdlib

This has been tested against centos 6.3 and ubuntu 12.04 in both fresh installs and rerunning with the new modules after running the current version of the installer to check it converts cleanly.
