### PR TITLE
Make foreman integration optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,6 +268,9 @@
 # $server_facts::                  Should foreman receive facts from puppet
 #                                  type:boolean
 #
+# $server_foreman::                Should foreman integration be installed
+#                                  type:boolean
+#
 # $server_foreman_url::            Foreman URL
 #
 # $server_foreman_ssl_ca::         SSL CA of the Foreman server
@@ -276,10 +279,7 @@
 #
 # $server_foreman_ssl_key::        Key for authenticating against Foreman server
 #
-#
 # $server_puppet_basedir::         Where is the puppet code base located
-#
-# $server_puppet_home::            Puppet var directory
 #
 # $server_enc_api::                What version of enc script to deploy. Valid
 #                                  values are 'v2' for latest, and 'v1'
@@ -408,13 +408,13 @@ class puppet (
   $server_strict_variables       = $puppet::params::server_strict_variables,
   $server_additional_settings    = $puppet::params::server_additional_settings,
   $server_rack_arguments         = $puppet::params::server_rack_arguments,
-  $server_foreman_url            = $foreman::params::foreman_url,
-  $server_foreman_ssl_ca         = $foreman::params::client_ssl_ca,
-  $server_foreman_ssl_cert       = $foreman::params::client_ssl_cert,
-  $server_foreman_ssl_key        = $foreman::params::client_ssl_key,
-  $server_facts                  = $foreman::params::receive_facts,
-  $server_puppet_home            = $foreman::params::puppet_home,
-  $server_puppet_basedir         = $foreman::params::puppet_basedir
+  $server_foreman                = $puppet::params::server_foreman,
+  $server_foreman_url            = $puppet::params::server_foreman_url,
+  $server_foreman_ssl_ca         = $puppet::params::client_ssl_ca,
+  $server_foreman_ssl_cert       = $puppet::params::client_ssl_cert,
+  $server_foreman_ssl_key        = $puppet::params::client_ssl_key,
+  $server_facts                  = $puppet::params::server_facts,
+  $server_puppet_basedir         = $puppet::params::server_puppet_basedir,
 ) inherits puppet::params {
 
   validate_bool($listen)
@@ -432,6 +432,7 @@ class puppet (
   validate_bool($server_facts)
   validate_bool($server_strict_variables)
   validate_hash($server_additional_settings)
+  validate_bool($server_foreman)
 
   validate_string($ca_server)
   validate_string($hiera_config)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,6 @@
 # Default parameters
 class puppet::params {
 
-  include foreman::params
-
   # Basic config
   $version             = 'present'
   $user                = 'puppet'
@@ -167,4 +165,12 @@ class puppet::params {
   # Puppet service name
   $service_name = 'puppet'
 
+  # Foreman parameters
+  $server_foreman          = true
+  $server_facts            = true
+  $server_puppet_basedir   = undef
+  $server_foreman_url      = "https://${::fqdn}"
+  $server_foreman_ssl_ca   = undef
+  $server_foreman_ssl_cert = undef
+  $server_foreman_ssl_key  = undef
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -23,18 +23,20 @@ class puppet::server::config inherits puppet::config {
     mode  => '0640',
   }
 
-  # Include foreman components for the puppetmaster
-  # ENC script, reporting script etc.
-  class {'foreman::puppetmaster':
-    foreman_url    => $puppet::server_foreman_url,
-    receive_facts  => $puppet::server_facts,
-    puppet_home    => $puppet::server_puppet_home,
-    puppet_basedir => $puppet::server_puppet_basedir,
-    enc_api        => $puppet::server_enc_api,
-    report_api     => $puppet::server_report_api,
-    ssl_ca         => $puppet::server_foreman_ssl_ca,
-    ssl_cert       => $puppet::server_foreman_ssl_cert,
-    ssl_key        => $puppet::server_foreman_ssl_key,
+  if $::puppet::server_foreman {
+    # Include foreman components for the puppetmaster
+    # ENC script, reporting script etc.
+    class {'foreman::puppetmaster':
+      foreman_url    => $puppet::server_foreman_url,
+      receive_facts  => $puppet::server_facts,
+      puppet_home    => $puppet::server_vardir,
+      puppet_basedir => $puppet::server_puppet_basedir,
+      enc_api        => $puppet::server_enc_api,
+      report_api     => $puppet::server_report_api,
+      ssl_ca         => pick($puppet::server_foreman_ssl_ca, $puppet::server::ssl_ca_cert),
+      ssl_cert       => pick($puppet::server_foreman_ssl_cert, $puppet::server::ssl_cert),
+      ssl_key        => pick($puppet::server_foreman_ssl_key, $puppet::server::ssl_cert_key),
+    }
   }
 
   $ca_server                   = $::puppet::ca_server


### PR DESCRIPTION
Instead of including foreman::params, the values are copied. That means 
foreman::params no longer needs to be included.

The next use of foreman is in puppet::server::config where it sets up 
reporting and ENC. This is wrapped in a new boolean $server_foreman. The user
will still need to take care of clearing $server_reports and
$server_external_nodes.

Fixes #154