### PR TITLE
Allow setting separate version for puppet server and client packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,6 +256,8 @@
 #
 # $server_package::                Custom package name for puppet master
 #
+# $server_version::                Custom package version for puppet master
+#
 # $server_certname::               The name to use when handling certificates.
 #
 # $server_strict_variables::       if set to true, it will throw parse errors
@@ -450,6 +452,7 @@ class puppet (
   $server_app_root               = $puppet::params::server_app_root,
   $server_ssl_dir                = $puppet::params::server_ssl_dir,
   $server_package                = $puppet::params::server_package,
+  $server_version                = $puppet::params::server_version,
   $server_certname               = $puppet::params::server_certname,
   $server_enc_api                = $puppet::params::server_enc_api,
   $server_report_api             = $puppet::params::server_report_api,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -174,6 +174,7 @@ class puppet::params {
   $server_ssl_dir  = "${vardir}/ssl"
 
   $server_package     = undef
+  $server_version     = undef
   $client_package     = $::operatingsystem ? {
     /(Debian|Ubuntu)/ => ['puppet-common','puppet'],
     default           => ['puppet'],

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -9,9 +9,10 @@ class puppet::server::install {
     'puppetserver' => 'puppetserver',
   }
   $server_package = pick($::puppet::server_package, $server_package_default)
+  $server_version = pick($::puppet::server_version, $::puppet::version)
 
   package { $server_package:
-    ensure => $::puppet::version,
+    ensure => $server_version,
   }
 
   if $puppet::server_git_repo {


### PR DESCRIPTION
When installing puppetserver the numbers do not progress in step with puppet client versions.