### PR TITLE
splay needs to be set in [main] section of puppet.conf, not in [agent]

### DIFF
--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -89,6 +89,20 @@ describe 'puppet::config' do
       end
     end
 
+    context 'when splay = true and splaylimit = 60s' do
+      let :pre_condition do
+        'class {"::puppet": splay => true, splaylimit => \'60s\'}'
+      end
+
+      it 'should contain puppet.conf [main] with splay and splaylimit' do
+        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+          '[main]',
+          '    splay      = true',
+          '    splaylimit = 60s',
+        ])
+      end
+    end
+
     context "when dns_alt_names => ['foo','bar']" do
       let :pre_condition do
         "class { 'puppet': dns_alt_names => ['foo','bar'] }"
@@ -299,6 +313,20 @@ describe 'puppet::config' do
 
       it 'should contain auth.conf with allow' do
         should contain_file('C:/ProgramData/PuppetLabs/puppet/etc/auth.conf').with_content(%r{^allow \$1, puppetproxy$})
+      end
+    end
+
+    context 'when splay = true and splaylimit = 60s' do
+      let :pre_condition do
+        'class {"::puppet": splay => true, splaylimit => \'60s\'}'
+      end
+
+      it 'should contain puppet.conf [main] with splay and splaylimit' do
+        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+          '[main]',
+          '    splay      = true',
+          '    splaylimit = 60s',
+        ])
       end
     end
 

--- a/templates/agent/puppet.conf.erb
+++ b/templates/agent/puppet.conf.erb
@@ -27,8 +27,6 @@
     server            = <%= if ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>
 <% end -%>
     listen            = <%= scope.lookupvar('::puppet::listen') %>
-    splay             = <%= scope.lookupvar('::puppet::splay') %>
-    splaylimit        = <%= scope.lookupvar('::puppet::splaylimit') %>
     runinterval       = <%= scope.lookupvar('::puppet::runinterval') %>
     noop              = <%= scope.lookupvar('::puppet::agent_noop') %>
 <% unless [nil, :undefined, :undef].include?(scope.lookupvar('::puppet::configtimeout')) -%>

--- a/templates/puppet.conf.erb
+++ b/templates/puppet.conf.erb
@@ -64,3 +64,7 @@
 <% scope.lookupvar("puppet::additional_settings").sort_by {|k, v| k}.each do |key, value| -%>
     <%= key %> = <%= value %>
 <% end -%>
+<% if scope.lookupvar("::puppet::splay") -%>
+    splay      = <%= scope.lookupvar('::puppet::splay') %>
+    splaylimit = <%= scope.lookupvar('::puppet::splaylimit') %>
+<% end -%>


### PR DESCRIPTION
If you set splay and splaylimit in the [agent] section of puppet.conf, it will not work. It needs to be set in the [main] section of puppet.conf. See below for proof and also see 


On a server where splay is set in agent, it does not work:
```
[root@localhost ~]# cat puppet-splay-agent.conf
[agent]
  splay = true
  splaylimit = 600s
[root@localhost ~]# 
[root@localhost ~]# /opt/puppetlabs/bin/puppet config --config ~/puppet-splay-agent.conf  print  | grep splay
config = /root/puppet-splay-agent.conf
splaylimit = 1800
splay = false
[root@localhost ~]# 
```


On a server where splay is set in main, it works.
```
[root@localhost ~]# cat puppet-splay-main.conf
[main]
  splay = true
  splaylimit = 600s
[root@localhost ~]# 
[root@localhost ~]# /opt/puppetlabs/bin/puppet config --config ~/puppet-splay-main.conf  print  | grep splay
config = /root/puppet-splay-main.conf
splaylimit = 600
splay = true
[root@localhost ~]# 
```

I tested the above on puppet 4.1.0 and 3.3.0.
