### PR TITLE
set ca_port to undef per default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class puppet::params {
   $configtimeout       = 120
   $usecacheonfailure   = true
   $ca_server           = ''
-  $ca_port             = ''
+  $ca_port             = undef
   $dns_alt_names       = []
   $use_srv_records     = false
   $srv_domain          = $::domain


### PR DESCRIPTION
Otherwise I'm getting `ca_port = 0` when running foreman-installer. Maybe something related to kafo interpreting the "integer" type hint.
