### PR TITLE
F19 update has changed service name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -111,9 +111,5 @@ class puppet::params {
   $puppetca_cmd = "${puppetca_path}/${puppetca_bin}"
 
   # Puppet service name
-  if $::operatingsystem == 'Fedora' and $::operatingsystemrelease >= 19 {
-    $service_name = 'puppetagent'
-  } else {
-    $service_name = 'puppet'
-  }
+  $service_name = 'puppet'
 }


### PR DESCRIPTION
In upstream Puppet 3.4 packages, the systemd service name on Fedora changed from "puppetagent" to "puppet" for consistency - probably a good thing (https://tickets.puppetlabs.com/browse/PUP-1200).

However systemd doesn't support "enabling" symlinks to unit files, and doesn't intend to (https://bugzilla.redhat.com/show_bug.cgi?id=955379 c14 etc).

This causes an error during our Puppet run:
[ERROR 2014-01-23 18:03:02 verbose] Could not enable puppetagent: Execution of '/sbin/chkconfig puppetagent on' returned 1: Note: Forwarding request to 'systemctl enable puppetagent.service'.
[ INFO 2014-01-23 18:03:02 verbose] Failed to issue method call: No such file or directory

Now Fedora has followed the same change in an update that was pushed today:
http://pkgs.fedoraproject.org/cgit/puppet.git/commit/?h=f19&id=4f6ba3aa322c8e990a36576a52de0b9b6b1b6086
https://admin.fedoraproject.org/updates/puppet-3.4.2-1.fc19

So we need to change this.
