### PR TITLE
Fixes #9286 - node.rb timeout too low and not configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -297,6 +297,10 @@
 #                                  Valid values are 'v2' for latest, and 'v1'
 #                                  for Foreman =< 1.2
 #
+# $server_request_timeout::        Timeout in node.rb script for fetching
+#                                  catalog from Foreman (in seconds).
+#                                  type:integer
+#
 # $server_ca_proxy::               The actual server that handles puppet CA.
 #                                  Setting this to anything non-empty causes
 #                                  the apache vhost to set up a proxy for all
@@ -412,6 +416,7 @@ class puppet (
   $server_certname               = $puppet::params::server_certname,
   $server_enc_api                = $puppet::params::server_enc_api,
   $server_report_api             = $puppet::params::server_report_api,
+  $server_request_timeout        = $puppet::params::server_request_timeout,
   $server_ca_proxy               = $puppet::params::server_ca_proxy,
   $server_strict_variables       = $puppet::params::server_strict_variables,
   $server_additional_settings    = $puppet::params::server_additional_settings,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,6 +89,7 @@ class puppet::params {
   $server_external_nodes      = '/etc/puppet/node.rb'
   $server_enc_api             = 'v2'
   $server_report_api          = 'v2'
+  $server_request_timeout     = 60
   $server_ca_proxy            = ''
   $server_certname            = $::clientcert
   $server_strict_variables    = false

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -33,6 +33,7 @@ class puppet::server::config inherits puppet::config {
       puppet_basedir => $puppet::server_puppet_basedir,
       enc_api        => $puppet::server_enc_api,
       report_api     => $puppet::server_report_api,
+      timeout        => $puppet::server_request_timeout,
       ssl_ca         => pick($puppet::server_foreman_ssl_ca, $puppet::server::ssl_ca_cert),
       ssl_cert       => pick($puppet::server_foreman_ssl_cert, $puppet::server::ssl_cert),
       ssl_key        => pick($puppet::server_foreman_ssl_key, $puppet::server::ssl_cert_key),

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -46,6 +46,7 @@ describe 'puppet::server::config' do
         :receive_facts  => true,
         :puppet_home    => '/var/lib/puppet',
         :puppet_basedir => '/usr/lib/ruby/site_ruby/1.9/puppet',
+        :timeout        => 60,
       })
     end
 


### PR DESCRIPTION
Make the node.rb timeout configurable. This is useful for use cases when
catalog compilation takes more time and/or the node.rb request to
Foreman is being handled by a freshly spawned Passenger worker.