### PR TITLE
Issue #4345: Add a server_ca_proxy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,6 +199,11 @@
 #                                  Valid values are 'v2' for latest, and 'v1'
 #                                  for Foreman =< 1.2
 #
+# $server_ca_proxy::               The actual server that handles puppet CA.
+#                                  Setting this to anything non-empty causes
+#                                  the apache vhost to set up a proxy for all
+#                                  certificates pointing to the value.
+#
 # === Usage:
 #
 # * Simple usage:
@@ -274,6 +279,7 @@ class puppet (
   $server_certname             = $puppet::params::server_certname,
   $server_enc_api              = $puppet::params::server_enc_api,
   $server_report_api           = $puppet::params::server_report_api,
+  $server_ca_proxy             = $puppet::params::server_ca_proxy,
   $server_foreman_url          = $foreman::params::foreman_url,
   $server_foreman_ssl_ca       = $foreman::params::client_ssl_ca,
   $server_foreman_ssl_cert     = $foreman::params::client_ssl_cert,
@@ -297,6 +303,7 @@ class puppet (
 
   validate_string($ca_server)
   validate_string($server_external_nodes)
+  validate_string($server_ca_proxy)
 
   class { 'puppet::config': } ->
   Class['puppet']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,7 @@ class puppet::params {
   $server_external_nodes     = '/etc/puppet/node.rb'
   $server_enc_api            = 'v2'
   $server_report_api         = 'v2'
+  $server_ca_proxy           = ''
   $server_certname           = $::clientcert
 
   # Need a new master template for the server?

--- a/spec/classes/puppet_server_passenger_spec.rb
+++ b/spec/classes/puppet_server_passenger_spec.rb
@@ -7,7 +7,24 @@ describe 'puppet::server::passenger' do
     :operatingsystemrelease => '6.5',
   } end
 
-  it 'should include the puppet vhost' do
-    should contain_apache__vhost('puppet')
+  describe 'without parameters' do
+    it 'should include the puppet vhost' do
+      should contain_apache__vhost('puppet').with({
+        :ssl_proxyengine => false,
+      })
+    end
+  end
+
+  describe 'with puppet ca' do
+    let :params do {
+      :puppet_ca_proxy => 'https://ca.example.org:8140',
+    } end
+
+    it 'should include the puppet vhost' do
+      should contain_apache__vhost('puppet').with({
+        :ssl_proxyengine => true,
+        :custom_fragment => "ProxyPassMatch ^/([^/]+/certificate.*)$ https://ca.example.org:8140/$1",
+      })
+    end
   end
 end


### PR DESCRIPTION
http://docs.puppetlabs.com/guides/scaling_multiple_masters.html#option-2-proxy-certificate-traffic describes how to set up a proxy CA. This adds a parameter to set up the ca proxy on the puppet master.
