### PR TITLE
Fix all hosts allowed in HTTP puppetmaster

### DIFF
--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -93,8 +93,15 @@ class puppet::server::passenger (
   }
 
   if $http {
+    # Order, deny and allow cannot be configured for Apache >= 2.4 using the Puppetlabs/Apache
+    # module, but they can be set to false. So, set to false and configure manually via custom fragments.
+    # We can't get rid of the 'Order allow,deny' directive and we need to support all Apache versions.
+    # Best we can do is reverse the Order directive and add our own 'Deny from all' for good measure.
     $directories_http = [
       merge($directory, {
+        'order'           => false,
+        'deny'            => false,
+        'allow'           => false,
         'custom_fragment' => join([
             'Order deny,allow',
             'Deny from all',


### PR DESCRIPTION
So, slightly embarrassing, but due to the way the puppetlabs/apache module handles Order, Allow and Deny between versions 2.2/2.4, the fact that when you specify no allowed hosts, all hosts are allowed somehow slipped through. This PR should fix it by actually forcing the puppetlabs/apache module to change the Order directive to Deny, Allow by default, then adding it again for good measure, denying all again and THEN adding allowed hosts again.

Slightly convoluted, but the best I can do with the current Apache 2.2/2.4 Order/Allow/Deny thing.