### PR TITLE
Use https

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,11 @@
 fixtures:
   repositories:
-    apache:           'git://github.com/theforeman/puppet-apache'
-    passenger:        'git://github.com/theforeman/puppet-passenger'
-    foreman:          'git://github.com/theforeman/puppet-foreman'
-    git:              'git://github.com/theforeman/puppet-git'
-    concat_native:    'git://github.com/theforeman/puppet-concat'
-    stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+    apache:           'https://github.com/theforeman/puppet-apache'
+    passenger:        'https://github.com/theforeman/puppet-passenger'
+    foreman:          'https://github.com/theforeman/puppet-foreman'
+    git:              'https://github.com/theforeman/puppet-git'
+    concat_native:    'https://github.com/theforeman/puppet-concat'
+    stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib.git'
 
   symlinks:
     puppet: "#{source_dir}"


### PR DESCRIPTION
HTTPS at least sometimes works over proxies in corporate networks while
git:// surely doesn't.
