### PR TITLE
Set mode/owner/group on common module directories

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -114,8 +114,15 @@ class puppet::server::config inherits puppet::config {
 
   }
   elsif ! $puppet::server_dynamic_environments {
-    file { ['/usr/share/puppet', $puppet::server_common_modules_path]:
+    file { '/usr/share/puppet':
       ensure => directory,
+    }
+
+    file { $puppet::server_common_modules_path:
+      ensure => directory,
+      owner  => $::puppet::server_environments_owner,
+      group  => $::puppet::server_environments_group,
+      mode   => $::puppet::server_environments_mode,
     }
 
     # make sure your site.pp exists (puppet #15106, foreman #1708)

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -51,10 +51,25 @@ describe 'puppet::server::config' do
     end
 
     it 'should set up the environments' do
-      should contain_file('/etc/puppet/environments').with_ensure('directory')
+      should contain_file('/etc/puppet/environments').with({
+        :ensure => 'directory',
+        :owner => 'puppet',
+        :group => nil,
+        :mode => '0755',
+      })
       should contain_file('/usr/share/puppet').with_ensure('directory')
-      should contain_file('/etc/puppet/environments/common').with_ensure('directory')
-      should contain_file('/usr/share/puppet/modules').with_ensure('directory')
+      should contain_file('/etc/puppet/environments/common').with({
+        :ensure => 'directory',
+        :owner => 'puppet',
+        :group => nil,
+        :mode => '0755',
+      })
+      should contain_file('/usr/share/puppet/modules').with({
+        :ensure => 'directory',
+        :owner => 'puppet',
+        :group => nil,
+        :mode => '0755',
+      })
 
       should contain_file('/etc/puppet/manifests/site.pp').with({
         :ensure  => 'file',

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -22,14 +22,23 @@ describe 'puppet::server::env' do
       it 'should only deploy directories' do
         should contain_file('/etc/puppet/environments/foo').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should contain_file('/etc/puppet/environments/foo/manifests').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should contain_file('/etc/puppet/environments/foo/modules').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should_not contain_file('/etc/puppet/environments/foo/environment.conf')
@@ -45,10 +54,16 @@ describe 'puppet::server::env' do
       it 'should add an env section' do
         should contain_file('/etc/puppet/environments/foo').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should contain_file('/etc/puppet/environments/foo/modules').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should contain_concat__fragment('puppet.conf+40-foo').


### PR DESCRIPTION
Ensure the mode/owner/group set by server_environments_* parameters is
applied to common module directories.