### PR TITLE
Add enc/report api options to puppetmaster

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,6 +141,12 @@
 #
 # $server_reports::         List of report types to include on the puppetmaster
 #
+# $server_enc_api::         What version of enc script to deploy. Valid values are
+#                           'v2' for latest, and 'v1' for Foreman =< 1.2
+#
+# $server_report_api::      What version of report processor to deploy. Valid values
+#                           are 'v2' for latest, and 'v1' for Foreman =< 1.2
+#
 # === Usage:
 #
 # * Simple usage:
@@ -208,7 +214,9 @@ class puppet (
   $server_foreman_url          = $foreman::params::foreman_url,
   $server_facts                = $foreman::params::facts,
   $server_puppet_home          = $foreman::params::puppet_home,
-  $server_puppet_basedir       = $foreman::params::puppet_basedir
+  $server_puppet_basedir       = $foreman::params::puppet_basedir,
+  $server_enc_api              = 'v2',
+  $server_report_api           = 'v2'
 ) inherits puppet::params {
 
   validate_bool($listen)

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -25,10 +25,12 @@ class puppet::server::config inherits puppet::config {
   # Include foreman components for the puppetmaster
   # ENC script, reporting script etc.
   class {'foreman::puppetmaster':
-    foreman_url          => $puppet::server_foreman_url,
-    facts                => $puppet::server_facts,
-    puppet_home          => $puppet::server_puppet_home,
-    puppet_basedir       => $puppet::server_puppet_basedir
+    foreman_url    => $puppet::server_foreman_url,
+    facts          => $puppet::server_facts,
+    puppet_home    => $puppet::server_puppet_home,
+    puppet_basedir => $puppet::server_puppet_basedir,
+    enc_api        => $puppet::server_enc_api,
+    report_api     => $puppet::server_report_api,
   }
 
   $ca_server                   = $::puppet::ca_server


### PR DESCRIPTION
Tests won't pass until puppet-foreman/105 is merged as the options to
`foreman::puppetmaster` aren't in the fixtures yet
