### PR TITLE
Apply server_environments_{owner,group,mode} to environments subdirs

### DIFF
--- a/manifests/server/env.pp
+++ b/manifests/server/env.pp
@@ -11,15 +11,24 @@ define puppet::server::env (
 ) {
   file { "${basedir}/${name}":
     ensure => directory,
+    owner  => $puppet::server_environments_owner,
+    group  => $puppet::server_environments_group,
+    mode   => $puppet::server_environments_mode,
   }
 
   file { "${basedir}/${name}/modules":
     ensure => directory,
+    owner  => $puppet::server_environments_owner,
+    group  => $puppet::server_environments_group,
+    mode   => $puppet::server_environments_mode,
   }
 
   if $directory_environments {
     file { "${basedir}/${name}/manifests":
       ensure => directory,
+      owner  => $puppet::server_environments_owner,
+      group  => $puppet::server_environments_group,
+      mode   => $puppet::server_environments_mode,
     }
 
     $custom_modulepath = $modulepath and ($modulepath != ["${basedir}/${name}/modules", $::puppet::server_common_modules_path])

--- a/manifests/server/env.pp
+++ b/manifests/server/env.pp
@@ -8,27 +8,30 @@ define puppet::server::env (
   $templatedir            = undef,
   $environment_timeout    = undef,
   $directory_environments = $::puppet::server_directory_environments,
+  $owner                  = $::puppet::server_environments_owner,
+  $group                  = $::puppet::server_environments_group,
+  $mode                   = $::puppet::server_environments_mode,
 ) {
   file { "${basedir}/${name}":
     ensure => directory,
-    owner  => $puppet::server_environments_owner,
-    group  => $puppet::server_environments_group,
-    mode   => $puppet::server_environments_mode,
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
   }
 
   file { "${basedir}/${name}/modules":
     ensure => directory,
-    owner  => $puppet::server_environments_owner,
-    group  => $puppet::server_environments_group,
-    mode   => $puppet::server_environments_mode,
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
   }
 
   if $directory_environments {
     file { "${basedir}/${name}/manifests":
       ensure => directory,
-      owner  => $puppet::server_environments_owner,
-      group  => $puppet::server_environments_group,
-      mode   => $puppet::server_environments_mode,
+      owner  => $owner,
+      group  => $group,
+      mode   => $mode,
     }
 
     $custom_modulepath = $modulepath and ($modulepath != ["${basedir}/${name}/modules", $::puppet::server_common_modules_path])


### PR DESCRIPTION
If Puppet doesn't manage those directories, they are owned by root and are not writable by e. g. a special code deployment user.