### PR TITLE
Split out the different ssl files into variables for re-use

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -64,7 +64,19 @@ class puppet::server (
     $use_service = true
   }
 
+  if $ca {
+    $ssl_ca_cert   = "${ssl_dir}/ca/ca_crt.pem"
+    $ssl_ca_crl    = "${ssl_dir}/ca/ca_crl.pem"
+    $ssl_chain     = "${ssl_dir}/ca/ca_crt.pem"
+  } else {
+    $ssl_ca_cert = "${ssl_dir}/certs/ca.pem"
+  }
+
+  $ssl_cert      = "${ssl_dir}/certs/${::fqdn}.pem"
+  $ssl_cert_key  = "${ssl_dir}/private_keys/${::fqdn}.pem"
+
   class { 'puppet::server::install': }~>
   class { 'puppet::server::config':  }~>
   class { 'puppet::server::service': }
+
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -47,7 +47,7 @@ class puppet::server::config inherits puppet::config {
   }
 
   exec {'puppet_server_config-generate_ca_cert':
-    creates => "${puppet::server::ssl_dir}/certs/${::fqdn}.pem",
+    creates => $::puppet::server::ssl_cert,
     command => "${puppet::params::puppetca_path}/${puppet::params::puppetca_bin} --generate ${::fqdn}",
     require => File["${puppet::server::dir}/puppet.conf"],
     notify  => Service[$puppet::server::httpd_service],

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -9,6 +9,22 @@ class puppet::server::passenger {
   include ::apache::params
   include ::passenger
 
+  # mirror 'external' params here for easy use in templates.
+
+  $ssl_dir      = $::puppet::server::ssl_dir
+  $ssl_cert     = $::puppet::server::ssl_cert
+  $ssl_cert_key = $::puppet::server::ssl_cert_key
+  $ssl_ca_cert  = $::puppet::server::ssl_ca_cert
+  # We check to surpress some warnings.
+  if $::puppet::server::ca {
+    $ssl_chain    = $::puppet::server::ssl_chain
+    $ssl_ca_crl   = $::puppet::server::ssl_ca_crl
+  }
+
+  $port         = $::puppet::server::port
+  $user         = $::puppet::server::user
+  $app_root     = $::puppet::server::app_root
+
   case $::operatingsystem {
     Debian,Ubuntu: {
       file { '/etc/default/puppetmaster':

--- a/templates/server/puppet-vhost.conf.erb
+++ b/templates/server/puppet-vhost.conf.erb
@@ -1,22 +1,23 @@
 <%= ERB.new(File.read(File.expand_path("../_header.erb",File.dirname(file)))).result(binding) -%>
 
-Listen <%= scope.lookupvar("puppet::server::port") %>
-<VirtualHost *:<%= scope.lookupvar("puppet::server::port") %>>
+Listen <%= @port %>
+<VirtualHost *:<%= @port %>>
 
 	SSLEngine on
 	SSLProtocol -ALL +SSLv3 +TLSv1
 	SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP
 
-	SSLCertificateFile      <%= scope.lookupvar("puppet::server::ssl_dir") %>/certs/<%= fqdn %>.pem
-	SSLCertificateKeyFile   <%= scope.lookupvar("puppet::server::ssl_dir") %>/private_keys/<%= fqdn %>.pem
-<% unless scope.lookupvar("puppet::server::ca") %>
-	SSLCACertificateFile    <%= scope.lookupvar("puppet::server::ssl_dir") %>/certs/ca.pem
-<% else -%>
-	SSLCertificateChainFile <%= scope.lookupvar("puppet::server::ssl_dir") %>/ca/ca_crt.pem
-	SSLCACertificateFile    <%= scope.lookupvar("puppet::server::ssl_dir") %>/ca/ca_crt.pem
-	# CRL checking should be enabled; if you have problems with Apache complaining about the CRL, disable the next line
-	SSLCARevocationFile     <%= scope.lookupvar("puppet::server::ssl_dir") %>/ca/ca_crl.pem
+	SSLCertificateFile      <%= @ssl_cert %>
+	SSLCertificateKeyFile   <%= @ssl_cert_key %>
+
+	SSLCACertificateFile    <%= @ssl_ca_cert %>
+<% if @ssl_chain -%>
+	SSLCertificateChainFile <%= @ssl_chain %>
 <% end -%>
+<% if @ssl_ca_crl -%>
+	SSLCARevocationFile     <%= @ssl_ca_crl %>
+<% end -%>
+
 	SSLVerifyClient optional
 	SSLVerifyDepth  1
 	SSLOptions +StdEnvVars +ExportCertData
@@ -35,8 +36,8 @@ Listen <%= scope.lookupvar("puppet::server::port") %>
 	PassengerStatThrottleRate 120
 
 	RackAutoDetect On
-	DocumentRoot <%= scope.lookupvar("puppet::server::app_root") %>/public/
-	<Directory <%= scope.lookupvar("puppet::server::app_root") %>>
+	DocumentRoot <%= @app_root %>/public/
+	<Directory <%= @app_root %>>
 		Options None
 		AllowOverride None
 		Order allow,deny

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -9,6 +9,7 @@
     external_nodes = <%= scope.lookupvar("puppet::server::external_nodes") %>
     node_terminus  = exec
     ca             = <%= scope.lookupvar("puppet::server::ca") %>
+    ssldir         = <%= scope.lookupvar("puppet::server::ssl_dir") %>
 <% if scope.lookupvar("puppet::server::git_repo") -%>
     manifest       = <%= scope.lookupvar("puppet::server::envs_dir") %>/$environment/manifests/site.pp
     modulepath     = <%= scope.lookupvar("puppet::server::envs_dir") %>/$environment/modules


### PR DESCRIPTION
Centralizes the different ssl files location configuration in once place so it can be reused by other modules.
