### PR TITLE
Introduce the config_version parameter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,10 @@ class puppet::params {
   # Set 'false' for staic environments, or 'true' for git-based workflow
   $git_repo            = false
 
+  # The script that is run to determine the reported manifest version. Undef
+  # means we determine it in server.pp
+  $config_version      = undef
+
   # Static environments config, ignore if the git_repo is 'true'
   # What environments do we have
   $environments        = ['development', 'production']

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -23,6 +23,9 @@
 #                           to using the puppetmaster service? Set to false
 #                           if you disabled passenger and you do NOT want to
 #                           use the puppetmaster service. Defaults to true.
+# $config_version::         How to determine the configuration version. When
+#                           using git_repo, by default a git describe approach
+#                           will be installed.
 class puppet::server (
   $user                = $puppet::params::user,
   $group               = $puppet::params::group,
@@ -35,6 +38,7 @@ class puppet::server (
   $httpd_service       = $puppet::params::httpd_service,
   $port                = $puppet::params::port,
   $external_nodes      = $puppet::params::external_nodes,
+  $config_version      = $puppet::params::config_version,
   $environments        = $puppet::params::environments,
   $manifest_path       = $puppet::params::manifest_path,
   $common_modules_path = $puppet::params::common_modules_path,
@@ -73,6 +77,16 @@ class puppet::server (
 
   $ssl_cert      = "${ssl_dir}/certs/${::fqdn}.pem"
   $ssl_cert_key  = "${ssl_dir}/private_keys/${::fqdn}.pem"
+
+  if $config_version == undef {
+    if $git_repo {
+      $config_version_cmd = "git --git-dir ${envs_dir}/\$environment/.git describe --all --long"
+    } else {
+      $config_version_cmd = ''
+    }
+  } else {
+    $config_version_cmd = $config_version
+  }
 
   class { 'puppet::server::install': }~>
   class { 'puppet::server::config':  }~>

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -20,9 +20,11 @@
 <% if scope.lookupvar("puppet::server::git_repo") -%>
     manifest       = <%= scope.lookupvar("puppet::server::envs_dir") %>/$environment/manifests/site.pp
     modulepath     = <%= scope.lookupvar("puppet::server::envs_dir") %>/$environment/modules
+    config_version = <%= scope.lookupvar("puppet::server::config_version_cmd") %>
 <% else -%>
 <% scope.lookupvar("puppet::server::environments").each do |env| -%>
 [<%= env %>]
     modulepath     = <%= scope.lookupvar("puppet::server::envs_dir") %>/<%= env %>/modules:<%= [scope.lookupvar("puppet::server::common_modules_path")].flatten.join(":") %>
+    config_version = <%= scope.lookupvar("puppet::server::config_version_cmd") %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
How to determine the configuration version. By default, it will be the time
that the configuration is parsed, but you can provide a shell script to
override how the version is determined. The output of this script will be added
to every log message in the reports, allowing you to correlate changes on your
hosts to the source version on the server.
- http://docs.puppetlabs.com/references/stable/configuration.html#configversion

Users of git_repo can use the following:

```
git --git-dir $envs_dir/$environment/.git --all --long
```
