### PR TITLE
Declare puppet user/group resource dependencies.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,19 +25,10 @@ class puppet::config(
     order   => '10',
   }
 
-  $dir_owner = $::puppet::server ? {
-    true    => $::puppet::user,
-    default => $::puppet::dir_owner,
-  }
-  $dir_group = $::puppet::server ? {
-    true    => $::puppet::group,
-    default => $::puppet::dir_group,
-  }
-
   file { $puppet_dir:
     ensure => directory,
-    owner  => $dir_owner,
-    group  => $dir_group,
+    owner  => $::puppet::dir_owner,
+    group  => $::puppet::dir_group,
   } ->
   case $::osfamily {
     'Windows': {


### PR DESCRIPTION
Declare dependencies for a puppet user/group to satisfy ownership parameters for $puppet_dir.  Specifically, ensure user and group resources are in place (if defined) before trying to set ownership on the path $puppet_dir.  Seeks to address #307.