### PR TITLE
include apache::mod::passenger

### DIFF
--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -16,6 +16,7 @@ class puppet::server::passenger (
 ) {
   include ::puppet::server::rack
   include ::apache
+  include ::apache::mod::passenger
 
   case $::operatingsystem {
     Debian,Ubuntu: {


### PR DESCRIPTION
for deploying a puppetmaster without theforman  you also need  mod_passenger
