### PR TITLE
Make stdin and stderr use unbuffered I/O

### DIFF
--- a/templates/server/post-receive.erb
+++ b/templates/server/post-receive.erb
@@ -5,6 +5,9 @@ ERB.new(File.read(File.expand_path("../_header.erb",File.dirname(file))), nil, n
 
 require 'fileutils'
 
+$stdout.sync = true
+$stderr.sync = true
+
 # Set this to where you want to keep your environments
 ENVIRONMENT_BASEDIR = "<%= scope.lookupvar("puppet::server_envs_dir") %>"
 


### PR DESCRIPTION
This makes sure they're in sync otherwise stdin is buffered while stderr
isn't and the puts and git's stderr output aren't in sync.
