### PR TITLE
Ensure that UTF8 is used by rack

### DIFF
--- a/templates/server/config.ru.erb
+++ b/templates/server/config.ru.erb
@@ -33,7 +33,7 @@ ARGV << "--vardir"  << "<%= scope.lookupvar('::puppet::server_vardir') %>"
 #
 
 #Ensure UTF-8 is our default (sadly Ruby 1.9 sets to US-ASCII)
-Encoding.default_external = Encoding::UTF_8
+Encoding.default_external = Encoding::UTF_8 if defined? Encoding
 
 require 'puppet/util/command_line'
 # we're usually running inside a Rack::Builder.new {} block,


### PR DESCRIPTION
Sadly Ruby 1.9 does not come with UTF-8 encoding as default but uses US-ASCII instead. This produces errors when trying to compile the catalog

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: invalid byte sequence in US-ASCII at /etc/puppet/environments/migration/modules/demo/manifests/init.pp:1 on node alex-dev-vm-demo.ch
Warning: Not using cache on failed catalog
```

The workaround to limit contain this for puppet only seems to do in the Rack configuration.  You can find the discussion [here](https://projects.puppetlabs.com/issues/20897). It is not parametrized while it is the default encoding for all other Ruby versions and having this change standarizes the setup.

Debian wheezy ships with Ruby 1.9.3 so I am affected by this problem.
