### PR TITLE
Add options to let the puppet master listen for HTTP connections too

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,32 @@ as per the examples above, and the execute _puppet apply_ e.g:
     EOF
     puppet apply install.pp --modulepath /path_to/extracted_tarball
 
+# Advanced scenarios
+
+An HTTP (non-SSL) puppetmaster instance can be set up (standalone or in addition to
+the SSL instance) by setting the `server_http` parameter to `true`. This is useful for
+reverse proxy or load balancer scenarios where the proxy/load balancer takes care of SSL
+termination. The HTTP puppetmaster instance expects the `X-Client-Verify`, `X-SSL-Client-DN`
+and `X-SSL-Subject` HTTP headers to have been set on the front end server.
+
+The listening port can be configured by setting `server_http_port` (which defaults to 8139).
+
+By default, this HTTP instance accepts no connection (`deny all` in the `<Directory>`
+snippet). Allowed hosts can be configured by setting the `server_http_allow` parameter
+(which expects an array).
+
+** Note that running an HTTP puppetmaster is a huge security risk when improperly
+configured. Allowed hosts should be tightly controlled; anyone with access to an allowed
+host can access all client catalogues and client certificates. **
+
+    # Configure an HTTP puppetmaster vhost in addition to the standard SSL vhost
+    class { '::puppet':
+      server               => true,
+      server_http          => true,
+      server_http_port     => 8130, # default: 8139
+      server_http_allow    => ['10.20.30.1', 'puppetbalancer.my.corp'],
+    }
+
 # Contributing
 
 * Fork the project

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -171,6 +171,19 @@
 # $server_ca::                     Provide puppet CA
 #                                  type:boolean
 #
+# $server_http::                   Should the puppet master listen on HTTP as well as HTTPS.
+#                                  Useful for load balancer or reverse proxy scenarios. Note that
+#                                  the HTTP puppet master denies access from all clients by default,
+#                                  allowed clients must be specified with $server_http_allow.
+#                                  type:boolean
+#
+# $server_http_port::              Puppet master HTTP port; defaults to 8139.
+#                                  type:integer
+#
+# $server_http_allow::             Array of allowed clients for the HTTP puppet master. Passed
+#                                  to Apache's 'Allow' directive.
+#                                  type:array
+#
 # $server_reports::                List of report types to include on the puppetmaster
 #
 # $server_implementation::         Puppet master implementation, either "master" (traditional
@@ -407,6 +420,9 @@ class puppet (
   $server_dir                    = $puppet::params::dir,
   $server_port                   = $puppet::params::port,
   $server_ca                     = $puppet::params::server_ca,
+  $server_http                   = $puppet::params::server_http,
+  $server_http_port              = $puppet::params::server_http_port,
+  $server_http_allow             = $puppet::params::server_http_allow,
   $server_reports                = $puppet::params::server_reports,
   $server_implementation         = $puppet::params::server_implementation,
   $server_passenger              = $puppet::params::server_passenger,
@@ -465,6 +481,7 @@ class puppet (
   validate_bool($server)
   validate_bool($allow_any_crl_auth)
   validate_bool($server_ca)
+  validate_bool($server_http)
   validate_bool($server_passenger)
   validate_bool($server_git_repo)
   validate_bool($server_service_fallback)
@@ -487,6 +504,10 @@ class puppet (
   }
   if $server_puppetdb_host {
     validate_string($server_puppetdb_host)
+  }
+  
+  if $server_http {
+    validate_array($server_http_allow)
   }
 
   validate_string($service_name)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,6 +116,9 @@ class puppet::params {
   $server_certname            = $::clientcert
   $server_strict_variables    = false
   $server_rack_arguments      = []
+  $server_http                = false
+  $server_http_port           = 8139
+  $server_http_allow          = []
 
   # Need a new master template for the server?
   $server_template = 'puppet/server/puppet.conf.erb'

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -13,7 +13,10 @@ class puppet::server::passenger (
   $ssl_chain          = $::puppet::server::ssl_chain,
   $ssl_dir            = $::puppet::server_ssl_dir,
   $puppet_ca_proxy    = $::puppet::server_ca_proxy,
-  $user               = $::puppet::server_user
+  $user               = $::puppet::server_user,
+  $http               = $::puppet::server_http,
+  $http_port          = $::puppet::server_http_port,
+  $http_allow         = $::puppet::server_http_allow,
 ) {
   include ::puppet::server::rack
   include ::apache
@@ -31,11 +34,13 @@ class puppet::server::passenger (
     }
   }
 
+  $directory = {
+    'path'              => "${app_root}/public/",
+    'passenger_enabled' => 'On',
+  }
+  
   $directories = [
-    {
-      'path'              => "${app_root}/public/",
-      'passenger_enabled' => 'On',
-    },
+    $directory,
   ]
 
   # The following client headers allow the same configuration to work with Pound.
@@ -87,4 +92,31 @@ class puppet::server::passenger (
     require              => Class['::puppet::server::rack'],
   }
 
+  if $http {
+    $directories_http = [
+      merge($directory, {
+        'custom_fragment' => join([
+            'Order deny,allow',
+            'Deny from all',
+            inline_template("<%- if @http_allow and Array(@http_allow).join(' ') != '' -%>Allow from <%= @http_allow.join(' ') %><%- end -%>"),
+          ], "\n")
+      }),
+    ]
+    
+    apache::vhost { 'puppet-http':
+      docroot         => "${app_root}/public/",
+      directories     => $directories_http,
+      port            => $http_port,
+      custom_fragment => join([
+          $custom_fragment ? {
+            undef   => '',
+            default => $custom_fragment
+          },
+          'SetEnvIf X-Client-Verify "(.*)" SSL_CLIENT_VERIFY=$1',
+          'SetEnvIf X-SSL-Client-DN "(.*)" SSL_CLIENT_S_DN=$1',
+        ], "\n"),
+      options         => ['None'],
+      require         => Class['::puppet::server::rack'],
+    }
+  }
 }


### PR DESCRIPTION
(load balancer/reverse proxy scenarios), protected by default Deny all. Configurable listen port and allow directive.