### PR TITLE
Do not set config_version when using directory envs

### DIFF
--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -179,8 +179,7 @@ describe 'puppet::server::config' do
       end
 
       it 'should configure puppet.conf' do
-        should contain_concat_fragment('puppet.conf+30-master').
-          with_content(%r{^\s+config_version\s+= git --git-dir /etc/puppet/environments/\$environment/.git describe --all --long$})
+        should_not contain_concat_fragment('puppet.conf+30-master').with_content(%r{^\s+config_version\s+=$})
 
         should contain_concat_fragment('puppet.conf+10-main').
           with_content(%r{^\s+environmentpath\s+= /etc/puppet/environments$})

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -18,9 +18,6 @@
     ( scope.lookupvar("puppet::server_git_repo") || scope.lookupvar("puppet::server_dynamic_environments") ) -%>
     manifest       = <%= scope.lookupvar("puppet::server_envs_dir") %>/$environment/manifests/site.pp
     modulepath     = <%= scope.lookupvar("puppet::server_envs_dir") %>/$environment/modules
-<% end -%>
-<% if scope.lookupvar("puppet::server_git_repo") ||
-        scope.lookupvar("puppet::server_dynamic_environments") -%>
     config_version = <%= scope.lookupvar("puppet::server::config_version_cmd") %>
 <% end -%>
 <% scope.lookupvar("puppet::server_additional_settings").sort_by {|k, v| k}.each do |key, value| -%>


### PR DESCRIPTION
According to the [docs](https://docs.puppetlabs.com/puppet/latest/reference/config_file_environment.html#configversion), config_version can't be used with directory environments since it will never be used. This also removes a deprecation warning users of directory environments will see.