### PR TITLE
Change perms on puppet.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,8 @@ class puppet::config(
   $main_template      = $::puppet::main_template,
   $nsauth_template    = $::puppet::nsauth_template,
   $puppet_dir         = $::puppet::dir,
+  $user               = $::puppet::user,
+  $group              = $::puppet::group,
 ) {
   concat_build { 'puppet.conf': }
   concat_fragment { 'puppet.conf+10-main':
@@ -18,6 +20,8 @@ class puppet::config(
   file { "${puppet_dir}/puppet.conf":
     source  => concat_output('puppet.conf'),
     require => Concat_build['puppet.conf'],
+    owner   => $user,
+    group   => $group,
     mode    => '0644',
   } ~>
   file { "${puppet_dir}/auth.conf":


### PR DESCRIPTION
When the umask on the server is 0077, the puppet.conf file has permissions of 0600 and the file can't be read by the foreman-proxy or puppet since the default owner is root.  By setting the perms to world readable, we resolve these issues.
