### PR TITLE
Fixed $agent_restart_command to fit Redhat 6 & 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -195,10 +195,22 @@ class puppet::params {
 
   # Puppet service name
   $service_name = 'puppet'
-  $agent_restart_command = $::osfamily ? {
-    'Debian' => '/usr/sbin/service puppet reload',
-    'Redhat' => '/usr/sbin/service puppet reload',
-    default  => undef,
+  # Command to restart the agent
+  case $::osfamily {
+    'Debian' : { $agent_restart_command = "/usr/sbin/service ${service_name} reload" }
+    'Redhat' : {
+               case versioncmp( $::operatingsystemrelease, 7.0) {
+                 '1','0' : {
+                   $agent_restart_command = "/usr/bin/systemctl restart ${service_name}" # operatingsystemrelease is equal or greater than 7.0
+                 }
+                 '-1' : {
+                   $agent_restart_command = "/sbin/service ${service_name} reload"       # operatingsystemrelease is less than 7.0
+                 }
+               }
+    }
+    default  : {
+      $agent_restart_command = undef
+    }
   }
 
   # Foreman parameters

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -197,16 +197,15 @@ class puppet::params {
   $service_name = 'puppet'
   # Command to restart the agent
   case $::osfamily {
-    'Debian' : { $agent_restart_command = "/usr/sbin/service ${service_name} reload" }
+    'Debian' : {
+      $agent_restart_command = "/usr/sbin/service ${service_name} reload"
+    }
     'Redhat' : {
-               case versioncmp( $::operatingsystemrelease, 7.0) {
-                 '1','0' : {
-                   $agent_restart_command = "/usr/bin/systemctl restart ${service_name}" # operatingsystemrelease is equal or greater than 7.0
-                 }
-                 '-1' : {
-                   $agent_restart_command = "/sbin/service ${service_name} reload"       # operatingsystemrelease is less than 7.0
-                 }
-               }
+      $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1') # workaround for the possibly missing operatingsystemmajrelease
+      $agent_restart_command = $osreleasemajor ? {
+        '7'     => "/usr/bin/systemctl restart ${service_name}",
+        default => "/sbin/service ${service_name} reload",
+      }
     }
     default  : {
       $agent_restart_command = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -195,7 +195,8 @@ class puppet::params {
 
   # Puppet service name
   $service_name = 'puppet'
-  # Command to restart the agent
+  # Command to reload/restart the agent
+  # If supported on the OS, reloading is prefered since it does not kill a currently active puppet run
   case $::osfamily {
     'Debian' : {
       $agent_restart_command = "/usr/sbin/service ${service_name} reload"
@@ -203,8 +204,9 @@ class puppet::params {
     'Redhat' : {
       $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1') # workaround for the possibly missing operatingsystemmajrelease
       $agent_restart_command = $osreleasemajor ? {
-        '7'     => "/usr/bin/systemctl restart ${service_name}",
-        default => "/sbin/service ${service_name} reload",
+        '6'     => "/sbin/service ${service_name} reload",
+        '7'     => "/usr/bin/systemctl reload-or-restart ${service_name}",
+        default => undef,
       }
     }
     default  : {


### PR DESCRIPTION
Changes:
  * Replaced selector between debian and Redhat to also distinguish
    between Redhat 6 and Redhat 7