### PR TITLE
Document sharedir parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,8 @@
 #
 # $ssldir::                        Override where SSL certificates are kept.
 #
+# $sharedir::                      Override the system data directory.
+#
 # $package_provider::              The provider used to install the agent.
 #                                  Defaults to chocolatey on Windows
 #                                  Defaults to undef elsewhere


### PR DESCRIPTION
I think this is the reason the nightly RPM build failed: http://ci.theforeman.org/job/packaging_build_rpm/2082/console

Ah yes, installers are now failing at runtime with:

    [FATAL 2015-07-23 07:50:06 fatal] Unable to continue because of: undocumented parameters in puppet: sharedir