### PR TITLE
Share the envs_dir value for git_repo and static envs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,18 +36,16 @@ class puppet::params {
   # Static environments config, ignore if the git_repo is 'true'
   # What environments do we have
   $environments        = ['development', 'production']
-  # Where we store our puppet modules
-  $modules_path        = "${dir}/modules"
+  # Where we store our puppet environments
+  $envs_dir            = "${dir}/environments"
   # Where remains our manifests dir
   $manifest_path       = "${dir}/manifests"
   # Modules in this directory would be shared across all environments
-  $common_modules_path = ["${modules_path}/common", '/usr/share/puppet/modules']
+  $common_modules_path = ["${envs_dir}/common", '/usr/share/puppet/modules']
 
   # Dynamic environments config, ignore if the git_repo is 'false'
   # Path to the repository
   $git_repo_path       = "${vardir}/puppet.git"
-  # Where to checkout the branches
-  $envs_dir            = "${dir}/environments"
   # Override these if you need your own hooks
   $post_hook_content   = 'puppet/server/post-receive.erb'
   $post_hook_name      = 'post-receive'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -36,7 +36,6 @@ class puppet::server (
   $port                = $puppet::params::port,
   $external_nodes      = $puppet::params::external_nodes,
   $environments        = $puppet::params::environments,
-  $modules_path        = $puppet::params::modules_path,
   $manifest_path       = $puppet::params::manifest_path,
   $common_modules_path = $puppet::params::common_modules_path,
   $foreman_url         = $foreman::params::foreman_url,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -94,7 +94,7 @@ class puppet::server::config inherits puppet::config {
   }
   else
   {
-    file { [$puppet::server::modules_path, $puppet::server::common_modules_path]:
+    file { [$puppet::server::envs_dir, $puppet::server::common_modules_path]:
       ensure => directory,
     }
 

--- a/manifests/server/env.pp
+++ b/manifests/server/env.pp
@@ -1,5 +1,5 @@
 # Set up a puppet environment
-define puppet::server::env ($basedir = $puppet::server::modules_path) {
+define puppet::server::env ($basedir = $puppet::server::envs_dir) {
   file { "${basedir}/${name}":
     ensure => directory,
   }

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -23,6 +23,6 @@
 <% else -%>
 <% scope.lookupvar("puppet::server::environments").each do |env| -%>
 [<%= env %>]
-    modulepath     = <%= scope.lookupvar("puppet::server::modules_path") %>/<%= env %>/modules:<%= [scope.lookupvar("puppet::server::common_modules_path")].flatten.join(":") %>
+    modulepath     = <%= scope.lookupvar("puppet::server::envs_dir") %>/<%= env %>/modules:<%= [scope.lookupvar("puppet::server::common_modules_path")].flatten.join(":") %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This does break compatibility for those who use modules_path, but I think that
in the long run this is a better way.
