### PR TITLE
Don't generate CA cert if not a CA server

### DIFF
--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -61,7 +61,7 @@ describe 'puppet::server::config' do
       should contain_exec('puppet_server_config-generate_ca_cert').with({
         :creates => "#{ssldir}/certs/#{facts[:fqdn]}.pem",
         :command => "#{puppetcacmd} --generate #{facts[:fqdn]}",
-        :require => /Concat\[#{conf_file}]/,
+        :require => /Concat\[#{conf_file}\]/,
       }).that_notifies('Service[httpd]')
     end
 


### PR DESCRIPTION
This addresses #113 in part as it stops generating a CA cert for masters that don't have `server_ca` set to true.

Setting the DNS alt names correctly doesn't require any changes as `puppet cert --generate` will read the dns_alt_names settings from puppet.conf. Users only need to set that setting properly via `dns_alt_names` and the alt names will be in the certificate.