### PR TITLE
Update params.pp to work on RedHat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -197,7 +197,7 @@ class puppet::params {
   $service_name = 'puppet'
   $agent_restart_command = $::osfamily ? {
     'Debian' => '/usr/sbin/service puppet reload',
-    'Redhat' => '/usr/sbin/service puppet reload',
+    'Redhat' => '/sbin/service puppet reload',
     default  => undef,
   }
 


### PR DESCRIPTION
on RedHat the service command is in /sbin
changed the agent_restart_command to /sbin/service to get it working on the RedHat osfamily