### PR TITLE
Set cron hour and cron minutes according to runinterval

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -10,10 +10,13 @@ class puppet::cron inherits puppet::service {
     default => $puppet::cron_cmd,
   }
 
+  $times = ip_to_cron($puppet::runinterval)
+
   cron { 'puppet':
     command => $command,
     user    => root,
-    minute  => ip_to_cron($puppet::cron_interval, $puppet::cron_range),
+    hour    => $times[0],
+    minute  => $times[1],
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,10 +89,6 @@ class puppet::params {
     default           => ['puppet'],
   }
 
-  # This only applies to puppet::cron
-  $cron_range          = 60 # the maximum value for our cron
-  $cron_interval       = 2  # the amount of values within the $cron_range
-
   # Only use 'puppet cert' on versions where puppetca no longer exists
   if versioncmp($::puppetversion, '3.0') < 0 {
     $puppetca_path = '/usr/sbin'


### PR DESCRIPTION
This is an ugly hack to set cron interval according to $puppet::runinterval
