### PR TITLE
FreeBSD agent support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,7 @@ class puppet::config(
         source  => concat_output('puppet.conf'),
         require => Concat_build['puppet.conf'],
         owner   => 'root',
-        group   => 'root',
+        group   => $::puppet::params::root_group,
         mode    => '0644',
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,8 @@
 #
 # $dir::                           Override the puppet directory.
 #
+# $vardir::                        Override the puppet var directory.
+#
 # $logdir::                        Override the log directory.
 #
 # $rundir::                        Override the PID directory.
@@ -159,8 +161,6 @@
 #
 # $server_port::                   Puppet master port
 #                                  type:integer
-#
-# $server_vardir::                 Puppet data directory.
 #
 # $server_ca::                     Provide puppet CA
 #                                  type:boolean
@@ -348,6 +348,7 @@ class puppet (
   $user                          = $puppet::params::user,
   $group                         = $puppet::params::group,
   $dir                           = $puppet::params::dir,
+  $vardir                        = $puppet::params::vardir,
   $logdir                        = $puppet::params::logdir,
   $rundir                        = $puppet::params::rundir,
   $ssldir                        = $puppet::params::ssldir,
@@ -395,7 +396,6 @@ class puppet (
   $server_group                  = $puppet::params::group,
   $server_dir                    = $puppet::params::dir,
   $server_port                   = $puppet::params::port,
-  $server_vardir                 = $puppet::params::server_vardir,
   $server_ca                     = $puppet::params::server_ca,
   $server_reports                = $puppet::params::server_reports,
   $server_implementation         = $puppet::params::server_implementation,
@@ -481,6 +481,7 @@ class puppet (
   validate_array($auth_allowed)
 
   validate_absolute_path($dir)
+  validate_absolute_path($vardir)
   validate_absolute_path($logdir)
   validate_absolute_path($rundir)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class puppet::params {
   $syslogfacility      = undef
 
   case $::osfamily {
-    Windows : {
+    'Windows' : {
       # Windows prefixes normal paths with the Data Directory's path and leaves 'puppet' off the end
       $dir_prefix = 'C:/ProgramData/PuppetLabs/puppet'
 
@@ -43,13 +43,26 @@ class puppet::params {
       $logdir = "${dir_prefix}/var/log"
       $rundir = "${dir_prefix}/var/run"
       $ssldir = '$confdir/ssl'
+      $vardir = "${dir_prefix}/var"
+      $root_group = undef
+    }
+
+    /^(FreeBSD|DragonFly)$/ : {
+      $dir        = '/usr/local/etc/puppet'
+      $logdir     = '/var/log/puppet'
+      $rundir     = '/var/run/puppet'
+      $ssldir     = '$vardir/ssl'
+      $vardir     = '/var/puppet'
+      $root_group = undef
     }
 
     default : {
-      $dir    = '/etc/puppet'
-      $logdir = '/var/log/puppet'
-      $rundir = '/var/run/puppet'
-      $ssldir = '$vardir/ssl'
+      $dir        = '/etc/puppet'
+      $logdir     = '/var/log/puppet'
+      $rundir     = '/var/run/puppet'
+      $ssldir     = '$vardir/ssl'
+      $vardir     = '/var/lib/puppet'
+      $root_group = undef
     }
   }
 
@@ -83,7 +96,6 @@ class puppet::params {
 
   # Will this host be a puppetmaster?
   $server                     = false
-  $server_vardir              = '/var/lib/puppet'
   $server_ca                  = true
   $server_reports             = 'foreman'
   $server_implementation      = 'master'
@@ -122,7 +134,7 @@ class puppet::params {
   # Owner of the environments dir: for cases external service needs write
   # access to manage it.
   $server_environments_owner   = $user
-  $server_environments_group   = 'root'
+  $server_environments_group   = $root_group
   $server_environments_mode    = '0755'
   # Where we store our puppet environments
   $server_envs_dir             = "${dir}/environments"
@@ -133,7 +145,7 @@ class puppet::params {
 
   # Dynamic environments config, ignore if the git_repo is 'false'
   # Path to the repository
-  $server_git_repo_path       = "${server_vardir}/puppet.git"
+  $server_git_repo_path       = "${vardir}/puppet.git"
   # Override these if you need your own hooks
   $server_post_hook_content   = 'puppet/server/post-receive.erb'
   $server_post_hook_name      = 'post-receive'
@@ -151,7 +163,7 @@ class puppet::params {
 
   # Passenger config
   $server_app_root = "${dir}/rack"
-  $server_ssl_dir  = "${server_vardir}/ssl"
+  $server_ssl_dir  = "${vardir}/ssl"
 
   $server_package     = undef
   $client_package     = $::operatingsystem ? {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -29,7 +29,7 @@ class puppet::server::config inherits puppet::config {
     class {'foreman::puppetmaster':
       foreman_url    => $puppet::server_foreman_url,
       receive_facts  => $puppet::server_facts,
-      puppet_home    => $puppet::server_vardir,
+      puppet_home    => $puppet::vardir,
       puppet_basedir => $puppet::server_puppet_basedir,
       enc_api        => $puppet::server_enc_api,
       report_api     => $puppet::server_report_api,
@@ -73,7 +73,7 @@ class puppet::server::config inherits puppet::config {
     Exec['puppet_server_config-generate_ca_cert'] ~> Service[$puppet::server_httpd_service]
   }
 
-  file { "${puppet::server_vardir}/reports":
+  file { "${puppet::vardir}/reports":
     ensure => directory,
     owner  => $puppet::server_user,
   }

--- a/manifests/server/env.pp
+++ b/manifests/server/env.pp
@@ -39,7 +39,7 @@ define puppet::server::env (
       file { "${basedir}/${name}/environment.conf":
         ensure  => file,
         owner   => 'root',
-        group   => 'root',
+        group   => $::puppet::params::root_group,
         mode    => '0644',
         content => template('puppet/server/environment.conf.erb'),
       }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -15,7 +15,7 @@ class puppet::server::install {
   }
 
   if $puppet::server_git_repo {
-    file { $puppet::server_vardir:
+    file { $puppet::vardir:
       ensure => directory,
       owner  => $puppet::server_user,
     }

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,8 @@
     { "operatingsystem": "Fedora",     "operatingsystemrelease": [ "19" ] },
     { "operatingsystem": "Debian",     "operatingsystemrelease": [ "6", "7" ] },
     { "operatingsystem": "Ubuntu",     "operatingsystemrelease": [ "12.04", "14.04" ] },
+    { "operatingsystem": "FreeBSD",    "operatingsystemrelease": [ "9", "10" ] },
+    { "operatingsystem": "DragonFly",  "operatingsystemrelease": [ "3.6", "3.8", "4" ] },
     { "operatingsystem": "Windows",    "operatingsystemrelease": 
       [ 
         "Vista", "7", "8",

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -1,6 +1,9 @@
 <%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
 
 [main]
+    # Where Puppet's general dynamic and/or growing data is kept
+    vardir = <%= scope.lookupvar('::puppet::vardir') %>
+
     # The Puppet log directory.
     # The default value is '$vardir/log'.
     logdir = <%= scope.lookupvar('::puppet::logdir') %>

--- a/templates/server/config.ru.erb
+++ b/templates/server/config.ru.erb
@@ -17,7 +17,7 @@ ARGV << "--rack"
 # to prevent reading configuration from ~puppet/.puppet/puppet.conf and writing
 # to ~puppet/.puppet
 ARGV << "--confdir" << "<%= scope.lookupvar('::puppet::server_dir') %>"
-ARGV << "--vardir"  << "<%= scope.lookupvar('::puppet::server_vardir') %>"
+ARGV << "--vardir"  << "<%= scope.lookupvar('::puppet::vardir') %>"
 <% (@server_rack_arguments || []).each do |server_rack_argument| -%>
 ARGV << "<%= server_rack_argument %>"
 <% end -%>


### PR DESCRIPTION
For the master configuration there's more stuff missing from puppetlabs-apache, so that's not going to happen for now.

The server_vardir parameter is gone, which is theoretically OK because the version is bumped anyway. puppet-foreman_proxy would need to be updated in one line where this is used as default for a puppet_home setting.