### PR TITLE
don't set deprecated configtimeout on 4.0+

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,12 @@ class puppet::params {
   $agent_noop          = false
   $show_diff           = false
   $module_repository   = undef
-  $configtimeout       = 120
+  if versioncmp($::puppetversion, '4.0') < 0 {
+    $configtimeout     = 120
+  }
+  else {
+    $configtimeout     = undef
+  }
   $usecacheonfailure   = true
   $ca_server           = undef
   $ca_port             = undef

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -101,7 +101,6 @@ describe 'puppet::server::config' do
         with({}) # So we can use a trailing dot on each with_content line
 
       should contain_concat__fragment('puppet.conf+20-agent').
-        with_content(/^\s+configtimeout\s+= 120$/).
         with_content(/^\s+classfile\s+= \$statedir\/classes.txt/).
         with({}) # So we can use a trailing dot on each with_content line
 
@@ -117,6 +116,20 @@ describe 'puppet::server::config' do
       should contain_concat('/etc/puppet/puppet.conf')
 
       should_not contain_file('/etc/puppet/puppet.conf').with_content(/storeconfigs/)
+    end
+
+    context 'on Puppet < 4.0.0', :if => (Puppet.version < '4.0.0') do
+      it 'should set configtimeout' do
+        should contain_concat__fragment('puppet.conf+20-agent').
+          with_content(/^\s+configtimeout\s+= 120$/)
+      end
+    end
+
+    context 'on Puppet >= 4.0.0', :if => (Puppet.version >= '4.0.0') do
+      it 'should not set configtimeout' do
+        should contain_concat__fragment('puppet.conf+20-agent').
+          without_content(/^\s+configtimeout\s+= 120$/)
+      end
     end
 
     it 'should not configure PuppetDB' do

--- a/templates/agent/puppet.conf.erb
+++ b/templates/agent/puppet.conf.erb
@@ -31,7 +31,9 @@
     splaylimit        = <%= scope.lookupvar('::puppet::splaylimit') %>
     runinterval       = <%= scope.lookupvar('::puppet::runinterval') %>
     noop              = <%= scope.lookupvar('::puppet::agent_noop') %>
+<% unless [nil, :undefined, :undef].include?(scope.lookupvar('::puppet::configtimeout')) -%>
     configtimeout     = <%= scope.lookupvar('::puppet::configtimeout') %>
+<% end -%>
     usecacheonfailure = <%= scope.lookupvar('::puppet::usecacheonfailure') %>
 <% unless [nil, :undefined, :undef].include?(scope.lookupvar('::puppet::prerun_command')) -%>
     prerun_command    = <%= scope.lookupvar('::puppet::prerun_command') %>


### PR DESCRIPTION
configtimeout was deprecated in 4.0 and will issue a warning if its set. It is set by default in the current template, when puppet 4 users use a puppet.conf generated from theforeman-puppet they'll see a warning like the one below

```
Warning: Setting configtimeout is deprecated. 
   (at /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/settings.rb:1102:in `issue_deprecation_warning')
```

This pull requests stops it from being set by default on puppet 4 boxes.

See https://docs.puppetlabs.com/puppet/4.1/reference/deprecated_settings.html#configtimeout and https://tickets.puppetlabs.com/browse/PUP-3666 for more details.

