### PR TITLE
fixes #4700 - deploy directory environments on Puppet 3.6 or higher

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,9 +132,12 @@
 #                                  type:boolean
 #
 # $server_dynamic_environments::   Use $environment in the modulepath
+#                                  Deprecated when $server_directory_environments is true,
+#                                  set $server_environments to [] instead.
 #                                  type:boolean
 #
-# $server_directory_environments:: Enable directory environments
+# $server_directory_environments:: Enable directory environments, defaulting to true
+#                                  with Puppet 3.6.0 or higher
 #                                  type:boolean
 #
 # $server_environments::           Environments to setup (creates directories).

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,10 +71,10 @@ class puppet::params {
   # Static environments config, ignore if the git_repo or dynamic_environments is 'true'
   # What environments do we have
   $server_environments         = ['development', 'production']
-  # Dynamic environments config
+  # Dynamic environments config (deprecated when directory_environments is true)
   $server_dynamic_environments = false
   # Directory environments config
-  $server_directory_environments = false
+  $server_directory_environments = versioncmp($::puppetversion, '3.6.0') >= 0
   # Owner of the environments dir: for cases external service needs write
   # access to manage it.
   $server_environments_owner   = $user
@@ -85,7 +85,7 @@ class puppet::params {
   # Where remains our manifests dir
   $server_manifest_path        = "${dir}/manifests"
   # Modules in this directory would be shared across all environments
-  $server_common_modules_path  = ["${server_envs_dir}/common", '/usr/share/puppet/modules']
+  $server_common_modules_path  = ["${server_envs_dir}/common", "${dir}/modules", '/usr/share/puppet/modules']
 
   # Dynamic environments config, ignore if the git_repo is 'false'
   # Path to the repository

--- a/manifests/server/env.pp
+++ b/manifests/server/env.pp
@@ -1,11 +1,13 @@
 # Set up a puppet environment
 define puppet::server::env (
-  $basedir        = $::puppet::server_envs_dir,
-  $config_version = $::puppet::server::config_version_cmd,
-  $manifest       = undef,
-  $manifestdir    = undef,
-  $modulepath     = ["${::puppet::server_envs_dir}/${name}/modules", $::puppet::server_common_modules_path],
-  $templatedir    = undef
+  $basedir                = $::puppet::server_envs_dir,
+  $config_version         = $::puppet::server::config_version_cmd,
+  $manifest               = undef,
+  $manifestdir            = undef,
+  $modulepath             = ["${::puppet::server_envs_dir}/${name}/modules", $::puppet::server_common_modules_path],
+  $templatedir            = undef,
+  $environment_timeout    = undef,
+  $directory_environments = $::puppet::server_directory_environments,
 ) {
   file { "${basedir}/${name}":
     ensure => directory,
@@ -15,7 +17,24 @@ define puppet::server::env (
     ensure => directory,
   }
 
-  concat_fragment { "puppet.conf+40-${name}":
-    content => template('puppet/server/puppet.conf.env.erb')
+  if $directory_environments {
+    file { "${basedir}/${name}/manifests":
+      ensure => directory,
+    }
+
+    $custom_modulepath = $modulepath and ($modulepath != ["${basedir}/${name}/modules", $::puppet::server_common_modules_path])
+    if $manifest or $config_version or $custom_modulepath or $environment_timeout {
+      file { "${basedir}/${name}/environment.conf":
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('puppet/server/environment.conf.erb'),
+      }
+    }
+  } else {
+    concat_fragment { "puppet.conf+40-${name}":
+      content => template('puppet/server/puppet.conf.env.erb')
+    }
   }
 }

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'puppet::server::config' do
-  let :facts do {
+  let :default_facts do {
     :clientcert             => 'puppetmaster.example.com',
     :concat_basedir         => '/nonexistant',
     :fqdn                   => 'puppetmaster.example.com',
@@ -9,6 +9,7 @@ describe 'puppet::server::config' do
     :operatingsystemrelease => '6.5',
     :osfamily               => 'RedHat',
   } end
+  let(:facts) { default_facts }
 
   describe 'with no custom parameters' do
     let :pre_condition do
@@ -61,6 +62,7 @@ describe 'puppet::server::config' do
         :content => "# Empty site.pp required (puppet #15106, foreman #1708)\n",
       })
 
+      should contain_puppet__server__env('development')
       should contain_puppet__server__env('production')
     end
 
@@ -87,14 +89,6 @@ describe 'puppet::server::config' do
         with_content(/^\s+node_terminus\s+= exec$/).
         with_content(/^\s+ca\s+= true$/).
         with_content(/^\s+ssldir\s+= \/var\/lib\/puppet\/ssl$/).
-        with({}) # So we can use a trailing dot on each with_content line
-
-      should contain_concat_fragment('puppet.conf+40-development').
-        with_content(/^\[development\]\n\s+modulepath\s+= \/etc\/puppet\/environments\/development\/modules:\/etc\/puppet\/environments\/common:\/usr\/share\/puppet\/modules\n\s+config_version = $/).
-        with({}) # So we can use a trailing dot on each with_content line
-
-      should contain_concat_fragment('puppet.conf+40-production').
-        with_content(/^\[production\]\n\s+modulepath\s+= \/etc\/puppet\/environments\/production\/modules:\/etc\/puppet\/environments\/common:\/usr\/share\/puppet\/modules\n\s+config_version = $/).
         with({}) # So we can use a trailing dot on each with_content line
 
       should contain_file('/etc/puppet/puppet.conf')
@@ -173,31 +167,93 @@ describe 'puppet::server::config' do
       })
     end
 
-    it 'should configure puppet.conf' do
-      should contain_concat_fragment('puppet.conf+30-master').
-        with_content(%r{^\s+manifest\s+= /etc/puppet/environments/\$environment/manifests/site.pp\n\s+modulepath\s+= /etc/puppet/environments/\$environment/modules\n\s+config_version\s+= git --git-dir /etc/puppet/environments/\$environment/.git describe --all --long$})
+    it { should_not contain_puppet__server__env('development') }
+    it { should_not contain_puppet__server__env('production') }
+
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet':
+           server                        => true,
+           server_git_repo               => true,
+           server_directory_environments => true,
+         }"
+      end
+
+      it 'should configure puppet.conf' do
+        should contain_concat_fragment('puppet.conf+30-master').
+          with_content(%r{^\s+environmentpath\s+= /etc/puppet/environments$}).
+          with_content(%r{^\s+config_version\s+= git --git-dir /etc/puppet/environments/\$environment/.git describe --all --long$})
+      end
+    end
+
+    context 'with config environments' do
+      let :pre_condition do
+        "class {'puppet':
+           server                        => true,
+           server_git_repo               => true,
+           server_directory_environments => false,
+         }"
+      end
+
+      it 'should configure puppet.conf' do
+        should contain_concat_fragment('puppet.conf+30-master').
+          with_content(%r{^\s+manifest\s+= /etc/puppet/environments/\$environment/manifests/site.pp\n\s+modulepath\s+= /etc/puppet/environments/\$environment/modules$}).
+          with_content(%r{^\s+config_version\s+= git --git-dir /etc/puppet/environments/\$environment/.git describe --all --long$})
+      end
     end
   end
 
   describe 'with dynamic environments' do
-    let :pre_condition do
-      "class {'puppet':
-          server                      => true,
-          server_dynamic_environments => true,
-          server_environments_owner   => 'apache',
-       }"
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet':
+           server                        => true,
+           server_dynamic_environments   => true,
+           server_directory_environments => true,
+           server_environments_owner     => 'apache',
+         }"
+      end
+
+      it 'should set up the environments directory' do
+        should contain_file('/etc/puppet/environments').with({
+          :ensure => 'directory',
+          :owner  => 'apache',
+        })
+      end
+
+      it 'should configure puppet.conf' do
+        should contain_concat_fragment('puppet.conf+30-master').
+          with_content(%r{^\s+environmentpath\s+= /etc/puppet/environments\n\s+basemodulepath\s+= /etc/puppet/environments/common:/etc/puppet/modules:/usr/share/puppet/modules$})
+      end
+
+      it { should_not contain_puppet__server__env('development') }
+      it { should_not contain_puppet__server__env('production') }
     end
 
-    it 'should set up the environments directory' do
-      should contain_file('/etc/puppet/environments').with({
-        :ensure => 'directory',
-        :owner  => 'apache',
-      })
-    end
+    context 'with config environments' do
+      let :pre_condition do
+        "class {'puppet':
+           server                        => true,
+           server_dynamic_environments   => true,
+           server_directory_environments => false,
+           server_environments_owner     => 'apache',
+         }"
+      end
 
-    it 'should configure puppet.conf' do
-      should contain_concat_fragment('puppet.conf+30-master').
-        with_content(%r{^\s+manifest\s+= /etc/puppet/environments/\$environment/manifests/site.pp\n\s+modulepath\s+= /etc/puppet/environments/\$environment/modules\n\s+config_version\s+= $})
+      it 'should set up the environments directory' do
+        should contain_file('/etc/puppet/environments').with({
+          :ensure => 'directory',
+          :owner  => 'apache',
+        })
+      end
+
+      it 'should configure puppet.conf' do
+        should contain_concat_fragment('puppet.conf+30-master').
+          with_content(%r{^\s+manifest\s+= /etc/puppet/environments/\$environment/manifests/site.pp\n\s+modulepath\s+= /etc/puppet/environments/\$environment/modules\n\s+config_version\s+= $})
+      end
+
+      it { should_not contain_puppet__server__env('development') }
+      it { should_not contain_puppet__server__env('production') }
     end
   end
 
@@ -232,6 +288,30 @@ describe 'puppet::server::config' do
     it 'should add the branch map to the post receive hook' do
       should contain_file('/var/lib/puppet/puppet.git/hooks/post-receive').
         with_content(/BRANCH_MAP = {\n  "a" => "b",\n  "c" => "d",\n}/)
+    end
+  end
+
+  describe 'directory environments default' do
+    let :pre_condition do
+      "class {'puppet':
+         server => true,
+       }"
+    end
+
+    context 'on old Puppet' do
+      let(:facts) { default_facts.merge(:puppetversion => '3.5.3') }
+      it 'should be disabled' do
+        should contain_concat_fragment('puppet.conf+30-master').
+          without_content(%r{^\s+environmentpath\s+=$})
+      end
+    end
+
+    context 'on Puppet 3.6.0+' do
+      let(:facts) { default_facts.merge(:puppetversion => '3.6.0') }
+      it 'should be enabled' do
+        should contain_concat_fragment('puppet.conf+30-master').
+          with_content(%r{^\s+environmentpath\s+= /etc/puppet/environments$})
+      end
     end
   end
 end

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'puppet::server::env' do
-  
+
   let(:title) { 'foo' }
 
   let :facts do {
@@ -14,84 +14,195 @@ describe 'puppet::server::env' do
   } end
 
   context 'with no custom parameters' do
-    let :pre_condition do
-      "class {'puppet': server => true}"
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => true}"
+      end
+
+      it 'should only deploy directories' do
+        should contain_file('/etc/puppet/environments/foo').with({
+          :ensure => 'directory',
+        })
+
+        should contain_file('/etc/puppet/environments/foo/manifests').with({
+          :ensure => 'directory',
+        })
+
+        should contain_file('/etc/puppet/environments/foo/modules').with({
+          :ensure => 'directory',
+        })
+
+        should_not contain_file('/etc/puppet/environments/foo/environment.conf')
+        should_not contain_concat_fragment('puppet.conf+40-foo')
+      end
     end
 
-    it 'should add an env section' do
-      should contain_file('/etc/puppet/environments/foo').with({
-        :ensure => 'directory',
-      })
+    context 'with config environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => false}"
+      end
 
-      should contain_file('/etc/puppet/environments/foo/modules').with({
-        :ensure => 'directory',
-      })
+      it 'should add an env section' do
+        should contain_file('/etc/puppet/environments/foo').with({
+          :ensure => 'directory',
+        })
 
-      should contain_concat_fragment('puppet.conf+40-foo').
-        without_content(/^\s+manifest\s+=/).
-        without_content(/^\s+manifestdir\s+=/).
-        with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/usr/share/puppet/modules$}).
-        without_content(/^\s+templatedir\s+=/).
-        with_content(/^\s+config_version\s+=/).
-        with({}) # So we can use a trailing dot on each with_content line
+        should contain_file('/etc/puppet/environments/foo/modules').with({
+          :ensure => 'directory',
+        })
+
+        should contain_concat_fragment('puppet.conf+40-foo').
+          without_content(/^\s+manifest\s+=/).
+          without_content(/^\s+manifestdir\s+=/).
+          with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/etc/puppet/modules:/usr/share/puppet/modules$}).
+          without_content(/^\s+templatedir\s+=/).
+          with_content(/^\s+config_version\s+=/).
+          with({}) # So we can use a trailing dot on each with_content line
+
+        should_not contain_file('/etc/puppet/environments/foo/environment.conf')
+      end
     end
-
   end
 
   context 'with server_config_version' do
-    let :pre_condition do
-      "class {'puppet': server => true, server_config_version => 'bar'}"
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => true, server_config_version => 'bar'}"
+      end
+
+      it 'should set config_version in environment.conf' do
+        should contain_file('/etc/puppet/environments/foo/environment.conf').
+          with_content(%r{\Aconfig_version\s+= bar\n\z}).
+          with({}) # So we can use a trailing dot on each with_content line
+      end
     end
 
-    it 'should add an env section' do
-      should contain_file('/etc/puppet/environments/foo').with({
-        :ensure => 'directory',
-      })
+    context 'with config environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => false, server_config_version => 'bar'}"
+      end
 
-      should contain_file('/etc/puppet/environments/foo/modules').with({
-        :ensure => 'directory',
-      })
-
-      should contain_concat_fragment('puppet.conf+40-foo').
-        without_content(/^\s+manifest\s+=/).
-        without_content(/^\s+manifestdir\s+=/).
-        with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/usr/share/puppet/modules$}).
-        without_content(/^\s+templatedir\s+=/).
-        with_content(/^\s+config_version\s+= bar/).
-        with({}) # So we can use a trailing dot on each with_content line
+      it 'should add config_version to an env section' do
+        should contain_concat_fragment('puppet.conf+40-foo').
+          without_content(/^\s+manifest\s+=/).
+          without_content(/^\s+manifestdir\s+=/).
+          with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/etc/puppet/modules:/usr/share/puppet/modules$}).
+          without_content(/^\s+templatedir\s+=/).
+          with_content(/^\s+config_version\s+= bar/).
+          with({}) # So we can use a trailing dot on each with_content line
+      end
     end
-
   end
 
   context 'with config_version' do
-    let :pre_condition do
-      "class {'puppet': server => true, server_config_version => 'bar'}"
-    end
-
     let :params do
       {
-        :config_version => 'bar',      
+        :config_version => 'bar',
       }
     end
 
-    it 'should add an env section' do
-      should contain_file('/etc/puppet/environments/foo').with({
-        :ensure => 'directory',
-      })
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => true}"
+      end
 
-      should contain_file('/etc/puppet/environments/foo/modules').with({
-        :ensure => 'directory',
-      })
-
-      should contain_concat_fragment('puppet.conf+40-foo').
-        without_content(/^\s+manifest\s+=/).
-        without_content(/^\s+manifestdir\s+=/).
-        with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/usr/share/puppet/modules$}).
-        without_content(/^\s+templatedir\s+=/).
-        with_content(/^\s+config_version\s+= bar/).
-        with({}) # So we can use a trailing dot on each with_content line
+      it 'should set config_version in environment.conf' do
+        should contain_file('/etc/puppet/environments/foo/environment.conf').
+          with_content(%r{\Aconfig_version\s+= bar\n\z}).
+          with({}) # So we can use a trailing dot on each with_content line
+      end
     end
 
+    context 'with config environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => false}"
+      end
+
+      it 'should add config_version to an env section' do
+        should contain_concat_fragment('puppet.conf+40-foo').
+          without_content(/^\s+manifest\s+=/).
+          without_content(/^\s+manifestdir\s+=/).
+          with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/etc/puppet/modules:/usr/share/puppet/modules$}).
+          without_content(/^\s+templatedir\s+=/).
+          with_content(/^\s+config_version\s+= bar/).
+          with({}) # So we can use a trailing dot on each with_content line
+      end
+    end
   end
 
+  context 'with modulepath' do
+    let :params do
+      {
+        :modulepath => ['/etc/puppet/example/modules', '/etc/puppet/vendor/modules'],
+      }
+    end
+
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => true}"
+      end
+
+      it 'should set modulepath in environment.conf' do
+        should contain_file('/etc/puppet/environments/foo/environment.conf').
+          with_content(%r{\Amodulepath\s+= /etc/puppet/example/modules:/etc/puppet/vendor/modules\n}).
+          with({}) # So we can use a trailing dot on each with_content line
+      end
+    end
+  end
+
+  context 'with undef modulepath' do
+    let :params do
+      {
+        :modulepath => Undef.new,
+      }
+    end
+
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => true}"
+      end
+
+      it { should_not contain_file('/etc/puppet/environments/foo/environment.conf') }
+    end
+  end
+
+  context 'with manifest' do
+    let :params do
+      {
+        :manifest => 'manifests/local.pp',
+      }
+    end
+
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => true}"
+      end
+
+      it 'should set manifest in environment.conf' do
+        should contain_file('/etc/puppet/environments/foo/environment.conf').
+          with_content(%r{\Amanifest\s+= manifests/local.pp\n\z}).
+          with({}) # So we can use a trailing dot on each with_content line
+      end
+    end
+  end
+
+  context 'with environment_timeout' do
+    let :params do
+      {
+        :environment_timeout => 'unlimited',
+      }
+    end
+
+    context 'with directory environments' do
+      let :pre_condition do
+        "class {'puppet': server => true, server_directory_environments => true}"
+      end
+
+      it 'should set environment_timeout in environment.conf' do
+        should contain_file('/etc/puppet/environments/foo/environment.conf').
+          with_content(%r{\Aenvironment_timeout\s+= unlimited\n\z}).
+          with({}) # So we can use a trailing dot on each with_content line
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,8 @@ RSpec.configure do |c|
   c.manifest_dir = File.join(fixture_path, 'manifests')
   c.mock_with :mocha
 end
+
+# Workaround for no method in rspec-puppet to pass undef through :params
+class Undef
+  def inspect; 'undef'; end
+end

--- a/templates/server/environment.conf.erb
+++ b/templates/server/environment.conf.erb
@@ -1,0 +1,12 @@
+<% if @manifest -%>
+manifest = <%= @manifest %>
+<% end -%>
+<% if @custom_modulepath && @modulepath -%>
+modulepath = <%= [@modulepath].flatten.join(":") %>
+<% end -%>
+<% if !@config_version.nil? && !@config_version.empty? -%>
+config_version = <%= @config_version %>
+<% end -%>
+<% if @environment_timeout -%>
+environment_timeout = <%= @environment_timeout %>
+<% end -%>

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -17,9 +17,13 @@
 
 <% if scope.lookupvar("puppet::server_directory_environments") -%>
     environmentpath  = <%= scope.lookupvar("puppet::server_envs_dir") %>
+    basemodulepath   = <%= [scope.lookupvar("puppet::server_common_modules_path")].flatten.join(':') %>
 <% elsif scope.lookupvar("puppet::server_git_repo") ||
         scope.lookupvar("puppet::server_dynamic_environments") -%>
     manifest       = <%= scope.lookupvar("puppet::server_envs_dir") %>/$environment/manifests/site.pp
     modulepath     = <%= scope.lookupvar("puppet::server_envs_dir") %>/$environment/modules
+<% end -%>
+<% if scope.lookupvar("puppet::server_git_repo") ||
+        scope.lookupvar("puppet::server_dynamic_environments") -%>
     config_version = <%= scope.lookupvar("puppet::server::config_version_cmd") %>
 <% end -%>


### PR DESCRIPTION
Also see commit messages for more detail.

Untested at the moment, will do next week in conjunction with https://github.com/theforeman/smart-proxy/pull/168.

Is the deprecation OK?  I don't see much point in keeping the dynamic envs boolean now there's no change in puppet.conf between the default prod/dev environments and no environments at all (via `$server_environments = []`) when using dir envs.

Replaces #158.
