### PR TITLE
Fixes puppet apply with strict_variables

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,7 +88,11 @@ class puppet::params {
   $remove_lock               = true
 
   # Custom puppetmaster
-  $puppetmaster              = $::puppetmaster
+  if defined('$trusted') and $::trusted['authenticated'] == 'local' {
+    $puppetmaster            = undef
+  } else {
+    $puppetmaster            = $::puppetmaster
+  }
 
   # Hashes containing additional settings
   $additional_settings   =      {}


### PR DESCRIPTION
On local, $::puppetmaster is not set, which errors out with strict variables.