### PR TITLE
Notify agent service when configs change

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,16 +18,17 @@ class puppet::config {
   } ->
   file { "${puppet::dir}/puppet.conf":
     content => template($puppet::agent_template),
-  } ->
+  } ~>
   file { "${puppet::dir}/auth.conf":
     content => template($puppet::auth_template),
-  } ->
-  class { "::puppet::${runmode_class}": }
+  } ~>
+  class { "::puppet::${runmode_class}": } ~>
+  Class['::puppet::service']
 
   if $puppet::listen {
     file { "${puppet::dir}/namespaceauth.conf":
       content => template($puppet::nsauth_template),
-      before  => Class["::puppet::${runmode_class}"],
+      notify  => Class["::puppet::${runmode_class}", '::puppet::service'],
     }
   }
 }


### PR DESCRIPTION
It appears that the agent doesn't monitor auth.conf etc, plus some puppet.conf changes (like listen = true) don't change on config reload.  ::puppet::service is needed here I think because of the inheritance - notifying the child class by itself didn't work.
