### PR TITLE
Update error raising tests and use of subject for rspec-puppet 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2.7'
 
 gem 'rake'
-gem 'rspec-puppet', '>= 1'
+gem 'rspec-puppet', '~> 2.0'
 gem 'puppetlabs_spec_helper', '>= 0.8.0'
 gem 'puppet-lint', '>= 1'
 gem 'simplecov'

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -73,7 +73,7 @@ describe 'puppet::agent::service' do
       "class {'puppet': agent => true, runmode => 'foo'}"
     end
 
-    it { expect { should create_class('puppet::agent::service') }.to raise_error(Puppet::Error, /Runmode of foo not supported by puppet::agent::config!/) }
+    it { should raise_error(Puppet::Error, /Runmode of foo not supported by puppet::agent::config!/) }
   end
 
 end

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -18,7 +18,7 @@ describe 'puppet::config' do
       end
 
       it 'should contain puppet.conf [main]' do
-        verify_concat_fragment_exact_contents(subject, 'puppet.conf+10-main', [
+        verify_concat_fragment_exact_contents(catalogue, 'puppet.conf+10-main', [
           '[main]',
           '    logdir = /var/log/puppet',
           '    rundir = /var/run/puppet',
@@ -58,7 +58,7 @@ describe 'puppet::config' do
       end
 
       it 'should contain puppet.conf [main] with dns_alt_names' do
-        verify_concat_fragment_contents(subject, 'puppet.conf+10-main', [
+        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
           '[main]',
           '    dns_alt_names = foo,bar',
         ])
@@ -71,7 +71,7 @@ describe 'puppet::config' do
       end
 
       it 'should contain puppet.conf [main] with syslogfacility' do
-        verify_concat_fragment_contents(subject, 'puppet.conf+10-main', [
+        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
           '[main]',
           '    syslogfacility = local6',
         ])
@@ -84,7 +84,7 @@ describe 'puppet::config' do
       end
 
       it 'should contain puppet.conf [main] with module_repository' do
-        verify_concat_fragment_contents(subject, 'puppet.conf+10-main', [
+        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
           '[main]',
           '    module_repository = https://myforgeapi.example.com',
         ])
@@ -97,7 +97,7 @@ describe 'puppet::config' do
       end
 
       it 'should contain puppet.conf [main] with non-default hiera_config' do
-        verify_concat_fragment_contents(subject, 'puppet.conf+10-main', [
+        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
           '[main]',
           '    hiera_config = /etc/puppet/hiera/production/hiera.yaml',
         ])
@@ -110,7 +110,7 @@ describe 'puppet::config' do
       end
 
       it 'should contain puppet.conf [main] with SRV settings' do
-        verify_concat_fragment_contents(subject, 'puppet.conf+10-main', [
+        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
           '[main]',
           '    use_srv_records = true',
           '    srv_domain = example.org',
@@ -170,7 +170,7 @@ describe 'puppet::config' do
       end
 
       it 'should contain puppet.conf [main]' do
-        verify_concat_fragment_exact_contents(subject, 'puppet.conf+10-main', [
+        verify_concat_fragment_exact_contents(catalogue, 'puppet.conf+10-main', [
           '[main]',
           '    logdir = C:/ProgramData/PuppetLabs/puppet/var/log',
           '    rundir = C:/ProgramData/PuppetLabs/puppet/var/run',
@@ -210,7 +210,7 @@ describe 'puppet::config' do
       end
 
       it 'should contain puppet.conf [main] with non-default hiera_config' do
-        verify_concat_fragment_contents(subject, 'puppet.conf+10-main', [
+        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
           '[main]',
           '    hiera_config = C:/ProgramData/PuppetLabs/hiera/etc/production/hiera.yaml',
         ])

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -63,7 +63,7 @@ describe 'puppet' do
       ].each do |p|
         context "when #{p} => 'foo'" do
           let(:params) {{ p => 'foo' }}
-          it { expect { should create_class('puppet') }.to raise_error(Puppet::Error, /is not an Array/) }
+          it { should raise_error(Puppet::Error, /is not an Array/) }
         end
       end
 
@@ -73,7 +73,7 @@ describe 'puppet' do
       ].each do |p|
         context "when #{p} => ['foo']" do
           let(:params) {{ p => ['foo'] }}
-          it { expect { should create_class('puppet') }.to raise_error(Puppet::Error, /is not a string/) }
+          it { should raise_error(Puppet::Error, /is not a string/) }
         end
       end
 
@@ -83,7 +83,7 @@ describe 'puppet' do
         ].each do |d|
         context "when #{d} => './somedir'" do
           let(:params) {{ d => './somedir'}}
-          it { expect { should create_class('puppet') }.to raise_error(Puppet::Error, /is not an absolute path/) }
+          it { should raise_error(Puppet::Error, /is not an absolute path/) }
         end
       end
     end

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -67,7 +67,7 @@ describe 'puppet::server::service' do
 
   describe 'when puppetmaster => true and puppetserver => true' do
     let(:params) { {:puppetserver => true, :puppetmaster => true} }
-    it { expect { should create_class('puppet::server::service') }.to raise_error(Puppet::Error, /Both puppetmaster and puppetserver cannot be enabled simultaneously/) }
+    it { should raise_error(Puppet::Error, /Both puppetmaster and puppetserver cannot be enabled simultaneously/) }
   end
 
 end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -97,7 +97,7 @@ describe 'puppet::server' do
     let :pre_condition do
       "class {'puppet': server => true, server_implementation => 'golang'}"
     end
-    it { expect { should create_class('puppet') }.to raise_error(Puppet::Error, /"golang" does not match/) }
+    it { should raise_error(Puppet::Error, /"golang" does not match/) }
   end
 
 end


### PR DESCRIPTION
The repo's tagged, but gem has yet to be released, so this is pre-emptive based on https://github.com/rodjek/rspec-puppet/commit/8459e14.

It might be best to pin at ~> 1.0 for the time being, instead of >= 1?

More PRs:
- https://github.com/theforeman/puppet-foreman/pull/259
- https://github.com/theforeman/puppet-tftp/pull/23
- https://github.com/theforeman/puppet-dhcp/pull/28
- https://github.com/theforeman/puppet-foreman_proxy/pull/129
- https://github.com/theforeman/foreman-installer-modulesync/pull/6