### PR TITLE
Don't manage puppetmaster/puppetserver services that aren't present

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -27,11 +27,19 @@ class puppet::server {
     $config_version_cmd = $::puppet::server_config_version
   }
 
+  if $::puppet::server_implementation == 'master' {
+    $pm_service = !$::puppet::server_passenger and $::puppet::server_service_fallback
+    $ps_service = undef
+  } elsif $::puppet::server_implementation == 'puppetserver' {
+    $pm_service = undef
+    $ps_service = true
+  }
+
   class { 'puppet::server::install': }~>
   class { 'puppet::server::config':  }~>
   class { 'puppet::server::service':
-    puppetmaster => $::puppet::server_implementation == 'master' and !$::puppet::server_passenger and $::puppet::server_service_fallback,
-    puppetserver => $::puppet::server_implementation == 'puppetserver',
+    puppetmaster => $pm_service,
+    puppetserver => $ps_service,
   }->
   Class['puppet::server']
 

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -11,31 +11,33 @@
 #                  type:boolean
 #
 class puppet::server::service(
-  $puppetmaster = true,
-  $puppetserver = false,
+  $puppetmaster = undef,
+  $puppetserver = undef,
 ) {
-  validate_bool($puppetmaster, $puppetserver)
-
   if $puppetmaster and $puppetserver {
     fail('Both puppetmaster and puppetserver cannot be enabled simultaneously')
   }
 
-  $pm_ensure = $puppetmaster ? {
-    true  => 'running',
-    false => 'stopped',
-  }
-  service { 'puppetmaster':
-    ensure => $pm_ensure,
-    enable => $puppetmaster,
+  if $puppetmaster != undef {
+    $pm_ensure = $puppetmaster ? {
+      true  => 'running',
+      false => 'stopped',
+    }
+    service { 'puppetmaster':
+      ensure => $pm_ensure,
+      enable => $puppetmaster,
+    }
   }
 
-  $ps_ensure = $puppetserver ? {
-    true  => 'running',
-    false => 'stopped',
-  }
-  service { 'puppetserver':
-    ensure => $ps_ensure,
-    enable => $puppetserver,
+  if $puppetserver != undef {
+    $ps_ensure = $puppetserver ? {
+      true  => 'running',
+      false => 'stopped',
+    }
+    service { 'puppetserver':
+      ensure => $ps_ensure,
+      enable => $puppetserver,
+    }
   }
 
 }

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -11,13 +11,42 @@ describe 'puppet::server::service' do
   } end
 
   describe 'default_parameters' do
+    it { should_not contain_service('puppetmaster') }
+    it { should_not contain_service('puppetserver') }
+  end
+
+  describe 'when puppetmaster => true' do
+    let(:params) { {:puppetmaster => true, :puppetserver => Undef.new} }
     it do
       should contain_service('puppetmaster').with({
         :ensure => 'running',
         :enable => 'true',
       })
     end
+  end
 
+  describe 'when puppetserver => true' do
+    let(:params) { {:puppetserver => true, :puppetmaster => Undef.new} }
+    it do
+      should contain_service('puppetserver').with({
+        :ensure => 'running',
+        :enable => 'true',
+      })
+    end
+  end
+
+  describe 'when puppetmaster => false' do
+    let(:params) { {:puppetmaster => false} }
+    it do
+      should contain_service('puppetmaster').with({
+        :ensure => 'stopped',
+        :enable => 'false',
+      })
+    end
+  end
+
+  describe 'when puppetserver => false' do
+    let(:params) { {:puppetserver => false} }
     it do
       should contain_service('puppetserver').with({
         :ensure => 'stopped',
@@ -26,24 +55,17 @@ describe 'puppet::server::service' do
     end
   end
 
-  describe 'when puppetserver => true' do
-    let(:params) { {:puppetserver => true, :puppetmaster => false} }
-    it do
-      should contain_service('puppetserver').with({
-        :ensure => 'running',
-        :enable => 'true',
-      })
-    end
-
-    it do
-      should contain_service('puppetmaster').with({
-        :ensure => 'stopped',
-        :enable => 'false',
-      })
-    end
+  describe 'when puppetmaster => undef' do
+    let(:params) { {:puppetmaster => Undef.new} }
+    it { should_not contain_service('puppetmaster') }
   end
 
-  describe 'when puppetserver => true' do
+  describe 'when puppetserver => undef' do
+    let(:params) { {:puppetserver => Undef.new} }
+    it { should_not contain_service('puppetserver') }
+  end
+
+  describe 'when puppetmaster => true and puppetserver => true' do
     let(:params) { {:puppetserver => true, :puppetmaster => true} }
     it { expect { should create_class('puppet::server::service') }.to raise_error(Puppet::Error, /Both puppetmaster and puppetserver cannot be enabled simultaneously/) }
   end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -23,7 +23,7 @@ describe 'puppet::server' do
         should contain_class('puppet::server::config')
         should contain_class('puppet::server::service').
           with_puppetmaster(false).
-          with_puppetserver(false)
+          with_puppetserver(nil)
       end
       it { should contain_package('puppet-server') }
     end
@@ -60,7 +60,7 @@ describe 'puppet::server' do
     it do
       should contain_class('puppet::server::service').
         with_puppetmaster(true).
-        with_puppetserver(false)
+        with_puppetserver(nil)
     end
 
     describe "and server_service_fallback => false" do
@@ -72,7 +72,7 @@ describe 'puppet::server' do
       it do
         should contain_class('puppet::server::service').
           with_puppetmaster(false).
-          with_puppetserver(false)
+          with_puppetserver(nil)
       end
     end
   end
@@ -86,7 +86,7 @@ describe 'puppet::server' do
     it { should_not contain_class('apache') }
     it do
       should contain_class('puppet::server::service').
-        with_puppetmaster(false).
+        with_puppetmaster(nil).
         with_puppetserver(true)
     end
     it { should contain_package('puppetserver') }


### PR DESCRIPTION
Under Debian or Ubuntu, the Puppet service providers throw errors for unknown
services, so just leave them unmanaged by default.
## 

Apologies, I think this is fixed now.  I've tested it under Ubuntu 14.04 and it seems OK.

Nightly test failure: http://ci.theforeman.org/job/systest_foreman/3418/console

<pre>
# [ERROR 2014-09-25 09:58:52 verbose]  /Stage[main]/Puppet::Server::Service/Service[puppetserver]: Could not evaluate: Could not find init script for 'puppetserver'
# [ INFO 2014-09-25 09:58:52 verbose] /usr/lib/ruby/vendor_ruby/puppet/provider/service/init.rb:138:in `search'
# [ INFO 2014-09-25 09:58:52 verbose] /usr/lib/ruby/vendor_ruby/puppet/provider/service/init.rb:102:in `initscript'
# [ INFO 2014-09-25 09:58:52 verbose] /usr/lib/ruby/vendor_ruby/puppet/provider/service/init.rb:159:in `statuscmd'
# [ INFO 2014-09-25 09:58:52 verbose] /usr/lib/ruby/vendor_ruby/puppet/provider/service/base.rb:41:in `status'
# [ INFO 2014-09-25 09:58:52 verbose] /usr/lib/ruby/vendor_ruby/puppet/type/service.rb:90:in `retrieve'
# [ INFO 2014-09-25 09:58:52 verbose] /usr/lib/ruby/vendor_ruby/puppet/type.rb:1048:in `retrieve'
</pre>
