### PR TITLE
pull in new auth.conf from puppet 3.5.0

### DIFF
--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -1,14 +1,19 @@
-# This file implements the defaults used by the puppet master.
+# This is the default auth.conf file, which implements the default rules
+# used by the puppet master. (That is, the rules below will still apply
+# even if this file is deleted.)
 #
-# The ACLs are evaluated in top-down order. More general
-# stanzas should be towards the bottom of the file and more
-# specific ones at the top, otherwise the general rules
-# take precedence and later rules will not be evaluated.
+# The ACLs are evaluated in top-down order. More specific stanzas should
+# be towards the top of the file and more general ones at the bottom;
+# otherwise, the general rules may "steal" requests that should be
+# governed by the specific rules.
+#
+# See http://docs.puppetlabs.com/guides/rest_auth_conf.html for a more complete
+# description of auth.conf's behavior.
 #
 # Supported syntax:
-# Each stanza in auth.conf starts with a path to mach, followed
+# Each stanza in auth.conf starts with a path to match, followed
 # by optional modifiers, and finally, a series of allow or deny
-# directives. 
+# directives.
 #
 # Example Stanza
 # ---------------------------------
@@ -17,25 +22,33 @@
 # [environment envlist]
 # [method methodlist]
 # [auth[enthicated] {yes|no|on|off|any}]
-# allow [host|backreference|*]
-# deny [host|backreference|*]
+# allow [host|backreference|*|regex]
+# deny [host|backreference|*|regex]
 # allow_ip [ip|cidr|ip_wildcard|*]
 # deny_ip [ip|cidr|ip_wildcard|*]
 #
-# The path match can either be a simple prefix match or a regular 
+# The path match can either be a simple prefix match or a regular
 # expression. `path /file` would match both `/file_metadata` and
 # `/file_content`. Regex matches allow the use of backreferences
 # in the allow/deny directives.
-# 
+#
 # The regex syntax is the same as for Ruby regex, and captures backreferences
 # for use in the `allow` and `deny` lines of that stanza
 #
 # Examples:
-# path ~ ^/path/to/resource    # equivalent to `path /path/to/resource`
-# allow *
 #
-# path ~ ^/catalog/([^/]+)$    # permit access only for the
-# allow $1                     # node whose cert matches the path
+# path ~ ^/path/to/resource    # Equivalent to `path /path/to/resource`.
+# allow *                      # Allow all authenticated nodes (since auth
+#                              # defaults to `yes`).
+#
+# path ~ ^/catalog/([^/]+)$    # Permit nodes to access their own catalog (by
+# allow $1                     # certname), but not any other node's catalog.
+#
+# path ~ ^/file_(metadata|content)/extra_files/  # Only allow certain nodes to
+# auth yes                                       # access the "extra_files"
+# allow /^(.+)\.example\.com$/                   # mount point; note this must
+# allow_ip 192.168.100.0/24                      # go ABOVE the "/file" rule,
+#                                                # since it is more specific.
 #
 # environment:: restrict an ACL to a comma-separated list of environments
 # method:: restrict an ACL to a comma-separated list of HTTP methods
@@ -44,7 +57,7 @@
 # (ie exactly as if auth yes was present).
 #
 
-### Authenticated paths - these apply only when the client
+### Authenticated ACLs - these rules apply only when the client
 ### has a valid certificate and is thus authenticated
 
 # allow nodes to retrieve their own catalog
@@ -70,27 +83,31 @@ path ~ ^/report/([^/]+)$
 method save
 allow $1
 
-# unconditionally allow access to all file services
-# which means in practice that fileserver.conf will
-# still be used
+# Allow all nodes to access all file services; this is necessary for
+# pluginsync, file serving from modules, and file serving from custom
+# mount points (see fileserver.conf). Note that the `/file` prefix matches
+# requests to both the file_metadata and file_content paths. See "Examples"
+# above if you need more granular access control for custom mount points.
 path /file
 allow *
 
-### Unauthenticated ACL, for clients for which the current master doesn't
-### have a valid certificate; we allow authenticated users, too, because
-### there isn't a great harm in letting that request through.
+### Unauthenticated ACLs, for clients without valid certificates; authenticated
+### clients can also access these paths, though they rarely need to.
 
-# allow access to the master CA
+# allow access to the CA certificate; unauthenticated nodes need this
+# in order to validate the puppet master's certificate
 path /certificate/ca
 auth any
 method find
 allow *
 
+# allow nodes to retrieve the certificate they requested earlier
 path /certificate/
 auth any
 method find
 allow *
 
+# allow nodes to request a new certificate
 path /certificate_request
 auth any
 method find, save
@@ -103,7 +120,12 @@ method save
 allow <%= if ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>
 
 <% end -%>
-# this one is not stricly necessary, but it has the merit
-# of showing the default policy, which is deny everything else
+
+path /v2.0/environments
+method find
+allow *
+
+# deny everything else; this ACL is not strictly necessary, but
+# illustrates the default policy.
 path /
 auth any


### PR DESCRIPTION
I updated my puppet master today and this new auth.conf came with it. Besides

```
path /v2.0/environments
method find
allow *
```

I see only extented comments
