### PR TITLE
Mode of rack application paths (system umask 0077)

### DIFF
--- a/manifests/server/rack.pp
+++ b/manifests/server/rack.pp
@@ -27,6 +27,7 @@ class puppet::server::rack {
     [$puppet::server_app_root, "${puppet::server_app_root}/public", "${puppet::server_app_root}/tmp"]:
       ensure => directory,
       owner  => $puppet::server_user,
+      mode   => '0755',
   }
 
   $configru_version = $::puppetversion ? {


### PR DESCRIPTION
When the OS has an umask of 0077 (the default is 0022) the rack application folders are created with less rights, e.g.:

drwx------. 2 puppet root   4.0K Dec 15 19:48 public
drwx------. 2 puppet root   4.0K Dec 15 19:48 tmp

When a puppet run is started, the following error will appear:

Warning: Error 403 on SERVER: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>403 Forbidden</title>
</head><body>

<h1>Forbidden</h1>

<p>You don't have permission to access /production/node/node.fqdn on this server.</p>

</body></html>

By adding the 'mode' value the installation will enforce the accessibility of the rack application paths.
