### PR TITLE
Ensure git-shell is installed before setting the user shell

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -21,7 +21,8 @@ class puppet::server::install {
     }
 
     user { $puppet::server_user:
-      shell => '/usr/bin/git-shell',
+      shell   => '/usr/bin/git-shell',
+      require => Class['::git::install'],
     }
   }
 }


### PR DESCRIPTION
Recent Puppet versions validate shells, and the ordering's unspecified currently.

<pre>
[ERROR 2014-10-23 10:24:53 main]  /Stage[main]/Puppet::Server::Install/User[puppet]/shell: change from /sbin/nologin to /usr/bin/git-shell failed: Shell /usr/bin/git-shell must exist
[ WARN 2014-10-23 10:25:10 main]  /Stage[main]/Git::Install/Package[git]/ensure: created
</pre>
