### PR TITLE
Set exec umask on Puppet 3.4+ for cert generation

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -48,19 +48,37 @@ class puppet::server::config inherits puppet::config {
     mode  => '0640',
   }
 
-  # If the ssl dir is not the default dir, it needs to be created before running
-  # the generate ca cert or it will fail.
-  exec {'puppet_server_config-create_ssl_dir':
-    creates => $::puppet::server_ssl_dir,
-    command => "/bin/mkdir -p ${::puppet::server_ssl_dir}",
-    before  => Exec['puppet_server_config-generate_ca_cert'],
-  }
+  # 3.4.0+ supports umask
+  if versioncmp($::puppetversion, '3.4.0') >= 0 {
+    # If the ssl dir is not the default dir, it needs to be created before running
+    # the generate ca cert or it will fail.
+    exec {'puppet_server_config-create_ssl_dir':
+      creates => $::puppet::server_ssl_dir,
+      command => "/bin/mkdir -p ${::puppet::server_ssl_dir}",
+      umask   => '0022',
+      before  => Exec['puppet_server_config-generate_ca_cert'],
+    }
 
-  # Generate a new CA and host cert if our host cert doesn't exist
-  exec {'puppet_server_config-generate_ca_cert':
-    creates => $::puppet::server::ssl_cert,
-    command => "${puppet::params::puppetca_path}/${puppet::params::puppetca_bin} --generate ${::fqdn}",
-    require => Concat["${puppet::server_dir}/puppet.conf"],
+    # Generate a new CA and host cert if our host cert doesn't exist
+    exec {'puppet_server_config-generate_ca_cert':
+      creates => $::puppet::server::ssl_cert,
+      command => "${puppet::puppetca_path}/${puppet::puppetca_bin} --generate ${::fqdn}",
+      umask   => '0022',
+      require => Concat["${puppet::server_dir}/puppet.conf"],
+    }
+  } else {
+    # Copy of above without umask for pre-3.4
+    exec {'puppet_server_config-create_ssl_dir':
+      creates => $::puppet::server_ssl_dir,
+      command => "/bin/mkdir -p ${::puppet::server_ssl_dir}",
+      before  => Exec['puppet_server_config-generate_ca_cert'],
+    }
+
+    exec {'puppet_server_config-generate_ca_cert':
+      creates => $::puppet::server::ssl_cert,
+      command => "${puppet::puppetca_path}/${puppet::puppetca_bin} --generate ${::fqdn}",
+      require => Concat["${puppet::server_dir}/puppet.conf"],
+    }
   }
 
   if $puppet::server_passenger and $::puppet::server_implementation == 'master' {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -115,8 +115,15 @@ class puppet::server::config inherits puppet::config {
 
   }
   elsif ! $puppet::server_dynamic_environments {
-    file { ['/usr/share/puppet', $puppet::server_common_modules_path]:
+    file { '/usr/share/puppet':
       ensure => directory,
+    }
+
+    file { $puppet::server_common_modules_path:
+      ensure => directory,
+      owner  => $::puppet::server_environments_owner,
+      group  => $::puppet::server_environments_group,
+      mode   => $::puppet::server_environments_mode,
     }
 
     # make sure your site.pp exists (puppet #15106, foreman #1708)

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -51,10 +51,25 @@ describe 'puppet::server::config' do
     end
 
     it 'should set up the environments' do
-      should contain_file('/etc/puppet/environments').with_ensure('directory')
+      should contain_file('/etc/puppet/environments').with({
+        :ensure => 'directory',
+        :owner => 'puppet',
+        :group => nil,
+        :mode => '0755',
+      })
       should contain_file('/usr/share/puppet').with_ensure('directory')
-      should contain_file('/etc/puppet/environments/common').with_ensure('directory')
-      should contain_file('/usr/share/puppet/modules').with_ensure('directory')
+      should contain_file('/etc/puppet/environments/common').with({
+        :ensure => 'directory',
+        :owner => 'puppet',
+        :group => nil,
+        :mode => '0755',
+      })
+      should contain_file('/usr/share/puppet/modules').with({
+        :ensure => 'directory',
+        :owner => 'puppet',
+        :group => nil,
+        :mode => '0755',
+      })
 
       should contain_file('/etc/puppet/manifests/site.pp').with({
         :ensure  => 'file',

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -22,14 +22,23 @@ describe 'puppet::server::env' do
       it 'should only deploy directories' do
         should contain_file('/etc/puppet/environments/foo').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should contain_file('/etc/puppet/environments/foo/manifests').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should contain_file('/etc/puppet/environments/foo/modules').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should_not contain_file('/etc/puppet/environments/foo/environment.conf')
@@ -45,10 +54,16 @@ describe 'puppet::server::env' do
       it 'should add an env section' do
         should contain_file('/etc/puppet/environments/foo').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should contain_file('/etc/puppet/environments/foo/modules').with({
           :ensure => 'directory',
+          :owner => 'puppet',
+          :group => nil,
+          :mode => '0755',
         })
 
         should contain_concat__fragment('puppet.conf+40-foo').


### PR DESCRIPTION
Sorry about the refactor in the middle, the file was a bit of a mess - but I can remove it if needed.

The umask ensures the cert generation works properly under a restrictive umask, as the Puppet CA doesn't enforce file permissions.  The agent does though, which means running the agent during/after installation can make it work as it tidies some file permissions.