### PR TITLE
Bugfix: removed dynamic_environment from config_version if statement

### DIFF
--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -14,13 +14,12 @@
     storeconfigs_backend = <%= @server_storeconfigs_backend %>
 <% end -%>
     strict_variables = <%= scope.lookupvar("puppet::server_strict_variables") %>
-<% if !scope.lookupvar("puppet::server_directory_environments")  && 
+<% if !scope.lookupvar("puppet::server_directory_environments")  &&
     ( scope.lookupvar("puppet::server_git_repo") || scope.lookupvar("puppet::server_dynamic_environments") ) -%>
     manifest       = <%= scope.lookupvar("puppet::server_envs_dir") %>/$environment/manifests/site.pp
     modulepath     = <%= scope.lookupvar("puppet::server_envs_dir") %>/$environment/modules
 <% end -%>
-<% if scope.lookupvar("puppet::server_git_repo") ||
-        scope.lookupvar("puppet::server_dynamic_environments") -%>
+<% if scope.lookupvar("puppet::server_git_repo") -%>
     config_version = <%= scope.lookupvar("puppet::server::config_version_cmd") %>
 <% end -%>
 <% scope.lookupvar("puppet::server_additional_settings").sort_by {|k, v| k}.each do |key, value| -%>


### PR DESCRIPTION
When using the param server_dynamic_environments I got this warning in my puppet runs:
```puppet
Warning: Setting config_version is deprecated in puppet.conf. See http://links.puppetlabs.com/env-settings-deprecations
   (at /usr/lib/ruby/site_ruby/1.8/puppet/settings.rb:1141:in `issue_deprecation_warning')
```

Since the dynamic environments are taking over from the config-file environments setting this config_version configuration didn't make much sense I think when the dynamic_environments param is setted to true?