### PR TITLE
pluginfactsource is not correctly set when using srv records

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,7 @@ class puppet::config(
   $module_repository  = $::puppet::module_repository,
   $nsauth_template    = $::puppet::nsauth_template,
   $pluginsource       = $::puppet::pluginsource,
+  $pluginfactsource   = $::puppet::pluginfactsource,
   $puppet_dir         = $::puppet::dir,
   $puppetmaster       = $::puppet::puppetmaster,
   $syslogfacility     = $::puppet::syslogfacility,

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -119,6 +119,7 @@ describe 'puppet::config' do
           '    use_srv_records = true',
           '    srv_domain = example.org',
           '    pluginsource = puppet:///plugins',
+          '    pluginfactsource = puppet:///pluginfacts',
         ])
       end
     end


### PR DESCRIPTION
by adding the missing parameter to the puppet::config class, the pluginfactsource source variable is now correctly set in puppet.conf.

This change is required to make the code from #212 work.