### PR TITLE
Add parser option to [master] section of puppet.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -495,6 +495,7 @@ class puppet (
   validate_absolute_path($rundir)
 
   validate_re($server_implementation, '^(master|puppetserver)$')
+  validate_re($server_parser, '^(current|future)$')
 
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -262,6 +262,9 @@
 # $server_puppetdb_swf::           PuppetDB soft_write_failure
 #                                  type:boolean
 #
+# $server_parser::                 Sets the parser to use. Valid options are 'current' or 'future'.
+#                                  Defaults to 'current'.
+#
 # === Advanced server parameters:
 #
 # $server_httpd_service::          Apache/httpd service name to notify
@@ -446,6 +449,7 @@ class puppet (
   $server_puppetdb_host          = $puppet::params::server_puppetdb_host,
   $server_puppetdb_port          = $puppet::params::server_puppetdb_port,
   $server_puppetdb_swf           = $puppet::params::server_puppetdb_swf,
+  $server_parser                 = $puppet::params::server_parser,
 ) inherits puppet::params {
 
   validate_bool($listen)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -200,4 +200,7 @@ class puppet::params {
   $server_foreman_ssl_ca   = undef
   $server_foreman_ssl_cert = undef
   $server_foreman_ssl_key  = undef
+
+  # Which Parser do we want to use? https://docs.puppetlabs.com/references/latest/configuration.html#parser
+  $server_parser = 'current'
 }

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -356,4 +356,18 @@ describe 'puppet::server::config' do
       end
     end
   end
+
+  describe 'with server_parser => future' do
+    let :pre_condition do
+      "class {'puppet':
+        server => true,
+        server_parser => 'future',
+      }"
+    end
+
+    it 'should configure future parser' do
+      should contain_concat_fragment('puppet.conf+30-master').
+        with_content(/^\s+parser\s+=\s+future$/)
+    end
+  end
 end

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -89,6 +89,7 @@ describe 'puppet::server::config' do
         with_content(/^\s+node_terminus\s+= exec$/).
         with_content(/^\s+ca\s+= true$/).
         with_content(/^\s+ssldir\s+= \/var\/lib\/puppet\/ssl$/).
+        with_content(/^\s+parser\s+=/).
         with({}) # So we can use a trailing dot on each with_content line
 
       should contain_file('/etc/puppet/puppet.conf')

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -89,7 +89,7 @@ describe 'puppet::server::config' do
         with_content(/^\s+node_terminus\s+= exec$/).
         with_content(/^\s+ca\s+= true$/).
         with_content(/^\s+ssldir\s+= \/var\/lib\/puppet\/ssl$/).
-        with_content(/^\s+parser\s+=/).
+        with_content(/^\s+parser\s+=\s+current$/).
         with({}) # So we can use a trailing dot on each with_content line
 
       should contain_file('/etc/puppet/puppet.conf')

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -9,6 +9,7 @@
     ca             = <%= scope.lookupvar("puppet::server_ca") %>
     ssldir         = <%= scope.lookupvar("puppet::server_ssl_dir") %>
     certname       = <%= scope.lookupvar("puppet::server_certname") %>
+    parser         = <%= scope.lookupvar("puppet::server_parser") %>
 <% if @server_storeconfigs_backend -%>
     storeconfigs   = true
     storeconfigs_backend = <%= @server_storeconfigs_backend %>


### PR DESCRIPTION
This PR adds the `parser` option to the `[master]` section of `puppet.conf` allowing you to specify the parser puppet should use.
It defaults to `parser = current`, which is the default if this option is left out, see https://docs.puppetlabs.com/references/latest/configuration.html#parser .

This allows module users to override the `::puppet::server_parser` to use the future parser.