### PR TITLE
Add hiera_config parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@ class puppet::config(
   $auth_template      = $::puppet::auth_template,
   $ca_server          = $::puppet::ca_server,
   $dns_alt_names      = $::puppet::dns_alt_names,
+  $hiera_config       = $::puppet::hiera_config,
   $main_template      = $::puppet::main_template,
   $nsauth_template    = $::puppet::nsauth_template,
   $puppet_dir         = $::puppet::dir,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,10 @@
 #                                  of the classes associated with the retrieved
 #                                  configuration.
 #
+# $hiera_config::                  The hiera configuration file.
+#                                  Defaults to '$confdir/hiera.yaml'.
+#                                  type:string
+#
 # $auth_template::                 Use a custom template for the auth
 #                                  configuration.
 #
@@ -261,6 +265,7 @@ class puppet (
   $ca_server                   = $puppet::params::ca_server,
   $dns_alt_names               = $puppet::params::dns_alt_names,
   $classfile                   = $puppet::params::classfile,
+  $hiera_config                = $puppet::params::hiera_config,
   $main_template               = $puppet::params::main_template,
   $agent_template              = $puppet::params::agent_template,
   $auth_template               = $puppet::params::auth_template,
@@ -330,6 +335,7 @@ class puppet (
   validate_bool($server_strict_variables)
 
   validate_string($ca_server)
+  validate_string($hiera_config)
   validate_string($server_external_nodes)
   validate_string($server_ca_proxy)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class puppet::params {
   $ca_server           = ''
   $dns_alt_names       = []
   $classfile           = '$vardir/classes.txt'
+  $hiera_config        = '$confdir/hiera.yaml'
 
   # Need your own config templates? Specify here:
   $main_template   = 'puppet/puppet.conf.erb'

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -24,6 +24,7 @@ describe 'puppet::config' do
         '    hostprivkey = $privatekeydir/$certname.pem { mode = 640 }',
         '    autosign       = $confdir/autosign.conf { mode = 664 }',
         '    show_diff     = false',
+        '    hiera_config = $confdir/hiera.yaml'
       ])
     end
   end
@@ -50,4 +51,18 @@ describe 'puppet::config' do
       ])
     end
   end
+
+  context "when hiera_config => '$confdir/hiera.yaml'" do
+    let :pre_condition do
+      "class { 'puppet': hiera_config => '/etc/puppet/hiera/production/hiera.yaml' }"
+    end
+
+    it 'should contain puppet.conf [main] with non-default hiera_config' do
+      verify_concat_fragment_contents(subject, 'puppet.conf+10-main', [
+        '[main]',
+        '    hiera_config = /etc/puppet/hiera/production/hiera.yaml',
+      ])
+    end
+  end
+
 end

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -43,4 +43,14 @@ describe 'puppet' do
     end
   end
 
+  # Test validate_string parameters
+  [
+    :hiera_config,
+  ].each do |p|
+    context "when #{p} => ['foo']" do
+      let(:params) {{ p => ['foo'] }}
+      it { expect { should create_class('puppet') }.to raise_error(Puppet::Error, /is not a string/) }
+    end
+  end
+
 end

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -26,7 +26,9 @@
     # Use specified CA server
     ca_server = <%= @ca_server %>
 <% end -%>
-
+<% if @hiera_config and !@hiera_config.empty? -%>
+    hiera_config = <%= @hiera_config %>
+<% end -%>
 <% if @dns_alt_names and !@dns_alt_names.empty? -%>
     dns_alt_names = <%= @dns_alt_names.join(",") %>
 <% end -%>


### PR DESCRIPTION
Another new parameter.

The default in Puppet is '$confdir/hiera.yaml', but for backwards compatibility I opted to make the default '' which prevents it from being added to puppet.conf.  If forcing the default to be visible (more transparent in my opinion) would not create an issue with backwards compatibility, then I can update PR to set default value in the module to match Puppet's default.
