### PR TITLE
Set explicit permissions and ownership

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,6 +27,8 @@ class puppet::config(
 
   file { $puppet_dir:
     ensure => directory,
+    owner  => $::puppet::user,
+    group  => $::puppet::group,
   } ->
   case $::osfamily {
     'Windows': {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -34,16 +34,21 @@ class puppet::server::config inherits puppet::config {
   file { "${puppet::vardir}/reports":
     ensure => directory,
     owner  => $puppet::server_user,
+    group  => $puppet::server_group,
+    mode   => '0750',
   }
 
   ## SSL and CA configuration
   # Open read permissions to private keys to puppet group for foreman, proxy etc.
   file { "${puppet::server_ssl_dir}/private_keys":
-    group => $puppet::server_group,
-    mode  => '0750',
+    ensure => directory,
+    owner  => $puppet::server_user,
+    group  => $puppet::server_group,
+    mode   => '0750',
   }
 
   file { "${puppet::server_ssl_dir}/private_keys/${::fqdn}.pem":
+    owner => $puppet::server_user,
     group => $puppet::server_group,
     mode  => '0640',
   }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -20,6 +20,7 @@ class puppet::server::install {
     file { $puppet::vardir:
       ensure => directory,
       owner  => $puppet::server_user,
+      group  => $puppet::server_group,
     }
 
     $git_shell = $::osfamily ? {


### PR DESCRIPTION
This matches the puppet default and it reduces differences if you set a
global default in site.pp.