### PR TITLE
Add remove_lock parameter

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -17,8 +17,10 @@ class puppet::agent::config {
       incl    => '/etc/default/puppet',
       lens    => 'Shellvars.lns',
     }
-    file {'/var/lib/puppet/state/agent_disabled.lock':
-      ensure => absent
+    if $::puppet::remove_lock {
+      file {'/var/lib/puppet/state/agent_disabled.lock':
+        ensure => absent
+      }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,6 +148,9 @@
 # $agent_additional_settings::     A hash of additional agent settings.
 #                                  type:hash
 #
+# $remove_lock::                   Remove the agent lock when running.
+#                                  type:boolean
+#
 # == puppet::server parameters
 #
 # $server::                        Should a puppet master be installed as well as the client
@@ -388,6 +391,7 @@ class puppet (
   $auth_allowed                  = $puppet::params::auth_allowed,
   $client_package                = $puppet::params::client_package,
   $agent                         = $puppet::params::agent,
+  $remove_lock                   = $puppet::params::remove_lock,
   $puppetmaster                  = $puppet::params::puppetmaster,
   $service_name                  = $puppet::params::service_name,
   $syslogfacility                = $puppet::params::syslogfacility,
@@ -450,6 +454,7 @@ class puppet (
   validate_bool($usecacheonfailure)
   validate_bool($agent_noop)
   validate_bool($agent)
+  validate_bool($remove_lock)
   validate_bool($server)
   validate_bool($allow_any_crl_auth)
   validate_bool($server_ca)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,6 +85,7 @@ class puppet::params {
 
   # Will this host be a puppet agent ?
   $agent                     = true
+  $remove_lock               = true
 
   # Custom puppetmaster
   $puppetmaster              = $::puppetmaster

--- a/spec/classes/puppet_agent_config_spec.rb
+++ b/spec/classes/puppet_agent_config_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe 'puppet::agent::config' do
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with default parameters' do
+        let :pre_condition do
+          'include ::puppet'
+        end
+
+        it { should compile.with_all_deps }
+        it { should contain_concat_fragment( 'puppet.conf+20-agent' ) }
+        if facts[:osfamily] == 'Debian'
+          it { should contain_augeas('puppet::set_start').
+               with_context('/files/etc/default/puppet').
+               with_changes('set START yes').
+               with_incl('/etc/default/puppet').
+               with_lens('Shellvars.lns').
+               with({})
+          }
+          it { should contain_file('/var/lib/puppet/state/agent_disabled.lock').
+               with_ensure(:absent).
+               with({})
+          }
+        end
+      end
+
+      context 'with runmode => cron' do
+        let :pre_condition do
+          'class { "::puppet": runmode => "cron" }'
+        end
+
+        it { should compile.with_all_deps }
+        it { should contain_concat_fragment( 'puppet.conf+20-agent' ) }
+        if facts[:osfamily] == 'Debian'
+          it { should contain_augeas('puppet::set_start').
+               with_context('/files/etc/default/puppet').
+               with_changes('set START no').
+               with_incl('/etc/default/puppet').
+               with_lens('Shellvars.lns').
+               with({})
+          }
+          it { should contain_file('/var/lib/puppet/state/agent_disabled.lock').
+               with_ensure(:absent).
+               with({})
+          }
+        end
+      end
+
+      context 'with remove_lock => false' do
+        let :pre_condition do
+          'class { "::puppet": remove_lock => false }'
+        end
+
+        it { should compile.with_all_deps }
+        it { should contain_concat_fragment( 'puppet.conf+20-agent' ) }
+        if facts[:osfamily] == 'Debian'
+          it { should contain_augeas('puppet::set_start').
+               with_context('/files/etc/default/puppet').
+               with_changes('set START yes').
+               with_incl('/etc/default/puppet').
+               with_lens('Shellvars.lns').
+               with({})
+          }
+          it { should_not contain_file('/var/lib/puppet/state/agent_disabled.lock') }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to be able to get around puppet locking system using `--agent_disabled_lockfile /nonexisting`, but by default the puppet lock is removed on Debian.
This patch will allow us to set `remove_lock` to false.