### PR TITLE
Don't set config_version to server_config_version for every environment

### DIFF
--- a/manifests/server/env.pp
+++ b/manifests/server/env.pp
@@ -1,7 +1,7 @@
 # Set up a puppet environment
 define puppet::server::env (
   $basedir        = $::puppet::server_envs_dir,
-  $config_version = $::puppet::server::config_version_cmd,
+  $config_version = undef,
   $manifest       = undef,
   $manifestdir    = undef,
   $modulepath     = [

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -90,11 +90,11 @@ describe 'puppet::server::config' do
         with({}) # So we can use a trailing dot on each with_content line
 
       should contain_concat_fragment('puppet.conf+40-development').
-        with_content(/^\[development\]\n\s+modulepath\s+= \/etc\/puppet\/environments\/development\/modules:\/etc\/puppet\/environments\/common:\/usr\/share\/puppet\/modules\n\s+config_version = $/).
+        with_content(%r{^\[development\]\n\s+modulepath\s+= /etc/puppet/environments/development/modules:/etc/puppet/environments/common:/usr/share/puppet/modules$}).
         with({}) # So we can use a trailing dot on each with_content line
 
       should contain_concat_fragment('puppet.conf+40-production').
-        with_content(/^\[production\]\n\s+modulepath\s+= \/etc\/puppet\/environments\/production\/modules:\/etc\/puppet\/environments\/common:\/usr\/share\/puppet\/modules\n\s+config_version = $/).
+        with_content(%r{^\[production\]\n\s+modulepath\s+= /etc/puppet/environments/production/modules:/etc/puppet/environments/common:/usr/share/puppet/modules$}).
         with({}) # So we can use a trailing dot on each with_content line
 
       should contain_file('/etc/puppet/puppet.conf')

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -32,7 +32,7 @@ describe 'puppet::server::env' do
         without_content(/^\s+manifestdir\s+=/).
         with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/usr/share/puppet/modules$}).
         without_content(/^\s+templatedir\s+=/).
-        with_content(/^\s+config_version\s+=/).
+        without_content(/^\s+config_version\s+=/).
         with({}) # So we can use a trailing dot on each with_content line
     end
 
@@ -57,7 +57,7 @@ describe 'puppet::server::env' do
         without_content(/^\s+manifestdir\s+=/).
         with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/usr/share/puppet/modules$}).
         without_content(/^\s+templatedir\s+=/).
-        with_content(/^\s+config_version\s+= bar/).
+        without_content(/^\s+config_version\s+=/).
         with({}) # So we can use a trailing dot on each with_content line
     end
 


### PR DESCRIPTION
There is no need to default `config_version` to `server_config_version` for `puppet::server::env` because the default behavior is to take the `config_version` from the `master` section
