### PR TITLE
Move show_diff from agent to main

### DIFF
--- a/templates/agent/puppet.conf.erb
+++ b/templates/agent/puppet.conf.erb
@@ -28,6 +28,5 @@
     splay         = <%= scope.lookupvar('::puppet::splay') %>
     runinterval   = <%= scope.lookupvar('::puppet::runinterval') %>
     noop          = <%= scope.lookupvar('::puppet::agent_noop') %>
-    show_diff     = <%= scope.lookupvar('::puppet::show_diff') %>
     configtimeout = <%= scope.lookupvar('::puppet::configtimeout') %>
 

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -20,6 +20,8 @@
     # Puppet 3.0.x requires this in both [main] and [master] - harmless on agents
     autosign       = $confdir/autosign.conf { mode = 664 }
 
+    show_diff     = <%= scope.lookupvar('::puppet::show_diff') %>
+
 <% if @ca_server and !@ca_server.empty? -%>
     # Use specified CA server
     ca_server = <%= @ca_server %>


### PR DESCRIPTION
This enables show_diff also for Puppet apply - which I use very often for testing.

Is there any reason only enabling it for the agent?
