### PR TITLE
Do not add the served by to the header

### DIFF
--- a/templates/_header.erb
+++ b/templates/_header.erb
@@ -1,5 +1,4 @@
 ### File managed with puppet ###
-## Served by:        '<%= scope.lookupvar('::servername') %>'
 ## Module:           '<%= scope.to_hash['module_name'] %>'
 <%
   module_paths = Puppet::Node::Environment.current[:modulepath].split(':').map{|i| File.expand_path(i) }.join('|')


### PR DESCRIPTION
In our workflow we use a staging server and do a puppet agent -t
--server --noop to see what changed. The served by header changes all the
files and triggers lots of refreshes. This makes it very hard to spot what
changed and what not.
