### PR TITLE
make sure server_manifest_path exists too

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -140,7 +140,13 @@ class puppet::server::config inherits puppet::config {
       mode   => $::puppet::server_environments_mode,
     }
 
-    # make sure your site.pp exists (puppet #15106, foreman #1708)
+    # make sure your site.pp exists (puppet #15106, foreman #1708) and server_manifest_path too
+    file { $puppet::server_manifest_path:
+      ensure => directory,
+      owner  => $puppet::server_user,
+      group  => $puppet::server_group,
+      mode   => '0755',
+    } ->
     file { "${puppet::server_manifest_path}/site.pp":
       ensure  => file,
       replace => false,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -146,7 +146,7 @@ class puppet::server::config inherits puppet::config {
       owner  => $puppet::server_user,
       group  => $puppet::server_group,
       mode   => '0755',
-    } ->
+    }
     file { "${puppet::server_manifest_path}/site.pp":
       ensure  => file,
       replace => false,


### PR DESCRIPTION
This PR addresses an error observed trying to run the module in standalone mode on a CentOS 7 host.  The module fails on missing $server_manifest_path, as that path is not created when puppet-agent is installed via yum prior to running the module.

Note this is for deployment of puppetserver v2.1 (aka puppet 4).

```
...
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/puppetlabs/code/manifests/site.pp20150825-2737-vftlyr.lock at 144:/home/myuser/puppettest/modules/puppet/manifests/server/config.pp
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/puppetlabs/code/manifests/site.pp20150825-2737-vftlyr.lock at 144:/home/myuser/puppettest/modules/puppet/manifests/server/config.pp
Wrapped exception:
No such file or directory @ dir_s_rmdir - /etc/puppetlabs/code/manifests/site.pp20150825-2737-vftlyr.lock
Error: /Stage[main]/Puppet::Server::Config/File[/etc/puppetlabs/code/manifests/site.pp]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/puppetlabs/code/manifests/site.pp20150825-2737-vftlyr.lock at 144:/home/myuser/puppettest/modules/puppet/manifests/server/config.pp
...
Notice: /Stage[main]/Puppet::Server::Service/Service[puppetserver]: Dependency File[/etc/puppetlabs/code/manifests/site.pp] has failures: true
Warning: /Stage[main]/Puppet::Server::Service/Service[puppetserver]: Skipping because of failed dependencies
```
This was the manifest used to run the module in standalone mode:
```
require java

class { '::puppet': 
  runmode => 'service',
  server => true,
  server_jvm_min_heap_size => '2G', 
  server_implementation => 'puppetserver',
  server_foreman        => false,
  server_reports        => 'store',
  server_external_nodes => '',
  server_environments   => [],
}
```