### PR TITLE
Added $manage_packages to control if module install packages

### DIFF
--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -1,7 +1,9 @@
 # Install the puppet client installation
 class puppet::agent::install {
-  package { $puppet::client_package:
-    ensure   => $::puppet::version,
-    provider => $::puppet::package_provider,
+  if $::puppet::manage_packages == true or $::puppet::manage_packages == 'agent' {
+    package { $puppet::client_package:
+      ensure   => $::puppet::version,
+      provider => $::puppet::package_provider,
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,11 @@
 #
 # $sharedir::                      Override the system data directory.
 #
+# $manage_packages::               Should this module install packages or not.
+#                                  Can also install only server packages with value
+#                                  of 'server' or only agent packages with 'agent'.
+#                                  Defaults to true
+#
 # $package_provider::              The provider used to install the agent.
 #                                  Defaults to chocolatey on Windows
 #                                  Defaults to undef elsewhere
@@ -383,6 +388,7 @@ class puppet (
   $rundir                        = $puppet::params::rundir,
   $ssldir                        = $puppet::params::ssldir,
   $sharedir                      = $puppet::params::sharedir,
+  $manage_packages               = $puppet::params::manage_packages,
   $package_provider              = $puppet::params::package_provider,
   $port                          = $puppet::params::port,
   $listen                        = $puppet::params::listen,
@@ -518,7 +524,7 @@ class puppet (
   if $server_puppetdb_host {
     validate_string($server_puppetdb_host)
   }
-  
+
   if $server_http {
     validate_array($server_http_allow)
   }
@@ -537,11 +543,15 @@ class puppet (
 
   validate_re($server_implementation, '^(master|puppetserver)$')
   validate_re($server_parser, '^(current|future)$')
-
+  
   if $server_environment_timeout {
     validate_re($server_environment_timeout, '^(unlimited|0|[0-9]+[smh]{1})$')
   }
 
+  if $manage_packages != true and $manage_packages != false {
+    validate_re($manage_packages, '^(server|agent)$')
+  }
+  
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,6 +74,7 @@ class puppet::params {
     }
   }
 
+  $manage_packages = true
   $package_provider = $::osfamily ? {
     'windows' => 'chocolatey',
     default   => undef,

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,19 +1,21 @@
 # Install the puppet server
 class puppet::server::install {
 
-  $server_package_default = $::puppet::server_implementation ? {
-    'master'       => $::osfamily ? {
-      'Debian'                => ['puppetmaster-common','puppetmaster'],
-      /^(FreeBSD|DragonFly)$/ => [],
-      default                 => ['puppet-server'],
-    },
-    'puppetserver' => 'puppetserver',
-  }
-  $server_package = pick($::puppet::server_package, $server_package_default)
-  $server_version = pick($::puppet::server_version, $::puppet::version)
+  if $::puppet::manage_packages == true or $::puppet::manage_packages == 'server' {
+    $server_package_default = $::puppet::server_implementation ? {
+      'master'       => $::osfamily ? {
+        'Debian'                => ['puppetmaster-common','puppetmaster'],
+        /^(FreeBSD|DragonFly)$/ => [],
+        default                 => ['puppet-server'],
+      },
+      'puppetserver' => 'puppetserver',
+    }
+    $server_package = pick($::puppet::server_package, $server_package_default)
+    $server_version = pick($::puppet::server_version, $::puppet::version)
 
-  package { $server_package:
-    ensure => $server_version,
+    package { $server_package:
+      ensure => $server_version,
+    }
   }
 
   if $puppet::server_git_repo {

--- a/spec/classes/puppet_agent_install_spec.rb
+++ b/spec/classes/puppet_agent_install_spec.rb
@@ -52,4 +52,54 @@ describe 'puppet::agent::install' do
 
   end
 
+  describe "when manage_packages => false" do
+    let :pre_condition do
+      "class { 'puppet': manage_packages => false }"
+    end
+    
+    let :facts do {
+      :osfamily => 'RedHat',
+      :concat_basedir => '/foo/bar',
+      :operatingsystemrelease => '6.6',
+      :puppetversion => Puppet.version,
+    } end
+    
+    it 'should not contain Package[puppet]' do
+      should_not contain_package('puppet')
+    end
+  end
+  
+  describe "when manage_packages => 'agent'" do
+    let :pre_condition do
+      "class { 'puppet': manage_packages => 'agent' }"
+    end
+    
+    let :facts do {
+      :osfamily => 'RedHat',
+      :concat_basedir => '/foo/bar',
+      :operatingsystemrelease => '6.6',
+      :puppetversion => Puppet.version,
+    } end
+    
+    it 'should contain Package[puppet]' do
+      should contain_package('puppet')
+    end
+  end
+  
+  describe "when manage_packages => 'server'" do
+    let :pre_condition do
+      "class { 'puppet': manage_packages => 'server' }"
+    end
+    
+    let :facts do {
+      :osfamily => 'RedHat',
+      :concat_basedir => '/foo/bar',
+      :operatingsystemrelease => '6.6',
+      :puppetversion => Puppet.version,
+    } end
+    
+    it 'should not contain Package[puppet]' do
+      should_not contain_package('puppet')
+    end
+  end
 end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -102,4 +102,39 @@ describe 'puppet::server' do
     it { should raise_error(Puppet::Error, /"golang" does not match/) }
   end
 
+  describe "when manage_packages => false" do
+    let :pre_condition do
+      "class { 'puppet': server => true, manage_packages => false,
+                         server_implementation => 'master' }"
+    end
+    
+    it { should compile.with_all_deps }
+    it 'should not contain Package[puppet-server]' do
+      should_not contain_package('puppet-server')
+    end
+  end
+  
+  describe "when manage_packages => 'agent'" do
+    let :pre_condition do
+      "class { 'puppet': server => true, manage_packages => 'agent',
+                         server_implementation => 'master' }"
+    end
+    
+    it { should compile.with_all_deps }
+    it 'should not contain Package[puppet-server]' do
+      should_not contain_package('puppet-server')
+    end
+  end
+  
+  describe "when manage_packages => 'server'" do
+    let :pre_condition do
+      "class { 'puppet': server => true, manage_packages => 'server',
+                         server_implementation => 'master' }"
+    end
+    
+    it { should compile.with_all_deps }
+    it 'should contain Package[puppet-server]' do
+      should contain_package('puppet-server')
+    end
+  end
 end


### PR DESCRIPTION
This allows one to use the puppet module but not have it install any of the puppet modules. I am championing this as we like the module, but can not handle having packages installed from an OS source as our puppet components are newer versions installed from gems. 

The default behavior out of the box is still to allow the module to manage package installation. This way existing functionality is not broken and still handles according to any existing documentation. 