### PR TITLE
puppet still need foreman as a dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,10 @@
   "tags":         ["foreman", "puppet", "puppetmaster", "puppet-server"],
   "dependencies": [
     { "name": "theforeman/concat_native", "version_requirement": ">= 1.3.0 < 2.0.0" },
+    { "name": "theforeman/foreman",       "version_requirement": ">= 3.0.0 < 4.0.0" },
+    { "name": "theforeman/git",           "version_requirement": ">= 1.0.0 < 2.0.0" },
     { "name": "puppetlabs/apache",        "version_requirement": ">= 1.2.0 < 2.0.0" },
+    { "name": "puppetlabs/puppetdb",      "version_requirement": ">= 4.0.0 < 5.0.0" },
     { "name": "puppetlabs/stdlib",        "version_requirement": ">= 2.0.0 < 5.0.0" }
   ],
   "requirements": [


### PR DESCRIPTION
Since the module uses class {'foreman::puppetmaster', it needs to have foreman as a dependency.

The same for git module and puppetdb