### PR TITLE
Fixed Dependency issue and added if statement to init.pp

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,5 +9,5 @@ project_page 'http://github.com/theforeman/foreman-installer'
 
 dependency 'theforeman/concat_native', '>= 1.3.0'
 dependency 'theforeman/git', '>= 1.3.0'
-dependency 'puppetlabs/apache', '>= 0.10.0'
+dependency 'puppetlabs/apache', '~> 0.10'
 dependency 'puppetlabs/stdlib', '>= 2.0.0'

--- a/Modulefile
+++ b/Modulefile
@@ -9,5 +9,5 @@ project_page 'http://github.com/theforeman/foreman-installer'
 
 dependency 'theforeman/concat_native', '>= 1.3.0'
 dependency 'theforeman/git', '>= 1.3.0'
-dependency 'puppetlabs/apache', '~> 0.10'
+dependency 'puppetlabs/apache', '>= 0.10.0'
 dependency 'puppetlabs/stdlib', '>= 2.0.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,9 @@
 # $main_template::                 Use a custom template for the main puppet
 #                                  configuration.
 #
+# $manage::                        Will this host be a managed by the puppet module?
+#                                  type:boolean
+#
 # == puppet::agent parameters
 #
 # $agent::                         Should a puppet agent be installed
@@ -240,6 +243,7 @@ class puppet (
   $auth_template               = $puppet::params::auth_template,
   $nsauth_template             = $puppet::params::nsauth_template,
   $client_package              = $puppet::params::client_package,
+  $manage                      = $puppet::params::manage,
   $agent                       = $puppet::params::agent,
   $server                      = $puppet::params::server,
   $server_user                 = $puppet::params::user,
@@ -287,6 +291,7 @@ class puppet (
   validate_bool($pluginsync)
   validate_bool($splay)
   validate_bool($agent_noop)
+  validate_bool($manage)
   validate_bool($agent)
   validate_bool($server)
   validate_bool($server_ca)
@@ -297,7 +302,7 @@ class puppet (
 
   validate_string($server_external_nodes)
 
-  if $agent == true or $server == true {
+  if $manage == true {
     class { 'puppet::config': } ->
     Class['puppet']
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -305,15 +305,15 @@ class puppet (
   if $manage == true {
     class { 'puppet::config': } ->
     Class['puppet']
-  }
-
-  if $agent == true {
-    include ::puppet::agent
-    Class['puppet::agent'] -> Class['puppet']
-  }
-
-  if $server == true {
-    include ::puppet::server
-    Class['puppet::server'] -> Class['puppet']
+	
+	  if $agent == true {
+	    include ::puppet::agent
+	    Class['puppet::agent'] -> Class['puppet']
+	  }
+	
+	  if $server == true {
+	    include ::puppet::server
+	    Class['puppet::server'] -> Class['puppet']
+	  }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -297,8 +297,10 @@ class puppet (
 
   validate_string($server_external_nodes)
 
-  class { 'puppet::config': } ->
-  Class['puppet']
+  if $agent == true or $server == true {
+    class { 'puppet::config': } ->
+    Class['puppet']
+  }
 
   if $agent == true {
     include ::puppet::agent

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,9 @@ class puppet::params {
   $auth_template   = 'puppet/auth.conf.erb'
   $nsauth_template = 'puppet/namespaceauth.conf.erb'
 
+  # Will this host be a managed by the puppet module ?
+  $manage                    = true
+
   # Will this host be a puppet agent ?
   $agent                     = true
 


### PR DESCRIPTION
Fixed dependency version bug in Modulefile for the puppetlabs/apache module

Added if statement around the "class { 'puppet::config': } -> ..." code in init.pp
  So that a node that defines puppet::agent: and puppet::server: false won't have
  any changes applied to their puppet.conf. Without this, the puppet.conf is always
  potentially modifiable, even when not intended.