### PR TITLE
Fixes #6352: Lowercase hostnames in certs

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,8 +19,9 @@ class puppet::server {
     $ssl_chain   = false
   }
 
-  $ssl_cert      = "${::puppet::server_ssl_dir}/certs/${::fqdn}.pem"
-  $ssl_cert_key  = "${::puppet::server_ssl_dir}/private_keys/${::fqdn}.pem"
+  $lower_fqdn    = downcase($::fqdn)
+  $ssl_cert      = "${::puppet::server_ssl_dir}/certs/${lower_fqdn}.pem"
+  $ssl_cert_key  = "${::puppet::server_ssl_dir}/private_keys/${lower_fqdn}.pem"
 
   if $::puppet::server_config_version == undef {
     if $::puppet::server_git_repo {

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -2,24 +2,47 @@ require 'spec_helper'
 
 describe 'puppet::server' do
 
-  let :pre_condition do
-    "class {'puppet': server => true}"
-  end
+  context 'basic case' do
+    let :pre_condition do
+      "class {'puppet': server => true}"
+    end
 
-  let :facts do {
-    :concat_basedir         => '/nonexistant',
-    :clientcert             => 'puppetmaster.example.com',
-    :fqdn                   => 'puppetmaster.example.com',
-    :operatingsystemrelease => '6.5',
-    :osfamily               => 'RedHat',
-  } end
+    let :facts do {
+      :concat_basedir         => '/nonexistant',
+      :clientcert             => 'puppetmaster.example.com',
+      :fqdn                   => 'puppetmaster.example.com',
+      :operatingsystemrelease => '6.5',
+      :osfamily               => 'RedHat',
+    } end
 
-  describe 'with no custom parameters' do
-    it 'should include classes' do
-      should contain_class('puppet::server::install')
-      should contain_class('puppet::server::config')
-      should contain_class('puppet::server::service')
+    describe 'with no custom parameters' do
+      it 'should include classes' do
+        should contain_class('puppet::server::install')
+        should contain_class('puppet::server::config')
+        should contain_class('puppet::server::service')
+      end
     end
   end
 
+  context 'with uppercase hostname' do
+    let :pre_condition do
+      "class {'puppet': server => true}"
+    end
+
+    let :facts do {
+      :concat_basedir         => '/nonexistant',
+      :clientcert             => 'PUPPETMASTER.example.com',
+      :fqdn                   => 'PUPPETMASTER.example.com',
+      :operatingsystemrelease => '6.5',
+      :osfamily               => 'RedHat',
+    } end
+
+    describe 'with no custom parameters' do
+      it 'should use lowercase certificates' do
+        should contain_class('puppet::server::passenger').
+          with_ssl_cert('/var/lib/puppet/ssl/certs/puppetmaster.example.com.pem').
+          with_ssl_cert_key('/var/lib/puppet/ssl/private_keys/puppetmaster.example.com.pem')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the same fix as https://github.com/theforeman/puppet-foreman/commit/aad76195117479ca6b2cbbf9f0579e3672a9c806 and is already part of https://github.com/theforeman/puppet-puppet/pull/162.

Relevant parts from http://projects.theforeman.org/issues/6352:

facter fqdn and hostname -f both return HOSTNAME.domain.com

```
Starting httpd: [Tue Jun 24 13:26:59 2014] [warn] module passenger_module is already loaded, skipping
Syntax error on line 37 of /etc/httpd/conf.d/25-puppet.conf: SSLCertificateFile: file '/var/lib/puppet/ssl/certs/HOSTNAME.domain.com.pem' does not exist or is empty
[FAILED]
```

There is a .pem file generated in /var/lib/puppet/certs/, but it is in lowercase.
