### PR TITLE
Specify a file mode on site.pp due to PUP-1255

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -110,6 +110,7 @@ class puppet::server::config inherits puppet::config {
       ensure  => present,
       replace => false,
       content => "# Empty site.pp required (puppet #15106, foreman #1708)\n",
+      mode    => '0644',
     }
 
     # setup empty directories for our environments


### PR DESCRIPTION
This continues to be a problem on Debian 7/Wheezy as http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=734444 hasn't been fixed.
