### PR TITLE
Correct $puppetrun_cmd on Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -201,7 +201,7 @@ class puppet::params {
     $puppetca_bin = 'puppet cert'
     $puppetrun_cmd = $::osfamily ? {
       /^(FreeBSD|DragonFly)$/ => '/usr/local/bin/puppet kick',
-      default                 => '/usr/bin/puppet/kick'
+      default                 => '/usr/bin/puppet kick'
     }
   }
 


### PR DESCRIPTION
Regression introduced in f74e45d1dc8a96929f22733f39052a798aeff52f.