### PR TITLE
Auth crl allow

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,10 +1,11 @@
 # Set up the puppet config
 class puppet::config(
-  $auth_template   = $::puppet::auth_template,
-  $ca_server       = $::puppet::ca_server,
-  $main_template   = $::puppet::main_template,
-  $nsauth_template = $::puppet::nsauth_template,
-  $puppet_dir      = $::puppet::dir,
+  $allow_any_crl_auth = $::puppet::allow_any_crl_auth,
+  $auth_template      = $::puppet::auth_template,
+  $ca_server          = $::puppet::ca_server,
+  $main_template      = $::puppet::main_template,
+  $nsauth_template    = $::puppet::nsauth_template,
+  $puppet_dir         = $::puppet::dir,
 ) {
   concat_build { 'puppet.conf': }
   concat_fragment { 'puppet.conf+10-main':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -204,6 +204,11 @@
 #                                  the apache vhost to set up a proxy for all
 #                                  certificates pointing to the value.
 #
+# $allow_any_crl_auth::            Allow any authentication for the CRL. This
+#                                  is needed on the puppet CA to accept clients
+#                                  from a the puppet CA proxy.
+#                                  type:boolean
+#
 # === Usage:
 #
 # * Simple usage:
@@ -244,6 +249,7 @@ class puppet (
   $agent_template              = $puppet::params::agent_template,
   $auth_template               = $puppet::params::auth_template,
   $nsauth_template             = $puppet::params::nsauth_template,
+  $allow_any_crl_auth          = $puppet::params::allow_any_crl_auth,
   $client_package              = $puppet::params::client_package,
   $agent                       = $puppet::params::agent,
   $server                      = $puppet::params::server,
@@ -295,6 +301,7 @@ class puppet (
   validate_bool($agent_noop)
   validate_bool($agent)
   validate_bool($server)
+  validate_bool($allow_any_crl_auth)
   validate_bool($server_ca)
   validate_bool($server_passenger)
   validate_bool($server_git_repo)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,9 @@ class puppet::params {
   $auth_template   = 'puppet/auth.conf.erb'
   $nsauth_template = 'puppet/namespaceauth.conf.erb'
 
+  # Allow any to the CRL. Needed in case of puppet CA proxy
+  $allow_any_crl_auth = false
+
   # Will this host be a puppet agent ?
   $agent                     = true
 

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -14,4 +14,14 @@ describe 'puppet::config' do
       should contain_file('/etc/puppet/auth.conf').with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
     end
   end
+
+  describe 'with allow_any_crl_auth' do
+    let :pre_condition do
+      'class {"::puppet": allow_any_crl_auth => true}'
+    end
+
+    it 'should contain auth.conf with auth any' do
+      should contain_file('/etc/puppet/auth.conf').with_content(%r{^path /certificate_revocation_list/ca\nauth any$})
+    end
+  end
 end

--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -59,6 +59,9 @@ allow $1
 
 # allow all nodes to access the certificates services
 path /certificate_revocation_list/ca
+<% if @allow_any_crl_auth -%>
+auth any
+<% end -%>
 method find
 allow *
 


### PR DESCRIPTION
This patch first refactors puppet::config a bit to make it easier to extend. It also adds fairly minimal tests. The next patch adds an auth_crl_allow parameter. http://docs.puppetlabs.com/guides/scaling_multiple_masters.html#option-2-proxy-certificate-traffic states the following should be present in auth.conf if using a puppet ca proxy:

path /certificate_revocation_list
auth any
method find
allow *

In my testing /certificate_revocation_list/ca was sufficient.
