### PR TITLE
manage Puppet 4 on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -219,12 +219,15 @@ class puppet::params {
 
   $server_package     = undef
   $server_version     = undef
-  $client_package     = $aio_package ? {
-    true       => ['puppet-agent'],
-    default    => $::osfamily ? {
-      'Debian' => ['puppet-common','puppet'],
-      default  => ['puppet'],
-    },
+
+  if $aio_package {
+    $client_package = ['puppet-agent']
+  } elsif ($::osfamily == 'Debian') {
+    $client_package = ['puppet-common','puppet']
+  } elsif ($::osfamily =~ /(FreeBSD|DragonFly)/) and (versioncmp($::puppetversion, '4.0') > 0) {
+    $client_package = ['puppet4']
+  } else {
+    $client_package = ['puppet']
   }
 
   # Only use 'puppet cert' on versions where puppetca no longer exists


### PR DESCRIPTION
this got added in freebsd/freebsd-ports@6386113

I'm not overly fond of removing the ternary but adding more conditions to it would not really help readability also.