### PR TITLE
Add environment parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -418,6 +418,7 @@ class puppet (
   $puppetmaster                  = $puppet::params::puppetmaster,
   $service_name                  = $puppet::params::service_name,
   $syslogfacility                = $puppet::params::syslogfacility,
+  $environment                   = $puppet::params::environment,
   $server                        = $puppet::params::server,
   $server_user                   = $puppet::params::user,
   $server_group                  = $puppet::params::group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class puppet::params {
   $classfile           = '$vardir/classes.txt'
   $hiera_config        = '$confdir/hiera.yaml'
   $syslogfacility      = undef
+  $environment         = $::environment
 
   case $::osfamily {
     'Windows' : {

--- a/templates/agent/puppet.conf.erb
+++ b/templates/agent/puppet.conf.erb
@@ -21,7 +21,7 @@
     report            = true
     pluginsync        = <%= scope.lookupvar('::puppet::pluginsync') %>
     masterport        = <%= scope.lookupvar("::puppet::port") rescue 8140 %>
-    environment       = <%= @environment %>
+    environment       = <%= scope.lookupvar("::puppet::environment") %>
     certname          = <%= @clientcert %>
 <% if !@use_srv_records -%>
     server            = <%= if ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>


### PR DESCRIPTION
Currently the environment set in puppet.conf comes from the top scope
variable. If we launch puppet with '--environment foo' for testing, it
changes the puppet.conf file (what we do no want). We used to override
$environment somewhere in our stack with the fixed environment so that
it work as expected thanks to dynamic scoping still functionnal in ERB
templates. But this workaround does not work anymore with the future
parser now they remove totally dynamic scoping.

This patch allows to set the environment in the puppet class.