### PR TITLE
Fixed 9347 - allow custom agent service name

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -5,7 +5,7 @@ class puppet::agent::service {
     'service': {
       service {'puppet':
         ensure    => running,
-        name      => $puppet::params::service_name,
+        name      => $puppet::service_name,
         hasstatus => true,
         enable    => true,
       }
@@ -19,7 +19,7 @@ class puppet::agent::service {
     'cron': {
       service {'puppet':
         ensure    => stopped,
-        name      => $puppet::params::service_name,
+        name      => $puppet::service_name,
         hasstatus => true,
         enable    => false,
       }
@@ -44,7 +44,7 @@ class puppet::agent::service {
     'none': {
       service { 'puppet':
         ensure    => stopped,
-        name      => $puppet::params::service_name,
+        name      => $puppet::service_name,
         hasstatus => true,
         enable    => false,
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,6 +138,8 @@
 #
 # $postrun_command::               A command which gets excuted after each Puppet run
 #
+# $service_name::                  The name of the puppet agent service.
+#
 # == puppet::server parameters
 #
 # $server::                        Should a puppet master be installed as well as the client
@@ -378,6 +380,7 @@ class puppet (
   $client_package                = $puppet::params::client_package,
   $agent                         = $puppet::params::agent,
   $puppetmaster                  = $puppet::params::puppetmaster,
+  $service_name                  = $puppet::params::service_name,
   $syslogfacility                = $puppet::params::syslogfacility,
   $server                        = $puppet::params::server,
   $server_user                   = $puppet::params::user,
@@ -458,6 +461,8 @@ class puppet (
   if $server_puppetdb_host {
     validate_string($server_puppetdb_host)
   }
+
+  validate_string($service_name)
 
   validate_array($listen_to)
   validate_array($dns_alt_names)

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -76,4 +76,20 @@ describe 'puppet::agent::service' do
     it { should raise_error(Puppet::Error, /Runmode of foo not supported by puppet::agent::config!/) }
   end
 
+  describe 'with custom service_name' do
+    let :pre_condition do
+      "class {'puppet': agent => true, service_name => 'pe-puppet'}"
+    end
+
+    it do
+      should contain_service('puppet').with({
+        :ensure     => 'running',
+        :name       => 'pe-puppet',
+        :hasstatus  => 'true',
+        :enable     => 'true',
+      })
+    end
+
+  end
+
 end


### PR DESCRIPTION
This fixes redmine issue #9347, allowing a custom service name to be provided.