### PR TITLE
Make foreman integration configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ wrapper classes or even your ENC (if it supports param classes). For example:
       post_hook_content => 'puppetserver/post-hook.puppet',
     }
 
+    # Perhaps you want to install without foreman?
+    class { '::puppet::server':
+        reports        => 'store',
+        external_nodes => false,
+    }
+
 Look in _init.pp_ for what can be configured this way, see Contributing if anything
 doesn't work.
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class puppet::params {
   $runmode             = 'service'
   $agent_noop          = false
   $external_nodes      = '/etc/puppet/node.rb'
+  $reports             = 'foreman'
 
 
   # Need your own config templates? Specify here:

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -46,6 +46,7 @@ class puppet::server (
   $environments         = $puppet::params::environments,
   $manifest_path        = $puppet::params::manifest_path,
   $common_modules_path  = $puppet::params::common_modules_path,
+  $reports              = $puppet::params::reports,
   $foreman_url          = $foreman::params::foreman_url,
   $facts                = $foreman::params::facts,
   $storeconfigs_backend = $puppet::params::storeconfigs_backend,

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -63,6 +63,37 @@ describe 'puppet::server::config' do
 
       should contain_puppet__server__env('production')
     end
+
+    it 'should configure puppet' do
+      should contain_file('/etc/puppet/puppet.conf').
+        with_content(/^\s+reports\s+= foreman$/).
+        with_content(/^\s+external_nodes\s+= \/etc\/puppet\/node.rb$/).
+        with_content(/^\s+node_terminus\s+= exec$/).
+        with_content(/^\s+ca\s+= true$/).
+        with_content(/^\s+ssldir\s+= \/var\/lib\/puppet\/ssl$/).
+        with_content(/^\[development\]\n\s+modulepath\s+= \/etc\/puppet\/environments\/development\/modules:\/etc\/puppet\/environments\/common:\/usr\/share\/puppet\/modules\n\s+config_version = $/).
+        with_content(/^\[production\]\n\s+modulepath\s+= \/etc\/puppet\/environments\/production\/modules:\/etc\/puppet\/environments\/common:\/usr\/share\/puppet\/modules\n\s+config_version = $/).
+        with({}) # So we can use a trailing dot on each with_content line
+
+      should_not contain_file('/etc/puppet/puppet.conf').with_content(/storeconfigs/)
+    end
   end
 
+  describe 'without foreman' do
+    let :pre_condition do
+      "include puppet
+      class {'puppet::server':
+        reports        => 'store',
+        external_nodes => false,
+      }"
+    end
+
+    it 'should store reports' do
+      should contain_file('/etc/puppet/puppet.conf').with_content(/^\s+reports\s+= store$/)
+    end
+
+    it 'should not contain external_nodes' do
+      should_not contain_file('/etc/puppet/puppet.conf').with_content(/external_nodes/)
+    end
+  end
 end

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -5,9 +5,11 @@
 
 [master]
     autosign       = $confdir/autosign.conf { mode = 664 }
-    reports        = foreman
+    reports        = <%= scope.lookupvar("puppet::server::reports") %>
+<% if scope.lookupvar("puppet::server::external_nodes") -%>
     external_nodes = <%= scope.lookupvar("puppet::server::external_nodes") %>
     node_terminus  = exec
+<% end -%>
     ca             = <%= scope.lookupvar("puppet::server::ca") %>
     ssldir         = <%= scope.lookupvar("puppet::server::ssl_dir") %>
 <% if scope.lookupvar("puppet::server::storeconfigs_backend") -%>


### PR DESCRIPTION
This patch makes reports and external_nodes configurable. It's based on 
https://github.com/theforeman/puppet-puppet/pull/74 written by Robin Bowes.
