### PR TITLE
Ensure foreman_proxy::service is refreshed after SSL certs change

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -8,7 +8,7 @@ class puppet::server::config inherits puppet::config {
   # Mirror the relationship, as defined() is parse-order dependent
   # Ensures puppetmasters certs are generated before the proxy is needed
   if defined(Class['foreman_proxy::config']) and $foreman_proxy::ssl {
-    Class['puppet::server::config'] -> Class['foreman_proxy::config']
+    Class['puppet::server::config'] ~> Class['foreman_proxy::config', 'foreman_proxy::service']
   }
 
   # Open read permissions to private keys to puppet group for foreman, proxy etc.


### PR DESCRIPTION
Paired with https://github.com/theforeman/puppet-foreman_proxy/pull/105
