### PR TITLE
Add support for puppetserver

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,11 +126,15 @@
 #
 # $server_reports::                List of report types to include on the puppetmaster
 #
+# $server_implementation::         Puppet master implementation, either "master" (traditional
+#                                  Ruby) or "puppetserver" (JVM-based)
+#
 # $server_passenger::              If set to true, we will configure apache with
 #                                  passenger. If set to false, we will enable the
 #                                  default puppetmaster service unless
 #                                  service_fallback is set to false. See 'Advanced
 #                                  server parameters' for more information.
+#                                  Only applicable when server_implementation is "master".
 #                                  type:boolean
 #
 # $server_external_nodes::         External nodes classifier executable
@@ -314,6 +318,7 @@ class puppet (
   $server_vardir                 = $puppet::params::server_vardir,
   $server_ca                     = $puppet::params::server_ca,
   $server_reports                = $puppet::params::server_reports,
+  $server_implementation         = $puppet::params::server_implementation,
   $server_passenger              = $puppet::params::server_passenger,
   $server_service_fallback       = $puppet::params::server_service_fallback,
   $server_passenger_max_pool     = $puppet::params::server_passenger_max_pool,
@@ -374,6 +379,8 @@ class puppet (
   validate_string($server_ca_proxy)
 
   validate_array($dns_alt_names)
+
+  validate_re($server_implementation, '^(master|puppetserver)$')
 
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,6 +51,7 @@ class puppet::params {
   $server_vardir             = '/var/lib/puppet'
   $server_ca                 = true
   $server_reports            = 'foreman'
+  $server_implementation     = 'master'
   $server_passenger          = true
   $server_service_fallback   = true
   $server_passenger_max_pool = 12
@@ -110,10 +111,7 @@ class puppet::params {
   $server_app_root = "${dir}/rack"
   $server_ssl_dir  = "${server_vardir}/ssl"
 
-  $server_package     =  $::operatingsystem ? {
-    /(Debian|Ubuntu)/ => ['puppetmaster-common','puppetmaster'],
-    default           => ['puppet-server'],
-  }
+  $server_package     = undef
   $client_package     = $::operatingsystem ? {
     /(Debian|Ubuntu)/ => ['puppet-common','puppet'],
     default           => ['puppet'],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -3,12 +3,6 @@
 # Sets up a puppet master.
 class puppet::server {
 
-  if $::puppet::server_passenger or ($::puppet::server_service_fallback == false) {
-    $use_service = false
-  } else {
-    $use_service = true
-  }
-
   if $::puppet::server_ca {
     $ssl_ca_cert   = "${::puppet::server_ssl_dir}/ca/ca_crt.pem"
     $ssl_ca_crl    = "${::puppet::server_ssl_dir}/ca/ca_crl.pem"
@@ -35,7 +29,10 @@ class puppet::server {
 
   class { 'puppet::server::install': }~>
   class { 'puppet::server::config':  }~>
-  class { 'puppet::server::service': }->
+  class { 'puppet::server::service':
+    puppetmaster => $::puppet::server_implementation == 'master' and !$::puppet::server_passenger and $::puppet::server_service_fallback,
+    puppetserver => $::puppet::server_implementation == 'puppetserver',
+  }->
   Class['puppet::server']
 
   Class['puppet::config'] ~> Class['puppet::server::service']

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,6 +1,6 @@
 # Set up the puppet server config
 class puppet::server::config inherits puppet::config {
-  if $puppet::server_passenger {
+  if $puppet::server_passenger and $::puppet::server_implementation == 'master' {
     # Anchor the passenger config inside this
     class { 'puppet::server::passenger': } -> Class['puppet::server::config']
   }
@@ -65,7 +65,7 @@ class puppet::server::config inherits puppet::config {
     require => File["${puppet::server_dir}/puppet.conf"],
   }
 
-  if $puppet::server_passenger {
+  if $puppet::server_passenger and $::puppet::server_implementation == 'master' {
     Exec['puppet_server_config-generate_ca_cert'] ~> Service[$puppet::server_httpd_service]
   }
 

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,7 +1,16 @@
 # Install the puppet server
 class puppet::server::install {
 
-  package { $puppet::server_package:
+  $server_package_default = $::puppet::server_implementation ? {
+    'master'       => $::operatingsystem ? {
+      /(Debian|Ubuntu)/ => ['puppetmaster-common','puppetmaster'],
+      default           => ['puppet-server'],
+    },
+    'puppetserver' => 'puppetserver',
+  }
+  $server_package = pick($::puppet::server_package, $server_package_default)
+
+  package { $server_package:
     ensure => $::puppet::version,
   }
 

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,17 +1,41 @@
+# == Class: puppet::server::service
+#
 # Set up the puppet server as a service
-class puppet::server::service {
+#
+# === Parameters:
+#
+# $puppetmaster::  Whether to start/stop the (Ruby) puppetmaster service
+#                  type:boolean
+#
+# $puppetserver::  Whether to start/stop the (JVM) puppetserver service
+#                  type:boolean
+#
+class puppet::server::service(
+  $puppetmaster = true,
+  $puppetserver = false,
+) {
+  validate_bool($puppetmaster, $puppetserver)
 
-  if $::puppet::server::use_service {
-    $ensured = 'running'
-    $enabled = true
-  } else {
-    $ensured = 'stopped'
-    $enabled = false
+  if $puppetmaster and $puppetserver {
+    fail('Both puppetmaster and puppetserver cannot be enabled simultaneously')
   }
 
+  $pm_ensure = $puppetmaster ? {
+    true  => 'running',
+    false => 'stopped',
+  }
   service { 'puppetmaster':
-    ensure => $ensured,
-    enable => $enabled,
+    ensure => $pm_ensure,
+    enable => $puppetmaster,
+  }
+
+  $ps_ensure = $puppetserver ? {
+    true  => 'running',
+    false => 'stopped',
+  }
+  service { 'puppetserver':
+    ensure => $ps_ensure,
+    enable => $puppetserver,
   }
 
 }

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'puppet::server::service' do
+
+  let :facts do {
+    :clientcert             => 'puppetmaster.example.com',
+    :concat_basedir         => '/nonexistant',
+    :fqdn                   => 'puppetmaster.example.com',
+    :operatingsystemrelease => '6.5',
+    :osfamily               => 'RedHat',
+  } end
+
+  describe 'default_parameters' do
+    it do
+      should contain_service('puppetmaster').with({
+        :ensure => 'running',
+        :enable => 'true',
+      })
+    end
+
+    it do
+      should contain_service('puppetserver').with({
+        :ensure => 'stopped',
+        :enable => 'false',
+      })
+    end
+  end
+
+  describe 'when puppetserver => true' do
+    let(:params) { {:puppetserver => true, :puppetmaster => false} }
+    it do
+      should contain_service('puppetserver').with({
+        :ensure => 'running',
+        :enable => 'true',
+      })
+    end
+
+    it do
+      should contain_service('puppetmaster').with({
+        :ensure => 'stopped',
+        :enable => 'false',
+      })
+    end
+  end
+
+  describe 'when puppetserver => true' do
+    let(:params) { {:puppetserver => true, :puppetmaster => true} }
+    it { expect { should create_class('puppet::server::service') }.to raise_error(Puppet::Error, /Both puppetmaster and puppetserver cannot be enabled simultaneously/) }
+  end
+
+end


### PR DESCRIPTION
Set server_implementation to 'puppetserver', which will disable Passenger,
install puppetserver and start it as a standalone service.
