### PR TITLE
Fix relationship specification, which fails under Puppet 2.7.11

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -8,7 +8,8 @@ class puppet::server::config inherits puppet::config {
   # Mirror the relationship, as defined() is parse-order dependent
   # Ensures puppetmasters certs are generated before the proxy is needed
   if defined(Class['foreman_proxy::config']) and $foreman_proxy::ssl {
-    Class['puppet::server::config'] ~> Class['foreman_proxy::config', 'foreman_proxy::service']
+    Class['puppet::server::config'] ~> Class['foreman_proxy::config']
+    Class['puppet::server::config'] ~> Class['foreman_proxy::service']
   }
 
   # Open read permissions to private keys to puppet group for foreman, proxy etc.


### PR DESCRIPTION
When using two class names, they get concatenated:

```
[ INFO 2014-08-15 09:04:41 verbose] Could not find resource
'Class[Foreman_proxy::Config]Class[Foreman_proxy::Service]' for relationship
from 'Class[Puppet::Server::Config]' on node foreman-precise.example.com
```

Paired with https://github.com/theforeman/puppet-foreman_proxy/pull/115
