### PR TITLE
These changes allow me to set puppet::server::librarian_path

### DIFF
--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -15,6 +15,6 @@
 <% else -%>
 <% scope.lookupvar("puppet::server::environments").each do |env| -%>
 [<%= env %>]
-    modulepath     = <%= scope.lookupvar("puppet::server::modules_path") %>/<%= env %>:<%= [scope.lookupvar("puppet::server::common_modules_path")].flatten.join(":") %>
+    modulepath     = <%= scope.lookupvar("puppet::server::modules_path") %>/<%= env %>/modules:<%= [scope.lookupvar("puppet::server::common_modules_path")].flatten.join(":") %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
 to '/modules' and automatically handle the fact that librarian is putting my modules into /etc/puppet/environments/$env/modules/*.

This should be a noop change for people who don't use explicitly set this.
