### PR TITLE
rspec speedup demo

### DIFF
--- a/spec/classes/puppet_agent_install_spec.rb
+++ b/spec/classes/puppet_agent_install_spec.rb
@@ -8,7 +8,12 @@ describe 'puppet::agent::install' do
     additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
   end
 
-  let :common_centos_facts do on_supported_os['centos-6-x86_64'].merge({
+on_supported_os.each do |os, os_facts|
+  next if not os == "centos-6-x86_64"
+  context "on #{os}" do
+
+  let (:common_centos_facts) do
+    os_facts.merge({
     :concat_basedir => '/nonexistant',
     :puppetversion  => Puppet.version,
   }).merge(additional_facts) end
@@ -167,4 +172,6 @@ describe 'puppet::agent::install' do
       end
     end
   end
+end
+end
 end

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -8,7 +8,12 @@ describe 'puppet::agent::service' do
     additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
   end
 
-  let :facts do on_supported_os['centos-6-x86_64'].merge({
+on_supported_os.each do |os, os_facts|
+  next if not os == "centos-6-x86_64"
+  context "on #{os}" do
+
+  let (:facts) do
+    os_facts.merge({
     :clientcert     => 'puppetmaster.example.com',
     :concat_basedir => '/nonexistant',
     :fqdn           => 'puppetmaster.example.com',
@@ -102,4 +107,6 @@ describe 'puppet::agent::service' do
 
   end
 
+end
+end
 end

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -2,8 +2,12 @@ require 'spec_helper'
 
 describe 'puppet::agent' do
 
-  let :default_facts do
-    on_supported_os['centos-6-x86_64'].merge({
+on_supported_os.each do |os, os_facts|
+  next if not os == "centos-6-x86_64"
+  context "on #{os}" do
+
+  let (:default_facts) do
+    os_facts.merge({
         :clientcert => 'puppetmaster.example.com',
         :concat_basedir => '/nonexistant',
         :fqdn => 'puppetmaster.example.com',
@@ -127,4 +131,5 @@ describe 'puppet::agent' do
   end
 
 end
-
+end
+end

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 describe 'puppet::config' do
 
   context "on a RedHat family OS" do
-    let :default_facts do on_supported_os['centos-6-x86_64'].merge({
+  on_supported_os.each do |os, os_facts|
+    next if not os == "centos-6-x86_64"
+    let :default_facts do
+      os_facts.merge({
       :concat_basedir         => '/foo/bar',
       :domain                 => 'example.org',
       :fqdn                   => 'host.example.com',
@@ -263,9 +266,13 @@ describe 'puppet::config' do
       end
     end
   end
+  end
 
   context "on a FreeBSD family OS" do
-    let :facts do on_supported_os['freebsd-10-amd64'].merge({
+  on_supported_os.each do |os, os_facts|
+    next if not os == "freebsd-10-amd64"
+    let :facts do
+      os_facts.merge({
       :concat_basedir => '/foo/bar',
       :domain   => 'example.org',
       :puppetversion => Puppet.version,
@@ -339,6 +346,7 @@ describe 'puppet::config' do
       end
     end
 
+  end
   end
 
   context "on a Windows family OS" do

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
 describe 'puppet' do
-  context 'on RedHat' do
-      let :default_facts do on_supported_os['centos-6-x86_64'].merge({
+on_supported_os.each do |os, os_facts|
+  next if not os == "centos-6-x86_64"
+  context "on #{os}" do
+
+  let (:default_facts) do
+    os_facts.merge({
         :clientcert             => 'puppetmaster.example.com',
         :concat_basedir         => '/nonexistant',
         :fqdn                   => 'puppetmaster.example.com',
@@ -150,4 +154,5 @@ describe 'puppet' do
       end
     end
   end
+end
 end

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 describe 'puppet::server::config' do
-  let :default_facts do on_supported_os['centos-6-x86_64'].merge({
+on_supported_os.each do |os, os_facts|
+  next if not os == "centos-6-x86_64"
+  context "on #{os}" do
+
+  let (:default_facts) do
+    os_facts.merge({
     :clientcert             => 'puppetmaster.example.com',
     :concat_basedir         => '/nonexistant',
     :fqdn                   => 'puppetmaster.example.com',
@@ -454,4 +459,6 @@ describe 'puppet::server::config' do
     end
   end
 
+end
+end
 end

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -8,7 +8,12 @@ describe 'puppet::server::service' do
     additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
   end
 
-  let :facts do on_supported_os['centos-6-x86_64'].merge({
+on_supported_os.each do |os, os_facts|
+  next if not os == "centos-6-x86_64"
+  context "on #{os}" do
+
+  let (:facts) do
+    os_facts.merge({
     :clientcert     => 'puppetmaster.example.com',
     :concat_basedir => '/nonexistant',
     :fqdn           => 'puppetmaster.example.com',
@@ -75,4 +80,6 @@ describe 'puppet::server::service' do
     it { should raise_error(Puppet::Error, /Both puppetmaster and puppetserver cannot be enabled simultaneously/) }
   end
 
+end
+end
 end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -2,7 +2,12 @@ require 'spec_helper'
 
 describe 'puppet::server' do
 
-  let :common_facts do on_supported_os['centos-6-x86_64'].merge({
+on_supported_os.each do |os, os_facts|
+  next if not os == "centos-6-x86_64"
+  context "on #{os}" do
+
+  let (:common_facts) do
+    os_facts.merge({
     :concat_basedir         => '/nonexistant',
     :clientcert             => 'puppetmaster.example.com',
     :fqdn                   => 'puppetmaster.example.com',
@@ -150,4 +155,6 @@ describe 'puppet::server' do
       should contain_package('puppet-server')
     end
   end
+end
+end
 end


### PR DESCRIPTION
`let`s are not shared between examples so `on_supported_os` is re-evaluated for each example, which is inefficient. By changing the statement into an `.each` iterator the method is only evaluated once per run. An added bonus is "full coverage" but that can be trimmed down to current functionality to skip (or run only) selected OSes.

I hacked an example together that shows the decreased runtime; when testing the whole matrix a lot of tests fail on various platforms so I only enabled the currently tested platforms. The example also has incorrect indentation and code style as I didn't wan't to mess with whitespace changes, it's unmerge-able as is.

I can work up a merge-able commit if you're interested. I would begin by only picking the platforms that are currently being tested, as the tests actually fail for some others, but going forward they can be enabled and the tests and/or manifests can be fixed. There are also inconsistencies in how the test files are organized that could also be cleaned up.

Are you interested?

I'm closing #315 in favor of this one.