### PR TITLE
Enable hasstatus to prevent puppetd versus installer confusion

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,8 @@
 # Set up the puppet client as a service
 class puppet::service {
   service {'puppet':
-    name    => $puppet::params::service_name,
-    require => Class['puppet::install']
+    name      => $puppet::params::service_name,
+    hasstatus => true,
+    require   => Class['puppet::install']
   }
 }


### PR DESCRIPTION
On 2.6, puppet incorrectly thinks the installer "puppet apply" run is puppetd, so it doesn't start the agent.

Kafo debug logs rock.

<pre>
[DEBUG 2013-09-20 08:45:34 puppet]  Service[puppet](provider=redhat): Executing 'ps -ef'
[DEBUG 2013-09-20 08:45:34 puppet]  Service[puppet](provider=redhat): PID is 2110
[DEBUG 2013-09-20 08:45:34 puppet]  Puppet::Type::Service::ProviderRedhat: Executing '/sbin/chkconfig puppet'
[DEBUG 2013-09-20 08:45:34 puppet]  Puppet::Type::Service::ProviderRedhat: Executing '/sbin/chkconfig puppet on'
[ WARN 2013-09-20 08:45:34 puppet]  /Stage[main]/Puppet::Service/Service[puppet]/enable: enable changed 'false' to 'true'
</pre>


(pid 2110 was the installer, not the agent)
