### PR TITLE
Bugfix: duplicate declaration error when combining puppetserver together...

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,7 +10,7 @@
 # $puppetserver::  Whether to start/stop the (JVM) puppetserver service
 #                  type:boolean
 #
-class puppet::server::service(
+class puppet::server::service (
   $puppetmaster = undef,
   $puppetserver = undef,
 ) {
@@ -34,9 +34,11 @@ class puppet::server::service(
       true  => 'running',
       false => 'stopped',
     }
-    service { 'puppetserver':
-      ensure => $ps_ensure,
-      enable => $puppetserver,
+    if ! defined(Service['puppetserver']) {
+      service { 'puppetserver':
+        ensure => $ps_ensure,
+        enable => $puppetserver,
+      }
     }
   }
 


### PR DESCRIPTION
... with puppetdb module

https://github.com/puppetlabs/puppetlabs-puppetdb#puppet_service_name

When using the puppetlabs-puppetdb module to configure puppetdb in combination with puppetserver implemention I got duplicate resource errors on the puppetserver service.

By simply issuing the if ! defined check this could be tackled on a rather proper way I suppose?