### PR TITLE
Add dns_alt_names parameter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--format documentation
+--color
+--tty
+--backtrace

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,7 @@ class puppet::config(
   $allow_any_crl_auth = $::puppet::allow_any_crl_auth,
   $auth_template      = $::puppet::auth_template,
   $ca_server          = $::puppet::ca_server,
+  $dns_alt_names      = $::puppet::dns_alt_names,
   $main_template      = $::puppet::main_template,
   $nsauth_template    = $::puppet::nsauth_template,
   $puppet_dir         = $::puppet::dir,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,10 @@
 #                                  a string with the location of the ca_server
 #                                  or 'false'.
 #
+# $dns_alt_names::                 Use additional DNS names when generating a
+#                                  certificate.  Defaults to an empty Array.
+#                                  type:array
+#
 # $classfile::                     The file in which puppet agent stores a list
 #                                  of the classes associated with the retrieved
 #                                  configuration.
@@ -255,6 +259,7 @@ class puppet (
   $show_diff                   = $puppet::params::show_diff,
   $configtimeout               = $puppet::params::configtimeout,
   $ca_server                   = $puppet::params::ca_server,
+  $dns_alt_names               = $puppet::params::dns_alt_names,
   $classfile                   = $puppet::params::classfile,
   $main_template               = $puppet::params::main_template,
   $agent_template              = $puppet::params::agent_template,
@@ -327,6 +332,8 @@ class puppet (
   validate_string($ca_server)
   validate_string($server_external_nodes)
   validate_string($server_ca_proxy)
+
+  validate_array($dns_alt_names)
 
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class puppet::params {
   $show_diff           = false
   $configtimeout       = 120
   $ca_server           = ''
+  $dns_alt_names       = []
   $classfile           = '$vardir/classes.txt'
 
   # Need your own config templates? Specify here:

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -13,6 +13,19 @@ describe 'puppet::config' do
     it 'should contain auth.conf' do
       should contain_file('/etc/puppet/auth.conf').with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
     end
+
+    it 'should contain puppet.conf [main]' do
+      verify_concat_fragment_exact_contents(subject, 'puppet.conf+10-main', [
+        '[main]',
+        '    logdir = /var/log/puppet',
+        '    rundir = /var/run/puppet',
+        '    ssldir = $vardir/ssl',
+        '    privatekeydir = $ssldir/private_keys { group = service }',
+        '    hostprivkey = $privatekeydir/$certname.pem { mode = 640 }',
+        '    autosign       = $confdir/autosign.conf { mode = 664 }',
+        '    show_diff     = false',
+      ])
+    end
   end
 
   describe 'with allow_any_crl_auth' do
@@ -22,6 +35,19 @@ describe 'puppet::config' do
 
     it 'should contain auth.conf with auth any' do
       should contain_file('/etc/puppet/auth.conf').with_content(%r{^path /certificate_revocation_list/ca\nauth any$})
+    end
+  end
+
+  context "when dns_alt_names => ['foo','bar']" do
+    let :pre_condition do
+      "class { 'puppet': dns_alt_names => ['foo','bar'] }"
+    end
+
+    it 'should contain puppet.conf [main] with dns_alt_names' do
+      verify_concat_fragment_contents(subject, 'puppet.conf+10-main', [
+        '[main]',
+        '    dns_alt_names = foo,bar',
+      ])
     end
   end
 end

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -33,4 +33,14 @@ describe 'puppet' do
     it { should contain_concat_fragment('puppet.conf+10-main').with_content(/^\s+ca_server\s+= ca.example.org$/) }
   end
 
+  # Test validate_array parameters
+  [
+    :dns_alt_names,
+  ].each do |p|
+    context "when #{p} => 'foo'" do
+      let(:params) {{ p => 'foo' }}
+      it { expect { should create_class('puppet') }.to raise_error(Puppet::Error, /is not an Array/) }
+    end
+  end
+
 end

--- a/spec/lib/module_spec_helper.rb
+++ b/spec/lib/module_spec_helper.rb
@@ -1,0 +1,9 @@
+def verify_concat_fragment_contents(subject, title, expected_lines)
+  content = subject.resource('concat_fragment', title).send(:parameters)[:content]
+  (content.split("\n") & expected_lines).should == expected_lines
+end
+
+def verify_concat_fragment_exact_contents(subject, title, expected_lines)
+  content = subject.resource('concat_fragment', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,1 +1,0 @@
---format documentation --colour --backtrace

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'lib/module_spec_helper'
 
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -27,3 +27,7 @@
     ca_server = <%= @ca_server %>
 <% end -%>
 
+<% if @dns_alt_names and !@dns_alt_names.empty? -%>
+    dns_alt_names = <%= @dns_alt_names.join(",") %>
+<% end -%>
+


### PR DESCRIPTION
Changes:
- Add dns_alt_names parameter
- Add spec helper functions to verify contents of concat_fragment resources
- Replace spec.opts with .rspec

Use case is to allow for multiple puppetmasters and a centralized CA, as described by the Puppetlabs documentation at http://docs.puppetlabs.com/guides/scaling_multiple_masters.html.
