### PR TITLE
Add runmode 'none' to allow for masterless Puppet usage scenarios

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -36,6 +36,18 @@ class puppet::agent::service {
         minute  => $times[1],
       }
     }
+    'none': {
+      service { 'puppet':
+        ensure    => stopped,
+        name      => $puppet::params::service_name,
+        hasstatus => true,
+        enable    => false,
+      }
+
+      cron { 'puppet':
+        ensure => absent,
+      }
+    }
     default: {
       fail("Runmode of ${puppet::runmode} not supported by puppet::agent::config!")
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@
 #                                  type:integer
 #
 # $runmode::                       Select the mode to setup the puppet agent.
-#                                  Can be either 'cron' or 'service'.
+#                                  Can be either 'cron', 'service', or 'none'.
 #
 # $cron_cmd::                      Specify command to launch when runmode is
 #                                  set 'cron'.

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe 'puppet::agent::service' do
+
+  let :facts do {
+    :clientcert             => 'puppetmaster.example.com',
+    :concat_basedir         => '/nonexistant',
+    :fqdn                   => 'puppetmaster.example.com',
+    :operatingsystemrelease => '6.5',
+    :osfamily               => 'RedHat',
+  } end
+
+  describe 'with no custom parameters' do
+    let :pre_condition do
+      "class {'puppet': agent => true}"
+    end
+
+    it do
+      should contain_service('puppet').with({
+        :ensure     => 'running',
+        :name       => 'puppet',
+        :hasstatus  => 'true',
+        :enable     => 'true',
+      })
+    end
+
+    it { should contain_cron('puppet').with_ensure('absent') }
+  end
+
+  describe 'when runmode => cron' do
+    let :pre_condition do
+      "class {'puppet': agent => true, runmode => 'cron'}"
+    end
+
+    it do
+      should contain_service('puppet').with({
+        :ensure     => 'stopped',
+        :name       => 'puppet',
+        :hasstatus  => 'true',
+        :enable     => 'false',
+      })
+    end
+
+    it do
+      should contain_cron('puppet').with({
+        :command  => '/usr/bin/env puppet agent --config /etc/puppet/puppet.conf --onetime --no-daemonize',
+        :user     => 'root',
+        :minute   => ['0','30'],
+        :hour     => '*',
+      })
+    end
+  end
+
+  describe 'when runmode => none' do
+    let :pre_condition do
+      "class {'puppet': agent => true, runmode => 'none'}"
+    end
+
+    it do
+      should contain_service('puppet').with({
+        :ensure     => 'stopped',
+        :name       => 'puppet',
+        :hasstatus  => 'true',
+        :enable     => 'false',
+      })
+    end
+
+    it { should contain_cron('puppet').with_ensure('absent') }
+  end
+
+  describe 'when runmode => foo' do
+    let :pre_condition do
+      "class {'puppet': agent => true, runmode => 'foo'}"
+    end
+
+    it { expect { should create_class('puppet::agent::service') }.to raise_error(Puppet::Error, /Runmode of foo not supported by puppet::agent::config!/) }
+  end
+
+end


### PR DESCRIPTION
Allow agent runmode to be set to "none".  The use case is to allow Puppet to be run in masterless mode without periodic cron jobs executing Puppet.
