### PR TITLE
classfile should default to /classes.txt

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class puppet::params {
   $pluginsource        = 'puppet:///plugins'
   $pluginfactsource    = 'puppet:///pluginfacts'
   # lint:endignore
-  $classfile           = '$vardir/classes.txt'
+  $classfile           = '$statedir/classes.txt'
   $hiera_config        = '$confdir/hiera.yaml'
   $syslogfacility      = undef
   $environment         = $::environment

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -102,7 +102,7 @@ describe 'puppet::server::config' do
 
       should contain_concat__fragment('puppet.conf+20-agent').
         with_content(/^\s+configtimeout\s+= 120$/).
-        with_content(/^\s+classfile\s+= \$vardir\/classes.txt/).
+        with_content(/^\s+classfile\s+= \$statedir\/classes.txt/).
         with({}) # So we can use a trailing dot on each with_content line
 
       should contain_concat__fragment('puppet.conf+30-master').


### PR DESCRIPTION
Hi! recently I noticed that the classfile parameter is pointing to the wrong place:

The documentation states that it should be set by default to ```$statedir/classes.txt``` 

I ran into a weird problem where MCollective could not find node based on classes because it was looking at the default file path, while this module sets it to a really old default.

The Mcollective documentation (from puppetlab) states:
> Puppet provides a list of classes applied to a node by default in /var/puppet/state/classes.txt or  /var/lib/puppet/state/classes.txt (depending on which Puppet version you are using. The latter is true for 0.25.5 onwards) , we’ll use this data with –with-class filters.


Thank you!
