### PR TITLE
Fix incomplete param for environment_timeout

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -333,6 +333,8 @@
 #                                  catalog from Foreman (in seconds).
 #                                  type:integer
 #
+# $server_environment_timeout::    Timeout for cached compiled catalogs (10s, 5m, ...)
+#
 # $server_ca_proxy::               The actual server that handles puppet CA.
 #                                  Setting this to anything non-empty causes
 #                                  the apache vhost to set up a proxy for all
@@ -472,6 +474,7 @@ class puppet (
   $server_puppetdb_port          = $puppet::params::server_puppetdb_port,
   $server_puppetdb_swf           = $puppet::params::server_puppetdb_swf,
   $server_parser                 = $puppet::params::server_parser,
+  $server_environment_timeout    = $puppet::params::server_environment_timeout,
 ) inherits puppet::params {
 
   validate_bool($listen)
@@ -527,6 +530,10 @@ class puppet (
 
   validate_re($server_implementation, '^(master|puppetserver)$')
   validate_re($server_parser, '^(current|future)$')
+
+  if $server_environment_timeout {
+    validate_re($server_environment_timeout, '^(unlimited|0|[0-9]+[smh]{1})$')
+  }
 
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -212,4 +212,7 @@ class puppet::params {
 
   # Which Parser do we want to use? https://docs.puppetlabs.com/references/latest/configuration.html#parser
   $server_parser = 'current'
+
+  # Timeout for cached environments, changed in puppet 3.7.x
+  $server_environment_timeout = undef
 }

--- a/manifests/server/env.pp
+++ b/manifests/server/env.pp
@@ -6,7 +6,7 @@ define puppet::server::env (
   $manifestdir            = undef,
   $modulepath             = ["${::puppet::server_envs_dir}/${name}/modules", $::puppet::server_common_modules_path],
   $templatedir            = undef,
-  $environment_timeout    = undef,
+  $environment_timeout    = $::puppet::server_environment_timeout,
   $directory_environments = $::puppet::server_directory_environments,
   $owner                  = $::puppet::server_environments_owner,
   $group                  = $::puppet::server_environments_group,

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -10,6 +10,9 @@
     ssldir         = <%= scope.lookupvar("puppet::server_ssl_dir") %>
     certname       = <%= scope.lookupvar("puppet::server_certname") %>
     parser         = <%= scope.lookupvar("puppet::server_parser") %>
+<% if @server_environment_timeout -%>
+    environment_timeout = <%= @server_environment_timeout %>
+<% end -%>
 <% if @server_storeconfigs_backend -%>
     storeconfigs   = true
     storeconfigs_backend = <%= @server_storeconfigs_backend %>


### PR DESCRIPTION
The default of this param changed in puppet 3.7.x from 3 minutes to no caching. Running this configuration in a bigger system causes performance issues.

You can now configure the timeout in the installer, if needed. Defaults to disabled.