### PR TITLE
Add parameter server_rack_arguments

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -239,6 +239,10 @@
 #                                  Example: {trusted_node_data => true, stringify_facts => true, ordering => 'manifest'}
 #                                  type:hash
 #
+# $server_rack_arguments           Arguments passed to rack app ARGV in addition to --confdir and
+#                                  --vardir.  The default is an empty array.
+#                                  type:array
+#
 # === Advanced server parameters:
 #
 # $server_httpd_service::          Apache/httpd service name to notify
@@ -403,6 +407,7 @@ class puppet (
   $server_ca_proxy               = $puppet::params::server_ca_proxy,
   $server_strict_variables       = $puppet::params::server_strict_variables,
   $server_additional_settings    = $puppet::params::server_additional_settings,
+  $server_rack_arguments         = $puppet::params::server_rack_arguments,
   $server_foreman_url            = $foreman::params::foreman_url,
   $server_foreman_ssl_ca         = $foreman::params::client_ssl_ca,
   $server_foreman_ssl_cert       = $foreman::params::client_ssl_cert,
@@ -435,6 +440,7 @@ class puppet (
 
   validate_array($listen_to)
   validate_array($dns_alt_names)
+  validate_array($server_rack_arguments)
   validate_array($auth_allowed)
 
   validate_absolute_path($dir)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -95,6 +95,7 @@ class puppet::params {
   $server_certname            = $::clientcert
   $server_strict_variables    = false
   $server_additional_settings = {}
+  $server_rack_arguments      = []
 
   # Need a new master template for the server?
   $server_template = 'puppet/server/puppet.conf.erb'

--- a/manifests/server/rack.pp
+++ b/manifests/server/rack.pp
@@ -12,6 +12,7 @@
 #
 class puppet::server::rack {
 
+  $server_rack_arguments = $puppet::server_rack_arguments
 
   exec {'puppet_server_rack-restart':
     command     => "/bin/touch ${puppet::server_app_root}/tmp/restart.txt",

--- a/spec/classes/puppet_server_rack_spec.rb
+++ b/spec/classes/puppet_server_rack_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe 'puppet::server::rack' do
+  let :facts do {
+    :concat_basedir         => '/nonexistant',
+    :osfamily               => 'RedHat',
+    :operatingsystemrelease => '6.5',
+  } end
+
+  describe 'defaults' do
+    let :pre_condition do
+      "class {'puppet': server => true}"
+    end
+
+    it 'should define Exec[puppet_server_rack-restart]' do
+      should contain_exec('puppet_server_rack-restart').with({
+        :command      => '/bin/touch /etc/puppet/rack/tmp/restart.txt',
+        :refreshonly  => true,
+        :cwd          => '/etc/puppet/rack',
+        :require      => ['Class[Puppet::Server::Install]', 'File[/etc/puppet/rack/tmp]'],
+      })
+    end
+
+    it 'should create server_app_root' do
+      should contain_file('/etc/puppet/rack').with({
+        :ensure => 'directory',
+        :owner  => 'puppet',
+        :mode   => '0755',
+      })
+    end
+
+    it 'should create server_app_root public' do
+      should contain_file('/etc/puppet/rack/public').with({
+        :ensure => 'directory',
+        :owner  => 'puppet',
+        :mode   => '0755',
+      })
+    end
+
+    it 'should create server_app_root tmp' do
+      should contain_file('/etc/puppet/rack/tmp').with({
+        :ensure => 'directory',
+        :owner  => 'puppet',
+        :mode   => '0755',
+      })
+    end
+
+    it 'should create config.ru' do
+      should contain_file('/etc/puppet/rack/config.ru').with({
+        :owner  => 'puppet',
+        :notify => 'Exec[puppet_server_rack-restart]',
+      })
+    end
+
+    it 'should manage config.ru contents' do
+      verify_exact_contents(catalogue, '/etc/puppet/rack/config.ru', [
+        '$0 = "master"',
+        'ARGV << "--rack"',
+        'ARGV << "--confdir" << "/etc/puppet"',
+        'ARGV << "--vardir"  << "/var/lib/puppet"',
+        'Encoding.default_external = Encoding::UTF_8 if defined? Encoding',
+        'require \'puppet/util/command_line\'',
+        'run Puppet::Util::CommandLine.new.execute',
+      ])
+    end
+  end
+
+  describe 'when server_rack_arguments defined' do
+    let :pre_condition do
+      "class {'puppet': server => true, server_rack_arguments => ['--profile', '--logdest', '/dne/log'] }"
+    end
+
+    it 'should set ARGV values' do
+      verify_contents(catalogue, '/etc/puppet/rack/config.ru', [
+        'ARGV << "--rack"',
+        'ARGV << "--confdir" << "/etc/puppet"',
+        'ARGV << "--vardir"  << "/var/lib/puppet"',
+        'ARGV << "--profile"',
+        'ARGV << "--logdest"',
+        'ARGV << "/dne/log"',
+      ])
+    end
+  end
+end

--- a/spec/lib/module_spec_helper.rb
+++ b/spec/lib/module_spec_helper.rb
@@ -7,3 +7,8 @@ def verify_concat_fragment_exact_contents(subject, title, expected_lines)
   content = subject.resource('concat_fragment', title).send(:parameters)[:content]
   content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
 end
+
+def verify_exact_contents(subject, title, expected_lines)
+  content = subject.resource('file', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |l| l =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end

--- a/templates/server/config.ru.erb
+++ b/templates/server/config.ru.erb
@@ -18,6 +18,9 @@ ARGV << "--rack"
 # to ~puppet/.puppet
 ARGV << "--confdir" << "<%= scope.lookupvar('::puppet::server_dir') %>"
 ARGV << "--vardir"  << "<%= scope.lookupvar('::puppet::server_vardir') %>"
+<% (@server_rack_arguments || []).each do |server_rack_argument| -%>
+ARGV << "<%= server_rack_argument %>"
+<% end -%>
 
 # NOTE: it's unfortunate that we have to use the "CommandLine" class
 #  here to launch the app, but it contains some initialization logic


### PR DESCRIPTION
* Default is an empty array
* Elements are added to ARGV in Puppet server's rack config.ru

This is an ugly work around to segfaults that occur when running Puppet under Passenger in Ruby 1.8.7 (CentOS 6.x).  The only way I've found to work around the segfaults is to enable profiling by appending the "--profile" flag to ARGV in config.ru.