### PR TITLE
Inheritance WIP

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,35 +4,42 @@
 #
 # === Parameters:
 #
-# $dir::              Override the puppet directory.
-#                     Defaults to '/etc/puppet'.
+# $version::          Specify a specific version of a package to install.
+#                     The version should be the exact match for your distro.
+#                     You can also use certain values like 'latest'.
 #
-# $ca_server::        Use a different ca server. Should be either a string
-#                     with the location of the ca_server or 'false'.
-#                     Defaults to 'false;.
+# $user::             Override the name of the puppet user.
+#
+# $group::            Override the name of the puppet group.
+#
+# $dir::              Override the puppet directory.
 #
 # $port::             Override the port of the master we connect to.
-#                     Defaults to '8140'.
+#                     type:integer
 #
 # $listen::           Should the puppet agent listen for connections.
-#                     Defaults to 'false'.
+#                     type:boolean
 #
 # $pluginsync::       Enable pluginsync.
-#                     Defaults to 'true'.
+#                     type:boolean
 #
 # $splay::            Switch to enable a random amount of time to sleep before
 #                     each run.
-#                     Defaults to 'false'.
+#                     type:boolean
 #
-# $runinterval::      Set up the interval to run the puppet agent.
-#                     Defaults to '1800' (seconds).
+# $runinterval::      Set up the interval (in seconds) to run the puppet agent.
+#                     type:integer
 #
 # $runmode::          Select the mode to setup the puppet agent. Can be either
 #                     'cron' or 'service'.
-#                     Defaults to 'service'.
 #
 # $agent_noop::       Run the agent in noop mode.
-#                     Defaults to 'false'.
+#                     type:boolean
+#
+# $show_diff::        Show and report changed files with diff output
+#
+# $ca_server::        Use a different ca server. Should be either a string
+#                     with the location of the ca_server or 'false'.
 #
 # $agent_template::   Use a custom template for the agent puppet configuration.
 #
@@ -40,19 +47,110 @@
 #
 # $nsauth_template::  Use a custom template for the nsauth configuration.
 #
-# $version::          Specify a specific version of a package to install.
-#                     The version should be the exact match for your distro.
-#                     You can also use certain values like 'latest'.
-#                     Defaults to 'present'.
+# $client_package::   Install a custom package to provide the puppet client
 #
-# $show_diff::        Show and report changed files with diff output
-#                     Defaults to 'false'.
+# == puppet::server parameters
+#
+# $server::           Should a puppet master be installed as well as the client
+#                     type:boolean
+#
+# $server_user::      Name of the puppetmaster user.
+#
+# $server_group::     Name of the puppetmaster group.
+#
+# $server_dir::       Puppet configuration directory
+#
+# $server_port::      Puppet master port
+#                     type:integer
+#
+# $server_vardir::    Puppet data directory.
+#
+# $server_ca::        Provide puppet CA
+#                     type:boolean
+#
+# $server_reports     List of report types to include on the puppetmaster
+#
+# $server_passenger:: If set to true, we will configure apache with
+#                     passenger. If set to false, we will enable the
+#                     default puppetmaster service unless
+#                     service_fallback is set to false. See 'Advanced
+#                     server parameters' for more information.
+#                     type:boolean
+#
+# $server_external_nodes::  External nodes classifier executable
+#
+# $server_template::        Which template should be used for master configuration
+#
+# $server_git_repo::        Use git repository as a source of modules
+#                           type:boolean
+#
+# $server_environments::    Environments to setup (creates directories)
+#                           type:array
+#
+# $server_envs_dir::        Directory that holds puppet environments
+#
+# $server_manifest_path::   Path to puppet site.pp manifest
+#
+# $server_common_modules_path:: Common modules paths
+#                               type:array
+#
+# $server_git_repo_path::       Git repository path
+#
+# $server_post_hook_content::   Which template to use for git post hook
+#
+# $server_post_hook_name::      Name of a git hook
+#
+# $server_storeconfigs_backend::   Do you use storeconfigs? (note: not required)
+#                                  false if you don't, "active_record" for 2.X
+#                                  style db, "puppetdb" for puppetdb
+#
+# $server_app_root::               Directory where the application lives
+#
+# $server_ssl_dir::                SSL directory
+#
+# $server_package::         Custom package name for puppet master
+#
+# === Advanced server parameters:
+#
+# $server_httpd_service::   Apache/httpd service name to notify on configuration
+#                           changes. Defaults to 'httpd' based on the default
+#                           apache module included with foreman-installer.
+#
+# $server_service_fallback:: If passenger is not used, do we want to fallback
+#                            to using the puppetmaster service? Set to false
+#                            if you disabled passenger and you do NOT want to
+#                            use the puppetmaster service. Defaults to true.
+#                            type:boolean
+#
+# $server_passenger_max_pool:: The PassengerMaxPoolSize parameter. If your host is
+#                              low on memory, it may be a good thing to lower
+#                              this. Defaults to 12.
+#                              type:integer
+#
+# $server_config_version::  How to determine the configuration version. When
+#                           using git_repo, by default a git describe approach
+#                           will be installed.
+#
+# $foreman_url::            Foreman URL
+#
+# $facts::                  Should foreman receive facts from puppet
+#                           type:boolean
+#
+# $puppet_basedir::         Where is the puppet code base located
+#
+# $puppet_home::            Puppet var directory
 #
 # === Usage:
 #
 # * Simple usage:
 #
 #     include puppet
+#
+# * Installing a puppetmaster
+#
+#   class {'puppet':
+#     server => true,
+#   }
 #
 # * Advanced usage:
 #
@@ -61,23 +159,65 @@
 #     version    => '2.7.20-1',
 #   }
 #
-#
 class puppet (
-  $dir                 = $puppet::params::dir,
-  $ca_server           = $puppet::params::ca_server,
-  $port                = $puppet::params::port,
-  $listen              = $puppet::params::listen,
-  $pluginsync          = $puppet::params::pluginsync,
-  $splay               = $puppet::params::splay,
-  $runinterval         = $puppet::params::runinterval,
-  $runmode             = $puppet::params::runmode,
-  $agent_noop          = $puppet::params::agent_noop,
-  $agent_template      = $puppet::params::agent_template,
-  $auth_template       = $puppet::params::auth_template,
-  $nsauth_template     = $puppet::params::nsauth_template,
-  $version             = $puppet::params::version,
-  $show_diff           = $puppet::params::show_diff
+  $version                     = $puppet::params::version,
+  $user                        = $puppet::params::user,
+  $group                       = $puppet::params::group,
+  $dir                         = $puppet::params::dir,
+  $port                        = $puppet::params::port,
+  $listen                      = $puppet::params::listen,
+  $pluginsync                  = $puppet::params::pluginsync,
+  $splay                       = $puppet::params::splay,
+  $runinterval                 = $puppet::params::runinterval,
+  $runmode                     = $puppet::params::runmode,
+  $agent_noop                  = $puppet::params::agent_noop,
+  $show_diff                   = $puppet::params::show_diff,
+  $ca_server                   = $puppet::params::ca_server,
+  $agent_template              = $puppet::params::agent_template,
+  $auth_template               = $puppet::params::auth_template,
+  $nsauth_template             = $puppet::params::nsauth_template,
+  $client_package              = $puppet::params::client_package,
+  $server                      = $puppet::params::server,
+  $server_user                 = $puppet::params::user,
+  $server_group                = $puppet::params::group,
+  $server_dir                  = $puppet::params::dir,
+  $server_port                 = $puppet::params::port,
+  $server_vardir               = $puppet::params::server_vardir,
+  $server_ca                   = $puppet::params::server_ca,
+  $server_reports              = $puppet::params::server_reports,
+  $server_passenger            = $puppet::params::server_passenger,
+  $server_service_fallback     = $puppet::params::server_service_fallback,
+  $server_passenger_max_pool   = $puppet::params::server_passenger_max_pool,
+  $server_httpd_service        = $puppet::params::server_httpd_service,
+  $server_external_nodes       = $puppet::params::server_external_nodes,
+  $server_template             = $puppet::params::server_template,
+  $server_config_version       = $puppet::params::server_config_version,
+  $server_git_repo             = $puppet::params::server_git_repo,
+  $server_environments         = $puppet::params::server_environments,
+  $server_envs_dir             = $puppet::params::server_envs_dir,
+  $server_manifest_path        = $puppet::params::server_manifest_path,
+  $server_common_modules_path  = $puppet::params::server_common_modules_path,
+  $server_git_repo_path        = $puppet::params::server_git_repo_path,
+  $server_post_hook_content    = $puppet::params::server_post_hook_content,
+  $server_post_hook_name       = $puppet::params::server_post_hook_name,
+  $server_storeconfigs_backend = $puppet::params::server_storeconfigs_backend,
+  $server_app_root             = $puppet::params::server_app_root,
+  $server_ssl_dir              = $puppet::params::server_ssl_dir,
+  $server_package              = $puppet::params::server_package,
+  $server_foreman_url          = $foreman::params::foreman_url,
+  $server_facts                = $foreman::params::facts,
+  $server_puppet_home          = $foreman::params::puppet_home,
+  $server_puppet_basedir       = $foreman::params::puppet_basedir
 ) inherits puppet::params {
-  class { 'puppet::install': }~>
-  class { 'puppet::config': }
+
+  class { 'puppet::install': } ~>
+  class { 'puppet::config': } ->
+  Class['puppet']
+
+  if $server == true {
+    class { 'puppet::server':
+      require => Class['puppet::config'],
+    }
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,13 +8,6 @@ class puppet::params {
   $user                = 'puppet'
   $group               = 'puppet'
   $dir                 = '/etc/puppet'
-  $vardir              = '/var/lib/puppet'
-  $ca                  = true
-  $ca_server           = false
-  $passenger           = true
-  $service_fallback    = true
-  $passenger_max_pool  = 12
-  $httpd_service       = 'httpd'
   $port                = 8140
   $listen              = false
   $pluginsync          = true
@@ -22,52 +15,63 @@ class puppet::params {
   $runinterval         = '1800'
   $runmode             = 'service'
   $agent_noop          = false
-  $external_nodes      = '/etc/puppet/node.rb'
-  $reports             = 'foreman'
   $show_diff           = false
-
+  $ca_server           = false
 
   # Need your own config templates? Specify here:
   $agent_template  = 'puppet/puppet.conf.erb'
-  $master_template = 'puppet/server/puppet.conf.erb'
   $auth_template   = 'puppet/auth.conf.erb'
   $nsauth_template = 'puppet/namespaceauth.conf.erb'
 
-  # Set 'false' for static environments, or 'true' for git-based workflow
-  $git_repo            = false
+  # Will this host be a puppetmaster?
+  $server                    = false
+  $server_vardir             = '/var/lib/puppet'
+  $server_ca                 = true
+  $server_reports            = 'foreman'
+  $server_passenger          = true
+  $server_service_fallback   = true
+  $server_passenger_max_pool = 12
+  $server_httpd_service      = 'httpd'
+  $server_external_nodes     = '/etc/puppet/node.rb'
+
+  # Need a new master template for the server?
+  $server_template = 'puppet/server/puppet.conf.erb'
 
   # The script that is run to determine the reported manifest version. Undef
   # means we determine it in server.pp
-  $config_version      = undef
+  $server_config_version      = undef
+
+  # Set 'false' for static environments, or 'true' for git-based workflow
+  $server_git_repo            = false
 
   # Static environments config, ignore if the git_repo is 'true'
   # What environments do we have
-  $environments        = ['development', 'production']
+  $server_environments        = ['development', 'production']
   # Where we store our puppet environments
-  $envs_dir            = "${dir}/environments"
+  $server_envs_dir            = "${dir}/environments"
   # Where remains our manifests dir
-  $manifest_path       = "${dir}/manifests"
+  $server_manifest_path       = "${dir}/manifests"
   # Modules in this directory would be shared across all environments
-  $common_modules_path = ["${envs_dir}/common", '/usr/share/puppet/modules']
+  $server_common_modules_path = ["${server_envs_dir}/common", '/usr/share/puppet/modules']
 
   # Dynamic environments config, ignore if the git_repo is 'false'
   # Path to the repository
-  $git_repo_path       = "${vardir}/puppet.git"
+  $server_git_repo_path       = "${server_vardir}/puppet.git"
   # Override these if you need your own hooks
-  $post_hook_content   = 'puppet/server/post-receive.erb'
-  $post_hook_name      = 'post-receive'
+  $server_post_hook_content   = 'puppet/server/post-receive.erb'
+  $server_post_hook_name      = 'post-receive'
 
   # Do you use storeconfigs? (note: not required)
   # - false if you don't
   # - active_record for 2.X style db
   # - puppetdb for puppetdb
-  $storeconfigs_backend = false
+  $server_storeconfigs_backend = false
 
   # Passenger config
-  $app_root            = "${dir}/rack"
-  $ssl_dir             = "${vardir}/ssl"
+  $server_app_root = "${dir}/rack"
+  $server_ssl_dir  = "${server_vardir}/ssl"
 
-  $master_package     =  $::operatingsystem ? {
+  $server_package     =  $::operatingsystem ? {
     /(Debian|Ubuntu)/ => ['puppetmaster-common','puppetmaster'],
     default           => ['puppet-server'],
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,161 +1,35 @@
-# == Class: puppet::server
-#
-# Sets up a puppet master.
-#
-# === Parameters:
-#
-# $passenger::              If set to true, we will configure apache with
-#                           passenger. If set to false, we will enable the
-#                           default puppetmaster service unless
-#                           service_fallback is set to false. See 'Advanced
-#                           parameters for more information.
-#                           type:boolean
-#
-# $user::                   Puppet user
-#
-# $group::                  Puppet group
-#
-# $dir::                    Puppet configuration directory
-#
-# $vardir::                 Puppet data directory
-#
-# $ca::                     Provide puppet CA
-#                           type:boolean
-#
-# $port::                   Puppet master port
-#                           type:integer
-#
-# $external_nodes::         External nodes classifier executable
-#
-# $environments::           Environments to setup (creates directories)
-#                           type:array
-#
-# $manifest_path::          Path to puppet site.pp manifest
-#
-# $common_modules_path::    Common modules paths
-#                           type:array
-#
-# $foreman_url::            Foreman URL
-#
-# $facts::                  Should foreman receive facts from puppet
-#                           type:boolean
-#
-# $puppet_basedir::         Where is the puppet code base located
-#
-# $puppet_home::            Puppet var directory
-#
-# $storeconfigs_backend::   Do you use storeconfigs? (note: not required)
-#                           false if you don't, "active_record" for 2.X style db, "puppetdb" for puppetdb
-#
-# $git_repo::               Use git repository as a source of modules
-#                           type:boolean
-#
-# $git_repo_path::          Git repository path
-#
-# $envs_dir::               Directory that holds puppet environments
-#
-# $app_root::               Directory where the application lives
-#
-# $ssl_dir::                SSL directory
-#
-# $master_package::         Custom package name for puppet master
-#
-# $post_hook_content::      Which template to use for git post hook
-#
-# $post_hook_name::         Name of a git hook
-#
-# $agent_template::         Which template should be used for agent configuration
-#
-# $master_template::        Which template should be used for master configuration
-#
-# $version::                Puppet master version
-#
-# === Advanced parameters:
-#
-# $httpd_service::          Apache/httpd service name to notify on configuration
-#                           changes. Defaults to 'httpd' based on the default
-#                           apache module included with foreman-installer.
-#
-# $service_fallback::       If passenger is not used, do we want to fallback
-#                           to using the puppetmaster service? Set to false
-#                           if you disabled passenger and you do NOT want to
-#                           use the puppetmaster service. Defaults to true.
-#                           type:boolean
-#
-# $passenger_max_pool::     The PassengerMaxPoolSize parameter. If your host is
-#                           low on memory, it may be a good thing to lower
-#                           this. Defaults to 12.
-#                           type:integer
-#
-# $config_version::         How to determine the configuration version. When
-#                           using git_repo, by default a git describe approach
-#                           will be installed.
-#
-class puppet::server (
-  $user                 = $puppet::params::user,
-  $group                = $puppet::params::group,
-  $dir                  = $puppet::params::dir,
-  $vardir               = $puppet::params::vardir,
-  $ca                   = $puppet::params::ca,
-  $ca_server            = $puppet::params::ca_server,
-  $passenger            = $puppet::params::passenger,
-  $service_fallback     = $puppet::params::service_fallback,
-  $passenger_max_pool   = $puppet::params::passenger_max_pool,
-  $httpd_service        = $puppet::params::httpd_service,
-  $port                 = $puppet::params::port,
-  $external_nodes       = $puppet::params::external_nodes,
-  $config_version       = $puppet::params::config_version,
-  $environments         = $puppet::params::environments,
-  $manifest_path        = $puppet::params::manifest_path,
-  $common_modules_path  = $puppet::params::common_modules_path,
-  $reports              = $puppet::params::reports,
-  $foreman_url          = $foreman::params::foreman_url,
-  $facts                = $foreman::params::facts,
-  $storeconfigs_backend = $puppet::params::storeconfigs_backend,
-  $puppet_home          = $foreman::params::puppet_home,
-  $puppet_basedir       = $foreman::params::puppet_basedir,
-  $git_repo             = $puppet::params::git_repo,
-  $git_repo_path        = $puppet::params::git_repo_path,
-  $envs_dir             = $puppet::params::envs_dir,
-  $app_root             = $puppet::params::app_root,
-  $ssl_dir              = $puppet::params::ssl_dir,
-  $master_package       = $puppet::params::master_package,
-  $post_hook_content    = $puppet::params::post_hook_content,
-  $post_hook_name       = $puppet::params::post_hook_name,
-  $agent_template       = $puppet::params::agent_template,
-  $master_template      = $puppet::params::master_template,
-  $version              = $puppet::params::version
-) inherits puppet::params {
+class puppet::server {
 
-  if $passenger or ($service_fallback == false) {
+  if $::puppet::server_passenger or ($::puppet::server_service_fallback == false) {
     $use_service = false
   } else {
     $use_service = true
   }
 
-  if $ca {
-    $ssl_ca_cert   = "${ssl_dir}/ca/ca_crt.pem"
-    $ssl_ca_crl    = "${ssl_dir}/ca/ca_crl.pem"
-    $ssl_chain     = "${ssl_dir}/ca/ca_crt.pem"
+  if $::puppet::server_ca {
+    $ssl_ca_cert   = "${::puppet::server_ssl_dir}/ca/ca_crt.pem"
+    $ssl_ca_crl    = "${::puppet::server_ssl_dir}/ca/ca_crl.pem"
+    $ssl_chain     = "${::puppet::server_ssl_dir}/ca/ca_crt.pem"
   } else {
-    $ssl_ca_cert = "${ssl_dir}/certs/ca.pem"
+    $ssl_ca_cert = "${::puppet::server_ssl_dir}/certs/ca.pem"
   }
 
-  $ssl_cert      = "${ssl_dir}/certs/${::fqdn}.pem"
-  $ssl_cert_key  = "${ssl_dir}/private_keys/${::fqdn}.pem"
+  $ssl_cert      = "${::puppet::server_ssl_dir}/certs/${::fqdn}.pem"
+  $ssl_cert_key  = "${::puppet::server_ssl_dir}/private_keys/${::fqdn}.pem"
 
-  if $config_version == undef {
-    if $git_repo {
+  if $::puppet::server_config_version == undef {
+    if $::puppet::server_git_repo {
       $config_version_cmd = "git --git-dir ${envs_dir}/\$environment/.git describe --all --long"
     } else {
       $config_version_cmd = ''
     }
   } else {
-    $config_version_cmd = $config_version
+    $config_version_cmd = $::puppet::server_config_version
   }
 
   class { 'puppet::server::install': }~>
   class { 'puppet::server::config':  }~>
-  class { 'puppet::server::service': }
+  class { 'puppet::server::service': }->
+  Class['puppet::server']
 
 }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,12 +1,12 @@
 # Install the puppet server
 class puppet::server::install {
 
-  package { $puppet::server::master_package:
-    ensure => $::puppet::server::version,
+  package { $puppet::server_package:
+    ensure => $::puppet::version,
   }
 
-  if $puppet::server::git_repo {
-    user { $puppet::server::user:
+  if $puppet::server_git_repo {
+    user { $puppet::server_user:
       shell => '/usr/bin/git-shell',
     }
   }

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -11,20 +11,20 @@ class puppet::server::passenger {
 
   # mirror 'external' params here for easy use in templates.
 
-  $ssl_dir      = $::puppet::server::ssl_dir
+  $ssl_dir      = $::puppet::server_ssl_dir
   $ssl_cert     = $::puppet::server::ssl_cert
   $ssl_cert_key = $::puppet::server::ssl_cert_key
   $ssl_ca_cert  = $::puppet::server::ssl_ca_cert
   # We check to surpress some warnings.
-  if $::puppet::server::ca {
+  if $::puppet::server_ca {
     $ssl_chain    = $::puppet::server::ssl_chain
     $ssl_ca_crl   = $::puppet::server::ssl_ca_crl
   }
 
-  $port               = $::puppet::server::port
-  $user               = $::puppet::server::user
-  $app_root           = $::puppet::server::app_root
-  $passenger_max_pool = $::puppet::server::passenger_max_pool
+  $port               = $::puppet::server_port
+  $user               = $::puppet::server_user
+  $app_root           = $::puppet::server_app_root
+  $passenger_max_pool = $::puppet::server_passenger_max_pool
 
   case $::operatingsystem {
     Debian,Ubuntu: {
@@ -43,7 +43,7 @@ class puppet::server::passenger {
     content => template('puppet/server/puppet-vhost.conf.erb'),
     mode    => '0644',
     notify  => Exec['reload-apache'],
-    before  => Service[$::puppet::server::httpd_service],
+    before  => Service[$::puppet::server_httpd_service],
     require => Class['::puppet::server::rack'],
   }
 

--- a/manifests/server/rack.pp
+++ b/manifests/server/rack.pp
@@ -14,19 +14,19 @@ class puppet::server::rack {
 
 
   exec {'puppet_server_rack-restart':
-    command     => "/bin/touch ${puppet::server::app_root}/tmp/restart.txt",
+    command     => "/bin/touch ${puppet::server_app_root}/tmp/restart.txt",
     refreshonly => true,
-    cwd         => $puppet::server::app_root,
+    cwd         => $puppet::server_app_root,
     require     => [
       Class['puppet::server::install'],
-      File["${puppet::server::app_root}/tmp"]
+      File["${puppet::server_app_root}/tmp"]
     ],
   }
 
   file {
-    [$puppet::server::app_root, "${puppet::server::app_root}/public", "${puppet::server::app_root}/tmp"]:
+    [$puppet::server_app_root, "${puppet::server_app_root}/public", "${puppet::server_app_root}/tmp"]:
       ensure => directory,
-      owner  => $puppet::server::user,
+      owner  => $puppet::server_user,
   }
 
   $configru_version = $::puppetversion ? {
@@ -34,8 +34,8 @@ class puppet::server::rack {
     default => 'config.ru.erb'
   }
   file {
-    "${puppet::server::app_root}/config.ru":
-      owner   => $puppet::server::user,
+    "${puppet::server_app_root}/config.ru":
+      owner   => $puppet::server_user,
       content => template("puppet/server/${configru_version}"),
       notify  => Exec['puppet_server_rack-restart'],
   }

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -11,8 +11,7 @@ describe 'puppet::server::config' do
 
   describe 'with no custom parameters' do
     let :pre_condition do
-      "include puppet
-      class {'puppet::server':}"
+      "class {'puppet': server => true}"
     end
 
     it 'should set up SSL permissions' do
@@ -29,13 +28,13 @@ describe 'puppet::server::config' do
       should contain_exec('puppet_server_config-create_ssl_dir').with({
         :creates => '/var/lib/puppet/ssl',
         :command => '/bin/mkdir -p /var/lib/puppet/ssl',
-        :before  => 'Exec[puppet_server_config-generate_ca_cert]',
+        :before  => /Exec\[puppet_server_config-generate_ca_cert\]/
       })
 
       should contain_exec('puppet_server_config-generate_ca_cert').with({
         :creates => "/var/lib/puppet/ssl/certs/#{facts[:fqdn]}.pem",
         :command => "/usr/sbin/puppetca --generate #{facts[:fqdn]}",
-        :require => 'File[/etc/puppet/puppet.conf]',
+        :require => /File\[\/etc\/puppet\/puppet\.conf\]/,
         :notify  => 'Service[httpd]',
       })
     end
@@ -81,11 +80,11 @@ describe 'puppet::server::config' do
 
   describe 'without foreman' do
     let :pre_condition do
-      "include puppet
-      class {'puppet::server':
-        reports        => 'store',
-        external_nodes => false,
-      }"
+      "class {'puppet':
+          server                => true,
+          server_reports        => 'store',
+          server_external_nodes => false,
+       }"
     end
 
     it 'should store reports' do

--- a/spec/classes/puppet_server_passenger_spec.rb
+++ b/spec/classes/puppet_server_passenger_spec.rb
@@ -12,8 +12,7 @@ describe 'puppet::server::passenger' do
   describe 'with no custom parameters' do
     let :pre_condition do
       "
-      include puppet
-      class {'puppet::server':}
+      class {'puppet': server => true}
       "
     end
 
@@ -33,8 +32,8 @@ describe 'puppet::server::passenger' do
           :path    => '/etc/httpd/conf.d/puppet.conf',
           :mode    => '0644',
           :notify  => 'Exec[reload-apache]',
-          :before  => 'Service[httpd]',
-          :require => 'Class[Puppet::Server::Rack]',
+          :before  => /Service\[httpd\]/,
+          :require => /Class\[Puppet::Server::Rack\]/,
         })
     end
   end
@@ -42,9 +41,9 @@ describe 'puppet::server::passenger' do
   describe 'with no custom parameters' do
     let :pre_condition do
       "
-      include puppet
-      class {'puppet::server':
-        passenger_max_pool => 6,
+      class {'puppet':
+        server                    => true,
+        server_passenger_max_pool => 6,
       }
       "
     end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'puppet::server' do
 
   let :pre_condition do
-    "include puppet"
+    "class {'puppet': server => true}"
   end
 
   let :facts do

--- a/templates/server/config.ru.erb
+++ b/templates/server/config.ru.erb
@@ -18,8 +18,8 @@ ARGV << "--rack"
 # Rack applications typically don't start as root.  Set --confdir and --vardir
 # to prevent reading configuration from ~puppet/.puppet/puppet.conf and writing
 # to ~puppet/.puppet
-ARGV << "--confdir" << "<%= scope.lookupvar('::puppet::server::dir') %>"
-ARGV << "--vardir"  << "<%= scope.lookupvar('::puppet::server::vardir') %>"
+ARGV << "--confdir" << "<%= scope.lookupvar('::puppet::server_dir') %>"
+ARGV << "--vardir"  << "<%= scope.lookupvar('::puppet::server_vardir') %>"
 
 # NOTE: it's unfortunate that we have to use the "CommandLine" class
 #  here to launch the app, but it contains some initialization logic

--- a/templates/server/post-receive.erb
+++ b/templates/server/post-receive.erb
@@ -6,7 +6,7 @@ ERB.new(File.read(File.expand_path("../_header.erb",File.dirname(file))), nil, n
 require 'fileutils'
 
 # Set this to where you want to keep your environments
-ENVIRONMENT_BASEDIR = "<%= scope.lookupvar("puppet::server::envs_dir") %>"
+ENVIRONMENT_BASEDIR = "<%= scope.lookupvar("puppet::server_envs_dir") %>"
 
 # post-receive hooks set GIT_DIR to the current repository. If you want to
 # clone from a non-local repository, set this to the URL of the repository,

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -5,26 +5,26 @@
 
 [master]
     autosign       = $confdir/autosign.conf { mode = 664 }
-    reports        = <%= scope.lookupvar("puppet::server::reports") %>
-<% if scope.lookupvar("puppet::server::external_nodes") -%>
-    external_nodes = <%= scope.lookupvar("puppet::server::external_nodes") %>
+    reports        = <%= scope.lookupvar("puppet::server_reports") %>
+<% if scope.lookupvar("puppet::server_external_nodes") -%>
+    external_nodes = <%= scope.lookupvar("puppet::server_external_nodes") %>
     node_terminus  = exec
 <% end -%>
-    ca             = <%= scope.lookupvar("puppet::server::ca") %>
-    ssldir         = <%= scope.lookupvar("puppet::server::ssl_dir") %>
-<% if scope.lookupvar("puppet::server::storeconfigs_backend") -%>
+    ca             = <%= scope.lookupvar("puppet::server_ca") %>
+    ssldir         = <%= scope.lookupvar("puppet::server_ssl_dir") %>
+<% if scope.lookupvar("puppet::server_storeconfigs_backend") -%>
     storeconfigs   = true
-    storeconfigs_backend = <%= scope.lookupvar("puppet::server::storeconfigs_backend") %>
+    storeconfigs_backend = <%= scope.lookupvar("puppet::server_storeconfigs_backend") %>
 <% end -%>
 
-<% if scope.lookupvar("puppet::server::git_repo") -%>
-    manifest       = <%= scope.lookupvar("puppet::server::envs_dir") %>/$environment/manifests/site.pp
-    modulepath     = <%= scope.lookupvar("puppet::server::envs_dir") %>/$environment/modules
+<% if scope.lookupvar("puppet::server_git_repo") -%>
+    manifest       = <%= scope.lookupvar("puppet::server_envs_dir") %>/$environment/manifests/site.pp
+    modulepath     = <%= scope.lookupvar("puppet::server_envs_dir") %>/$environment/modules
     config_version = <%= scope.lookupvar("puppet::server::config_version_cmd") %>
 <% else -%>
-<% scope.lookupvar("puppet::server::environments").each do |env| -%>
+<% scope.lookupvar("puppet::server_environments").each do |env| -%>
 [<%= env %>]
-    modulepath     = <%= scope.lookupvar("puppet::server::envs_dir") %>/<%= env %>/modules:<%= [scope.lookupvar("puppet::server::common_modules_path")].flatten.join(":") %>
+    modulepath     = <%= scope.lookupvar("puppet::server_envs_dir") %>/<%= env %>/modules:<%= [scope.lookupvar("puppet::server_common_modules_path")].flatten.join(":") %>
     config_version = <%= scope.lookupvar("puppet::server::config_version_cmd") %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
An attempt to do what we discussed in #85 - making the server classes part of puppet and using a parameter to control it's inclusion.

All the class parameters in server.pp have been move to init.pp and prefixed with `server_` which keeps a nice namespace. It's a bit ugly, but we can tidy that up as we go - in many cases it's preferable to be able to specify e.g. a different user for the puppetmaster from the agent.

This _seems_ to solve the inheritance issue, since the server class is now called correctly. The ugliness in init.pp is about the only downside, I think.
