### PR TITLE
workaround for very slow rspec run

### DIFF
--- a/spec/classes/puppet_agent_install_spec.rb
+++ b/spec/classes/puppet_agent_install_spec.rb
@@ -8,7 +8,7 @@ describe 'puppet::agent::install' do
     additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
   end
 
-  let :common_centos_facts do on_supported_os['centos-6-x86_64'].merge({
+  let :common_centos_facts do on_supported_os(supported_os_opts)['centos-6-x86_64'].merge({
     :concat_basedir => '/nonexistant',
     :puppetversion  => Puppet.version,
   }).merge(additional_facts) end

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -8,7 +8,7 @@ describe 'puppet::agent::service' do
     additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
   end
 
-  let :facts do on_supported_os['centos-6-x86_64'].merge({
+  let :facts do on_supported_os(supported_os_opts)['centos-6-x86_64'].merge({
     :clientcert     => 'puppetmaster.example.com',
     :concat_basedir => '/nonexistant',
     :fqdn           => 'puppetmaster.example.com',

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'puppet::agent' do
 
   let :default_facts do
-    on_supported_os['centos-6-x86_64'].merge({
+    on_supported_os(supported_os_opts)['centos-6-x86_64'].merge({
         :clientcert => 'puppetmaster.example.com',
         :concat_basedir => '/nonexistant',
         :fqdn => 'puppetmaster.example.com',

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'puppet::config' do
 
   context "on a RedHat family OS" do
-    let :default_facts do on_supported_os['centos-6-x86_64'].merge({
+    let :default_facts do on_supported_os(supported_os_opts)['centos-6-x86_64'].merge({
       :concat_basedir         => '/foo/bar',
       :domain                 => 'example.org',
       :fqdn                   => 'host.example.com',

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -265,7 +265,7 @@ describe 'puppet::config' do
   end
 
   context "on a FreeBSD family OS" do
-    let :facts do on_supported_os['freebsd-10-amd64'].merge({
+    let :facts do on_supported_os(supported_os_opts)['freebsd-10-amd64'].merge({
       :concat_basedir => '/foo/bar',
       :domain   => 'example.org',
       :puppetversion => Puppet.version,

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'puppet' do
   context 'on RedHat' do
-      let :default_facts do on_supported_os['centos-6-x86_64'].merge({
+      let :default_facts do on_supported_os(supported_os_opts)['centos-6-x86_64'].merge({
         :clientcert             => 'puppetmaster.example.com',
         :concat_basedir         => '/nonexistant',
         :fqdn                   => 'puppetmaster.example.com',

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'puppet::server::config' do
-  let :default_facts do on_supported_os['centos-6-x86_64'].merge({
+  let :default_facts do on_supported_os(supported_os_opts)['centos-6-x86_64'].merge({
     :clientcert             => 'puppetmaster.example.com',
     :concat_basedir         => '/nonexistant',
     :fqdn                   => 'puppetmaster.example.com',

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -8,7 +8,7 @@ describe 'puppet::server::service' do
     additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
   end
 
-  let :facts do on_supported_os['centos-6-x86_64'].merge({
+  let :facts do on_supported_os(supported_os_opts)['centos-6-x86_64'].merge({
     :clientcert     => 'puppetmaster.example.com',
     :concat_basedir => '/nonexistant',
     :fqdn           => 'puppetmaster.example.com',

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'puppet::server' do
 
-  let :common_facts do on_supported_os['centos-6-x86_64'].merge({
+  let :common_facts do on_supported_os(supported_os_opts)['centos-6-x86_64'].merge({
     :concat_basedir         => '/nonexistant',
     :clientcert             => 'puppetmaster.example.com',
     :fqdn                   => 'puppetmaster.example.com',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,9 @@ end
 
 # Workaround for slow rspec-puppet-facts
 def supported_os_opts
-    { :supported_os => [ { "operatingsystem" => "CentOS", "operatingsystemrelease" => [ "6" ] } ] }
+    { :supported_os => [ { "operatingsystem" => "CentOS", "operatingsystemrelease" => [ "6" ] },
+                         { "operatingsystem" => "FreeBSD", "operatingsystemrelease" => [ "10" ] }
+    ] }
 end
 
 def get_content(subject, title)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,11 @@ class Undef
   def inspect; 'undef'; end
 end
 
+# Workaround for slow rspec-puppet-facts
+def supported_os_opts
+    { :supported_os => [ { "operatingsystem" => "CentOS", "operatingsystemrelease" => [ "6" ] } ] }
+end
+
 def get_content(subject, title)
   content = subject.resource('file', title).send(:parameters)[:content]
   content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }


### PR DESCRIPTION
It seems that a large `operatingsystem_support` section in metadata.json takes a really long time to get parsed by rspec-puppet-facts.  Since tests are only run on one instance of a supported OS for most of the tests this passes an opts hash to `on_supported_os` which limits parsing and speeds up the rspec run a lot.