### PR TITLE
refactor rspec tests for speed and coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ rvm:
   - 1.8.7
 env:
   - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
-  - PUPPET_VERSION=3.5 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
   - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
   - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
-  - PUPPET_VERSION=3.5 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
   - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
   - PUPPET_VERSION=2.7.0 ONLY_OS=ubuntu-12-x86_64,centos-6-x86_64
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ matrix:
       env: PUPPET_VERSION=2.7.0 ONLY_OS=ubuntu-12-x86_64,centos-6-x86_64
     # No support for Ruby 1.8.7 on Puppet 4.x
     - rvm: 1.8.7
-      env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+      env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64
     - rvm: 1.8.7
-      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
-    # Exclude FreeBSD tests on Ruby 1.8.7
+      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-9-amd64,freebsd-10-amd64
     - rvm: 1.8.7
       env: PUPPET_VERSION=4.0 ONLY_OS=freebsd-9-amd64,freebsd-10-amd64
+    # Exclude FreeBSD tests on Ruby 1.8.7
     - rvm: 1.8.7
       env: PUPPET_VERSION=3.5 ONLY_OS=freebsd-9-amd64,freebsd-10-amd64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
     - rvm: 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,17 @@ matrix:
   exclude:
     # No real support for Ruby 1.9.3 on Puppet 2.x
     - rvm: 1.9.3
-      env: PUPPET_VERSION=2.7.0
+      env: PUPPET_VERSION=2.7.0 ONLY_OS=ubuntu-12-x86_64,centos-6-x86_64
     # No support for Ruby 2.0 before Puppet 3.2
     - rvm: 2.0.0
-      env: PUPPET_VERSION=2.7.0
+      env: PUPPET_VERSION=2.7.0 ONLY_OS=ubuntu-12-x86_64,centos-6-x86_64
     # No support for Ruby 2.1 before Puppet 3.5
     - rvm: 2.1.5
-      env: PUPPET_VERSION=2.7.0
+      env: PUPPET_VERSION=2.7.0 ONLY_OS=ubuntu-12-x86_64,centos-6-x86_64
     # No support for Ruby 1.8.7 on Puppet 4.x
     - rvm: 1.8.7
-      env: PUPPET_VERSION=4.0
+      env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+    - rvm: 1.8.7
+      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
 bundler_args: --without development
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,20 @@
 # This file is managed centrally by modulesync
 #   https://github.com/theforeman/foreman-installer-modulesync
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
   - 2.1.5
+  - 2.0.0
+  - 1.9.3
+  - 1.8.7
 env:
-  - PUPPET_VERSION=2.7.0
-  - PUPPET_VERSION=3.5
-  - PUPPET_VERSION=3.5 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=4.0
+  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  - PUPPET_VERSION=3.5 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  - PUPPET_VERSION=3.5 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  - PUPPET_VERSION=2.7.0 ONLY_OS=ubuntu-12-x86_64,centos-6-x86_64
 matrix:
+  fast_finish: true
   exclude:
     # No real support for Ruby 1.9.3 on Puppet 2.x
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,19 @@ rvm:
   - 1.9.3
   - 1.8.7
 env:
-  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
-  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+  # First test the major distros
+  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64
+  # Test FreeBSD explicitly so we can exclude ruby 1.8.7 tests
+  - PUPPET_VERSION=4.0 ONLY_OS=freebsd-9-amd64,freebsd-10-amd64
+  - PUPPET_VERSION=3.5 ONLY_OS=freebsd-9-amd64,freebsd-10-amd64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 ONLY_OS=freebsd-9-amd64,freebsd-10-amd64
+  # Test the rest of the supported platforms
+  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-9-amd64,freebsd-10-amd64
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-9-amd64,freebsd-10-amd64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-9-amd64,freebsd-10-amd64
+  # Only test Puppet 2.7 on ubuntu 12 and centos 6
   - PUPPET_VERSION=2.7.0 ONLY_OS=ubuntu-12-x86_64,centos-6-x86_64
 matrix:
   fast_finish: true
@@ -31,5 +38,12 @@ matrix:
       env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
     - rvm: 1.8.7
       env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+    # Exclude FreeBSD tests on Ruby 1.8.7
+    - rvm: 1.8.7
+      env: PUPPET_VERSION=4.0 ONLY_OS=freebsd-9-amd64,freebsd-10-amd64
+    - rvm: 1.8.7
+      env: PUPPET_VERSION=3.5 ONLY_OS=freebsd-9-amd64,freebsd-10-amd64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+    - rvm: 1.8.7
+      env: PUPPET_VERSION=3.5 ONLY_OS=freebsd-9-amd64,freebsd-10-amd64
 bundler_args: --without development
 sudo: false

--- a/spec/classes/puppet_agent_config_spec.rb
+++ b/spec/classes/puppet_agent_config_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'puppet::agent::config' do
 
   on_supported_os.each do |os, facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
     context "on #{os}" do
       let(:facts) do
         facts.merge({

--- a/spec/classes/puppet_agent_config_spec.rb
+++ b/spec/classes/puppet_agent_config_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'puppet::agent::config' do
 
   on_supported_os.each do |os, facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let(:facts) do
         facts.merge({

--- a/spec/classes/puppet_agent_install_spec.rb
+++ b/spec/classes/puppet_agent_install_spec.rb
@@ -1,46 +1,103 @@
 require 'spec_helper'
 
 describe 'puppet::agent::install' do
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :concat_basedir         => '/nonexistant',
+          :puppetversion          => Puppet.version,
+      }) end
 
-  if Puppet.version < '4.0'
-    additional_facts = {}
-  else
-    additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+      if Puppet.version < '4.0'
+        client_package = 'puppet'
+        additional_facts = {}
+      else
+        client_package = 'puppet-agent'
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+      end
+
+      let (:facts) do
+        default_facts.merge(additional_facts)
+      end
+
+      describe 'with default parameters' do
+        let :pre_condition do
+          'include ::puppet'
+        end
+
+        it 'should not define provider' do
+          should contain_package(client_package).without_provider(nil)
+        end
+      end
+
+      describe "when manage_packages => false" do
+        let :pre_condition do
+          "class { 'puppet': manage_packages => false }"
+        end
+
+        it 'should not contain Package[puppet]' do
+          should_not contain_package('puppet')
+        end
+
+        it 'should not contain Package[puppet-agent]' do
+          should_not contain_package('puppet-agent')
+        end
+      end
+
+      describe "when manage_packages => 'agent'" do
+        let :pre_condition do
+          "class { 'puppet': manage_packages => 'agent' }"
+        end
+
+        it 'should contain Package[puppet]' do
+          should contain_package(client_package)
+        end
+      end
+
+      describe "when manage_packages => 'server'" do
+        let :pre_condition do
+          "class { 'puppet': manage_packages => 'server' }"
+        end
+
+        it 'should not contain Package[puppet]' do
+          should_not contain_package('puppet')
+        end
+
+        it 'should not contain Package[puppet-agent]' do
+          should_not contain_package('puppet-agent')
+        end
+      end
+
+    end
   end
 
-  let :common_centos_facts do on_supported_os['centos-6-x86_64'].merge({
-    :concat_basedir => '/nonexistant',
-    :puppetversion  => Puppet.version,
-  }).merge(additional_facts) end
-
-  describe 'with default parameters' do
-    let :pre_condition do
-      'include ::puppet'
+  # Windows is currently not supported by rspec-puppet-facts
+  context "on Windows" do
+    let :default_facts do
+      {
+        :osfamily => 'windows',
+        :concat_basedir => 'C:\Temp',
+        :puppetversion => Puppet.version,
+      }
     end
 
     if Puppet.version < '4.0'
       client_package = 'puppet'
+      additional_facts = {}
     else
       client_package = 'puppet-agent'
+      additional_facts = {}
     end
 
-    context "on a RedHat family OS" do
-      let :facts do
-        common_centos_facts
-      end
-
-      it 'should not define provider' do
-        should contain_package(client_package).without_provider(nil)
-      end
+    let (:facts) do
+      default_facts.merge(additional_facts)
     end
 
-    context "on a Windows family OS" do
-      let :facts do
-        {
-          :osfamily => 'windows',
-          :concat_basedir => 'C:\Temp',
-          :puppetversion => Puppet.version,
-        }
+    describe 'with default parameters' do
+      let :pre_condition do
+        'include ::puppet'
       end
 
       it 'should define provider as chocolatey' do
@@ -48,123 +105,29 @@ describe 'puppet::agent::install' do
       end
     end
 
-  end
-
-  describe "when package_provider => 'msi'" do
-
-    if Puppet.version < '4.0'
-      client_package = 'puppet'
-    else
-      client_package = 'puppet-agent'
-    end
-
-    let :pre_condition do
-      "class { 'puppet': package_provider => 'msi', }"
-    end
-
-    let :facts do
-      {
-        :osfamily => 'windows',
-        :concat_basedir => 'C:\Temp',
-        :puppetversion => Puppet.version,
-      }
-    end
-
-    it 'should define provider as msi' do
-      should contain_package(client_package).with_provider('msi')
-    end
-
-  end
-
-  describe "when package_provider => 'windows' and source is defined" do
-
-    if Puppet.version < '4.0'
-      client_package = 'puppet'
-    else
-      client_package = 'puppet-agent'
-    end
-
-    let :pre_condition do
-      "class { 'puppet': package_provider => 'windows', package_source => 'C:\\Temp\\puppet.exe' }"
-    end
-
-    let :facts do
-      {
-        :osfamily => 'windows',
-        :concat_basedir => 'C:\Temp',
-        :puppetversion => Puppet.version,
-      }
-    end
-
-    it 'should define provider as windows' do
-      should contain_package(client_package).with_provider('windows')
-    end
-
-    it 'should define source as C:\Temp\puppet.exe' do
-      should contain_package(client_package).with_source('C:\Temp\puppet.exe')
-    end
-
-  end
-
-  describe "when manage_packages => false" do
-    let :pre_condition do
-      "class { 'puppet': manage_packages => false }"
-    end
-
-    context "on a RedHat family OS" do
-      let :facts do
-        common_centos_facts
+    describe "when package_provider => 'msi'" do
+      let :pre_condition do
+        "class { 'puppet': package_provider => 'msi', }"
       end
 
-      it 'should not contain Package[puppet]' do
-        should_not contain_package('puppet')
+      it 'should define provider as msi' do
+        should contain_package(client_package).with_provider('msi')
+      end
+    end
+
+    describe "when package_provider => 'windows' and source is defined" do
+      let :pre_condition do
+        "class { 'puppet': package_provider => 'windows', package_source => 'C:\\Temp\\puppet.exe' }"
       end
 
-      it 'should not contain Package[puppet-agent]' do
-        should_not contain_package('puppet-agent')
+      it 'should define provider as windows' do
+        should contain_package(client_package).with_provider('windows')
+      end
+
+      it 'should define source as C:\Temp\puppet.exe' do
+        should contain_package(client_package).with_source('C:\Temp\puppet.exe')
       end
     end
   end
 
-  describe "when manage_packages => 'agent'" do
-    let :pre_condition do
-      "class { 'puppet': manage_packages => 'agent' }"
-    end
-
-    if Puppet.version < '4.0'
-      client_package = 'puppet'
-    else
-      client_package = 'puppet-agent'
-    end
-
-    context "on a RedHat family OS" do
-      let :facts do
-        common_centos_facts
-      end
-
-      it 'should contain Package[puppet]' do
-        should contain_package(client_package)
-      end
-    end
-  end
-
-  describe "when manage_packages => 'server'" do
-    let :pre_condition do
-      "class { 'puppet': manage_packages => 'server' }"
-    end
-
-    context "on a RedHat family OS" do
-      let :facts do
-        common_centos_facts
-      end
-
-      it 'should not contain Package[puppet]' do
-        should_not contain_package('puppet')
-      end
-
-      it 'should not contain Package[puppet-agent]' do
-        should_not contain_package('puppet-agent')
-      end
-    end
-  end
 end

--- a/spec/classes/puppet_agent_install_spec.rb
+++ b/spec/classes/puppet_agent_install_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::agent::install' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -1,105 +1,114 @@
 require 'spec_helper'
 
 describe 'puppet::agent::service' do
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :clientcert     => 'puppetmaster.example.com',
+          :concat_basedir => '/nonexistant',
+          :fqdn           => 'puppetmaster.example.com',
+          :puppetversion  => Puppet.version,
+      }) end
 
-  if Puppet.version < '4.0'
-    additional_facts = {}
-  else
-    additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-  end
-
-  let :facts do on_supported_os['centos-6-x86_64'].merge({
-    :clientcert     => 'puppetmaster.example.com',
-    :concat_basedir => '/nonexistant',
-    :fqdn           => 'puppetmaster.example.com',
-    :puppetversion  => Puppet.version,
-  }).merge(additional_facts) end
-
-  describe 'with no custom parameters' do
-    let :pre_condition do
-      "class {'puppet': agent => true}"
-    end
-
-    it do
-      should contain_service('puppet').with({
-        :ensure     => 'running',
-        :name       => 'puppet',
-        :hasstatus  => 'true',
-        :enable     => 'true',
-      })
-    end
-
-    it { should contain_cron('puppet').with_ensure('absent') }
-  end
-
-  describe 'when runmode => cron' do
-    let :pre_condition do
-      "class {'puppet': agent => true, runmode => 'cron'}"
-    end
-
-    it do
-      should contain_service('puppet').with({
-        :ensure     => 'stopped',
-        :name       => 'puppet',
-        :hasstatus  => 'true',
-        :enable     => 'false',
-      })
-    end
-
-    it do
       if Puppet.version < '4.0'
         confdir = '/etc/puppet'
+        additional_facts = {}
       else
         confdir = '/etc/puppetlabs/puppet'
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
-      should contain_cron('puppet').with({
-        :command  => "/usr/bin/env puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize",
-        :user     => 'root',
-        :minute   => ['15','45'],
-        :hour     => '*',
-      })
+
+      if os_facts[:osfamily] == 'FreeBSD'
+        confdir = '/usr/local/etc/puppet'
+      end
+
+      let :facts do
+        default_facts.merge(additional_facts)
+      end
+
+      describe 'with no custom parameters' do
+        let :pre_condition do
+          "class {'puppet': agent => true}"
+        end
+
+        it do
+          should contain_service('puppet').with({
+            :ensure     => 'running',
+            :name       => 'puppet',
+            :hasstatus  => 'true',
+            :enable     => 'true',
+          })
+        end
+
+        it { should contain_cron('puppet').with_ensure('absent') }
+      end
+
+      describe 'when runmode => cron' do
+        let :pre_condition do
+          "class {'puppet': agent => true, runmode => 'cron'}"
+        end
+
+        it do
+          should contain_service('puppet').with({
+            :ensure     => 'stopped',
+            :name       => 'puppet',
+            :hasstatus  => 'true',
+            :enable     => 'false',
+          })
+        end
+
+        it do
+          should contain_cron('puppet').with({
+            :command  => "/usr/bin/env puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize",
+            :user     => 'root',
+            :minute   => ['15','45'],
+            :hour     => '*',
+          })
+        end
+      end
+
+      describe 'when runmode => none' do
+        let :pre_condition do
+          "class {'puppet': agent => true, runmode => 'none'}"
+        end
+
+        it do
+          should contain_service('puppet').with({
+            :ensure     => 'stopped',
+            :name       => 'puppet',
+            :hasstatus  => 'true',
+            :enable     => 'false',
+          })
+        end
+
+        it { should contain_cron('puppet').with_ensure('absent') }
+      end
+
+      describe 'when runmode => foo' do
+        let :pre_condition do
+          "class {'puppet': agent => true, runmode => 'foo'}"
+        end
+
+        it { should raise_error(Puppet::Error, /Runmode of foo not supported by puppet::agent::config!/) }
+      end
+
+      describe 'with custom service_name' do
+        let :pre_condition do
+          "class {'puppet': agent => true, service_name => 'pe-puppet'}"
+        end
+
+        it do
+          should contain_service('puppet').with({
+            :ensure     => 'running',
+            :name       => 'pe-puppet',
+            :hasstatus  => 'true',
+            :enable     => 'true',
+          })
+        end
+
+      end
     end
   end
-
-  describe 'when runmode => none' do
-    let :pre_condition do
-      "class {'puppet': agent => true, runmode => 'none'}"
-    end
-
-    it do
-      should contain_service('puppet').with({
-        :ensure     => 'stopped',
-        :name       => 'puppet',
-        :hasstatus  => 'true',
-        :enable     => 'false',
-      })
-    end
-
-    it { should contain_cron('puppet').with_ensure('absent') }
-  end
-
-  describe 'when runmode => foo' do
-    let :pre_condition do
-      "class {'puppet': agent => true, runmode => 'foo'}"
-    end
-
-    it { should raise_error(Puppet::Error, /Runmode of foo not supported by puppet::agent::config!/) }
-  end
-
-  describe 'with custom service_name' do
-    let :pre_condition do
-      "class {'puppet': agent => true, service_name => 'pe-puppet'}"
-    end
-
-    it do
-      should contain_service('puppet').with({
-        :ensure     => 'running',
-        :name       => 'pe-puppet',
-        :hasstatus  => 'true',
-        :enable     => 'true',
-      })
-    end
-
-  end
-
 end

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::agent::service' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::agent' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -1,130 +1,136 @@
 require 'spec_helper'
 
 describe 'puppet::agent' do
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :clientcert => 'puppetmaster.example.com',
+          :concat_basedir => '/nonexistant',
+          :fqdn => 'puppetmaster.example.com',
+          :puppetversion => Puppet.version,
+      }) end
 
-  let :default_facts do
-    on_supported_os['centos-6-x86_64'].merge({
-        :clientcert => 'puppetmaster.example.com',
-        :concat_basedir => '/nonexistant',
-        :fqdn => 'puppetmaster.example.com',
-        :puppetversion => Puppet.version,
-    })
+      if Puppet.version < '4.0'
+        client_package = 'puppet'
+        confdir        = '/etc/puppet'
+        additional_facts = {}
+      else
+        client_package = 'puppet-agent'
+        confdir        = '/etc/puppetlabs/puppet'
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+      end
+
+      if os_facts[:osfamily] == 'FreeBSD'
+        confdir = '/usr/local/etc/puppet'
+      end
+
+      let :facts do
+        default_facts.merge(additional_facts)
+      end
+
+      describe 'with no custom parameters' do
+        let :pre_condition do
+          "class {'puppet': agent => true}"
+        end
+        it { should contain_class('puppet::agent::install') }
+        it { should contain_class('puppet::agent::config') }
+        it { should contain_class('puppet::agent::service') }
+        it { should contain_file(confdir).with_ensure('directory') }
+        it { should contain_concat("#{confdir}/puppet.conf") }
+        it { should contain_package(client_package).with_ensure('present') }
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+            with_content(/^\[agent\]/).
+            with({})
+        end
+
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+                     with_content(/server.*puppetmaster\.example\.com/)
+        end
+
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+            without_content(/prerun_command\s*=/)
+        end
+
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+            without_content(/postrun_command\s*=/)
+        end
+      end
+
+      describe 'puppetmaster parameter overrides server fqdn' do
+        let(:pre_condition) { "class {'puppet': agent => true, puppetmaster => 'mymaster.example.com'}" }
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+                     with_content(/server.*mymaster\.example\.com/)
+        end
+      end
+
+      describe 'global puppetmaster overrides fqdn' do
+        let(:pre_condition) { "class {'puppet': agent => true}" }
+        let :facts do
+          default_facts.merge({:puppetmaster => 'mymaster.example.com'})
+        end
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+                     with_content(/server.*mymaster\.example\.com/)
+        end
+      end
+
+      describe 'puppetmaster parameter overrides global puppetmaster' do
+        let(:pre_condition) { "class {'puppet': agent => true, puppetmaster => 'mymaster.example.com'}" }
+        let :facts do
+          default_facts.merge({:puppetmaster => 'global.example.com'})
+        end
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+                     with_content(/server.*mymaster\.example\.com/)
+        end
+      end
+
+      describe 'use_srv_records removes server setting' do
+        let(:pre_condition) { "class {'puppet': agent => true, use_srv_records => true}" }
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+                     without_content(/server\s*=/)
+        end
+      end
+
+      describe 'set prerun_command will be included in config' do
+        let(:pre_condition) { "class {'puppet': agent => true, prerun_command => '/my/prerun'}" }
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+            with_content(/prerun_command.*\/my\/prerun/)
+        end
+      end
+
+      describe 'set postrun_command will be included in config' do
+        let(:pre_condition) { "class {'puppet': agent => true, postrun_command => '/my/postrun'}" }
+        it do
+          should contain_concat__fragment('puppet.conf+20-agent').
+            with_content(/postrun_command.*\/my\/postrun/)
+        end
+      end
+
+      describe 'with additional settings' do
+        let :pre_condition do
+          "class {'puppet':
+              agent_additional_settings => {ignoreschedules => true},
+           }"
+        end
+
+        it 'should configure puppet.conf' do
+          should contain_concat__fragment('puppet.conf+20-agent').
+            with_content(/^\s+ignoreschedules\s+= true$/).
+            with({}) # So we can use a trailing dot on each with_content line
+        end
+      end
+
+    end
   end
-
-  let :facts do
-    if Puppet.version < '4.0'
-      default_facts
-    else
-      default_facts.merge({:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'})
-    end
-  end
-
-  describe 'with no custom parameters' do
-    let :pre_condition do
-      "class {'puppet': agent => true}"
-    end
-    if Puppet.version < '4.0'
-      client_package = 'puppet'
-      confdir        = '/etc/puppet'
-    else
-      client_package = 'puppet-agent'
-      confdir        = '/etc/puppetlabs/puppet'
-    end
-    it { should contain_class('puppet::agent::install') }
-    it { should contain_class('puppet::agent::config') }
-    it { should contain_class('puppet::agent::service') }
-    it { should contain_file(confdir).with_ensure('directory') }
-    it { should contain_concat("#{confdir}/puppet.conf") }
-    it { should contain_package(client_package).with_ensure('present') }
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-        with_content(/^\[agent\]/).
-        with({})
-    end
-
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-                 with_content(/server.*puppetmaster\.example\.com/)
-    end
-
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-        without_content(/prerun_command\s*=/)
-    end
-
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-        without_content(/postrun_command\s*=/)
-    end
-  end
-
-  describe 'puppetmaster parameter overrides server fqdn' do
-    let(:pre_condition) { "class {'puppet': agent => true, puppetmaster => 'mymaster.example.com'}" }
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-                 with_content(/server.*mymaster\.example\.com/)
-    end
-  end
-
-  describe 'global puppetmaster overrides fqdn' do
-    let(:pre_condition) { "class {'puppet': agent => true}" }
-    let :facts do
-      default_facts.merge({:puppetmaster => 'mymaster.example.com'})
-    end
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-                 with_content(/server.*mymaster\.example\.com/)
-    end
-  end
-
-  describe 'puppetmaster parameter overrides global puppetmaster' do
-    let(:pre_condition) { "class {'puppet': agent => true, puppetmaster => 'mymaster.example.com'}" }
-    let :facts do
-      default_facts.merge({:puppetmaster => 'global.example.com'})
-    end
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-                 with_content(/server.*mymaster\.example\.com/)
-    end
-  end
-
-  describe 'use_srv_records removes server setting' do
-    let(:pre_condition) { "class {'puppet': agent => true, use_srv_records => true}" }
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-                 without_content(/server\s*=/)
-    end
-  end
-
-  describe 'set prerun_command will be included in config' do
-    let(:pre_condition) { "class {'puppet': agent => true, prerun_command => '/my/prerun'}" }
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-        with_content(/prerun_command.*\/my\/prerun/)
-    end
-  end
-
-  describe 'set postrun_command will be included in config' do
-    let(:pre_condition) { "class {'puppet': agent => true, postrun_command => '/my/postrun'}" }
-    it do
-      should contain_concat__fragment('puppet.conf+20-agent').
-        with_content(/postrun_command.*\/my\/postrun/)
-    end
-  end
-
-  describe 'with additional settings' do
-    let :pre_condition do
-      "class {'puppet':
-          agent_additional_settings => {ignoreschedules => true},
-       }"
-    end
-
-    it 'should configure puppet.conf' do
-      should contain_concat__fragment('puppet.conf+20-agent').
-        with_content(/^\s+ignoreschedules\s+= true$/).
-        with({}) # So we can use a trailing dot on each with_content line
-    end
-  end
-
 end
 

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -1,344 +1,276 @@
 require 'spec_helper'
 
 describe 'puppet::config' do
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :concat_basedir         => '/foo/bar',
+          :domain                 => 'example.org',
+          :fqdn                   => 'host.example.com',
+          :puppetversion          => Puppet.version,
+      }) end
 
-  context "on a RedHat family OS" do
-    let :default_facts do on_supported_os['centos-6-x86_64'].merge({
-      :concat_basedir         => '/foo/bar',
-      :domain                 => 'example.org',
-      :fqdn                   => 'host.example.com',
-      :puppetversion          => Puppet.version,
-    }) end
-
-    if Puppet.version < '4.0'
-      codedir = '/etc/puppet'
-      confdir = '/etc/puppet'
-      logdir  = '/var/log/puppet'
-      rundir  = '/var/run/puppet'
-      ssldir  = '/var/lib/puppet/ssl'
-      vardir  = '/var/lib/puppet'
-      additional_facts = {}
-    else
-      codedir = '/etc/puppetlabs/code'
-      confdir = '/etc/puppetlabs/puppet'
-      logdir  = '/var/log/puppetlabs/puppet'
-      rundir  = '/var/run/puppetlabs'
-      ssldir  = '/etc/puppetlabs/puppet/ssl'
-      vardir  = '/opt/puppetlabs/puppet/cache'
-      additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-    end
-
-    let :facts do
-      default_facts.merge(additional_facts)
-    end
-
-    describe 'with default parameters' do
-      let :pre_condition do
-        'include ::puppet'
+      if Puppet.version < '4.0'
+        codedir = '/etc/puppet'
+        confdir = '/etc/puppet'
+        logdir  = '/var/log/puppet'
+        rundir  = '/var/run/puppet'
+        ssldir  = '/var/lib/puppet/ssl'
+        vardir  = '/var/lib/puppet'
+        sharedir = '/usr/share/puppet'
+        additional_facts = {}
+      else
+        codedir = '/etc/puppetlabs/code'
+        confdir = '/etc/puppetlabs/puppet'
+        logdir  = '/var/log/puppetlabs/puppet'
+        rundir  = '/var/run/puppetlabs'
+        ssldir  = '/etc/puppetlabs/puppet/ssl'
+        vardir  = '/opt/puppetlabs/puppet/cache'
+        sharedir = '/opt/puppetlabs/puppet'
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
-      it 'should contain auth.conf' do
-        should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
+      if os_facts[:osfamily] == 'FreeBSD'
+        codedir = '/usr/local/etc/puppet'
+        confdir = '/usr/local/etc/puppet'
+        logdir  = '/var/log/puppet'
+        rundir  = '/var/run/puppet'
+        ssldir  = '/var/puppet/ssl'
+        vardir  = '/var/puppet'
+        sharedir = '/usr/local/share/puppet'
       end
 
-      it 'should_not contain default_manifest setting in puppet.conf' do
-        should_not contain_concat__fragment('puppet.conf+10-main').with_content(/\s+default_manifest = .*/)
+      let :facts do
+        default_facts.merge(additional_facts)
       end
 
-      it 'should_not contain default manifest /etc/puppet/manifests/default_manifest.pp' do
-        should_not contain_file('/etc/puppet/manifests/default_manifest.pp')
-      end
-
-      it 'should contain puppet.conf [main]' do
-        concat_fragment_content = [
-          '[main]',
-          "    vardir = #{vardir}",
-          "    logdir = #{logdir}",
-          "    rundir = #{rundir}",
-          "    ssldir = #{ssldir}",
-          '    privatekeydir = $ssldir/private_keys { group = service }',
-          '    hostprivkey = $privatekeydir/$certname.pem { mode = 640 }',
-          '    autosign       = $confdir/autosign.conf { mode = 664 }',
-          '    show_diff     = false',
-          '    hiera_config = $confdir/hiera.yaml'
-        ]
-        if Puppet.version >= '3.6' and Puppet.version < '4.0'
-          concat_fragment_content.concat([
-            '    environmentpath  = /etc/puppet/environments',
-            '    basemodulepath   = /etc/puppet/environments/common:/etc/puppet/modules:/usr/share/puppet/modules',
-          ])
-        elsif Puppet.version >= '4.0'
-          concat_fragment_content.concat([
-            '    environmentpath  = /etc/puppetlabs/code/environments',
-            '    basemodulepath   = /etc/puppetlabs/code/environments/common:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules',
-          ])
+      describe 'with default parameters' do
+        let :pre_condition do
+          'include ::puppet'
         end
-        verify_concat_fragment_exact_contents(catalogue, 'puppet.conf+10-main', concat_fragment_content)
-      end
-    end
 
-    describe 'with server_default_manifest => true and undef content' do
-      let :pre_condition do
-        'class { "::puppet": server_default_manifest => true }'
-      end
+        it 'should contain auth.conf' do
+          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
+        end
 
-      it 'should contain default_manifest setting in puppet.conf' do
-        should contain_concat__fragment('puppet.conf+10-main').with_content(/\s+default_manifest = \/etc\/puppet\/manifests\/default_manifest\.pp$/)
-      end
+        it 'should_not contain default_manifest setting in puppet.conf' do
+          should_not contain_concat__fragment('puppet.conf+10-main').with_content(/\s+default_manifest = .*/)
+        end
 
-      it 'should_not contain default manifest /etc/puppet/manifests/default_manifest.pp' do
-        should_not contain_file('/etc/puppet/manifests/default_manifest.pp')
-      end
-    end
+        it 'should_not contain default manifest /etc/puppet/manifests/default_manifest.pp' do
+          should_not contain_file('/etc/puppet/manifests/default_manifest.pp')
+        end
 
-    describe 'with server_default_manifest => true and server_default_manifest_content => "include foo"' do
-      let :pre_condition do
-        'class { "::puppet": server_default_manifest => true, server_default_manifest_content => "include foo" }'
-      end
-
-      it 'should contain default_manifest setting in puppet.conf' do
-        should contain_concat__fragment('puppet.conf+10-main').with_content(/\s+default_manifest = \/etc\/puppet\/manifests\/default_manifest\.pp$/)
-      end
-
-      it 'should contain default manifest /etc/puppet/manifests/default_manifest.pp' do
-        should contain_file('/etc/puppet/manifests/default_manifest.pp').with_content(/include foo/)
-      end
-    end
-
-    describe 'with allow_any_crl_auth' do
-      let :pre_condition do
-        'class {"::puppet": allow_any_crl_auth => true}'
-      end
-
-      it 'should contain auth.conf with auth any' do
-        should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nauth any$})
-      end
-    end
-
-    describe 'with auth_allowed' do
-      let :pre_condition do
-        'class {"::puppet": auth_allowed => [\'$1\', \'puppetproxy\']}'
-      end
-
-      it 'should contain auth.conf with allow' do
-        should contain_file("#{confdir}/auth.conf").with_content(%r{^allow \$1, puppetproxy$})
-      end
-    end
-
-    context "when autosign => true" do
-      let :pre_condition do
-        'class { "::puppet": autosign => true }'
-      end
-
-      it 'should contain puppet.conf [main] with autosign = true' do
-        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
-          '[main]',
-          '    autosign       = true',
-        ])
-      end
-    end
-
-    context 'when autosign => $confdir/custom_autosign {mode = 664}' do
-      let :pre_condition do
-        %q{class { "::puppet": autosign => '$confdir/custom_autosign {mode = 664}'}}
-      end
-
-      it 'should contain puppet.conf [main] with autosign = $confdir/custom_autosign {mode = 664}' do
-        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
-          '[main]',
-          '    autosign       = $confdir/custom_autosign {mode = 664}',
-        ])
-      end
-    end
-
-    context "when dns_alt_names => ['foo','bar']" do
-      let :pre_condition do
-        "class { 'puppet': dns_alt_names => ['foo','bar'] }"
-      end
-
-      it 'should contain puppet.conf [main] with dns_alt_names' do
-        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
-          '[main]',
-          '    dns_alt_names = foo,bar',
-        ])
-      end
-    end
-
-    context "when syslogfacility => 'local6'" do
-      let :pre_condition do
-        "class { 'puppet': syslogfacility => 'local6' }"
-      end
-
-      it 'should contain puppet.conf [main] with syslogfacility' do
-        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
-          '[main]',
-          '    syslogfacility = local6',
-        ])
-      end
-    end
-
-    context "when module_repository => 'https://myforgeapi.example.com'" do
-      let :pre_condition do
-        "class { 'puppet': module_repository => 'https://myforgeapi.example.com' }"
-      end
-
-      it 'should contain puppet.conf [main] with module_repository' do
-        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
-          '[main]',
-          '    module_repository = https://myforgeapi.example.com',
-        ])
-      end
-    end
-
-    context "when hiera_config => '$confdir/hiera.yaml'" do
-      let :pre_condition do
-        "class { 'puppet': hiera_config => '/etc/puppet/hiera/production/hiera.yaml' }"
-      end
-
-      it 'should contain puppet.conf [main] with non-default hiera_config' do
-        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
-          '[main]',
-          '    hiera_config = /etc/puppet/hiera/production/hiera.yaml',
-        ])
-      end
-    end
-
-    context "when use_srv_records => true" do
-      let :pre_condition do
-        "class { 'puppet': use_srv_records => true }"
-      end
-
-      it 'should contain puppet.conf [main] with SRV settings' do
-        verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
-          '[main]',
-          '    use_srv_records = true',
-          '    srv_domain = example.org',
-          '    pluginsource = puppet:///plugins',
-          '    pluginfactsource = puppet:///pluginfacts',
-        ])
-      end
-    end
-
-    describe 'when listen and listen_to has values' do
-      let :pre_condition do
-        'class {"::puppet": listen => true, listen_to => ["node1.example.com","node2.example.com",],}'
-      end
-
-      it 'should contain auth.conf with auth any' do
-        should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow node1.example.com,node2.example.com$})
-      end
-    end
-
-    describe 'when listen and puppetmaster has value' do
-      let :pre_condition do
-        'class {"::puppet": listen => true, puppetmaster => "master.example.com",}'
-      end
-
-      it 'should contain auth.conf with auth any' do
-        should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow master.example.com$})
-      end
-    end
-
-    describe 'when listen => true and default value is used' do
-      let :pre_condition do
-        'class {"::puppet": listen => true}'
-      end
-
-      it 'should contain auth.conf with auth any' do
-        should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow #{facts[:fqdn]}$})
+        it 'should contain puppet.conf [main]' do
+          concat_fragment_content = [
+            '[main]',
+            "    vardir = #{vardir}",
+            "    logdir = #{logdir}",
+            "    rundir = #{rundir}",
+            "    ssldir = #{ssldir}",
+            '    privatekeydir = $ssldir/private_keys { group = service }',
+            '    hostprivkey = $privatekeydir/$certname.pem { mode = 640 }',
+            '    autosign       = $confdir/autosign.conf { mode = 664 }',
+            '    show_diff     = false',
+            '    hiera_config = $confdir/hiera.yaml'
+          ]
+          concat_fragment_content.concat([
+            "    environmentpath  = #{codedir}/environments",
+            "    basemodulepath   = #{codedir}/environments/common:#{codedir}/modules:#{sharedir}/modules",
+          ])
+          verify_concat_fragment_exact_contents(catalogue, 'puppet.conf+10-main', concat_fragment_content)
         end
       end
 
-    describe 'with additional settings' do
-      let :pre_condition do
-        "class {'puppet':
-            additional_settings => {disable_warnings => deprecations},
-         }"
+      describe 'with server_default_manifest => true and undef content' do
+        let :pre_condition do
+          'class { "::puppet": server_default_manifest => true }'
+        end
+
+        it 'should contain default_manifest setting in puppet.conf' do
+          should contain_concat__fragment('puppet.conf+10-main').with_content(/\s+default_manifest = \/etc\/puppet\/manifests\/default_manifest\.pp$/)
+        end
+
+        it 'should_not contain default manifest /etc/puppet/manifests/default_manifest.pp' do
+          should_not contain_file('/etc/puppet/manifests/default_manifest.pp')
+        end
       end
 
-      it 'should configure puppet.conf' do
-        should contain_concat__fragment('puppet.conf+10-main').
-          with_content(/^\s+disable_warnings\s+= deprecations$/).
-          with({}) # So we can use a trailing dot on each with_content line
-      end
-    end
-  end
+      describe 'with server_default_manifest => true and server_default_manifest_content => "include foo"' do
+        let :pre_condition do
+          'class { "::puppet": server_default_manifest => true, server_default_manifest_content => "include foo" }'
+        end
 
-  context "on a FreeBSD family OS" do
-    let :facts do on_supported_os['freebsd-10-amd64'].merge({
-      :concat_basedir => '/foo/bar',
-      :domain   => 'example.org',
-      :puppetversion => Puppet.version,
-    }) end
+        it 'should contain default_manifest setting in puppet.conf' do
+          should contain_concat__fragment('puppet.conf+10-main').with_content(/\s+default_manifest = \/etc\/puppet\/manifests\/default_manifest\.pp$/)
+        end
 
-    describe 'with default parameters' do
-      let :pre_condition do
-        'include ::puppet'
+        it 'should contain default manifest /etc/puppet/manifests/default_manifest.pp' do
+          should contain_file('/etc/puppet/manifests/default_manifest.pp').with_content(/include foo/)
+        end
       end
 
-      it 'should contain auth.conf' do
-        should contain_file('/usr/local/etc/puppet/auth.conf').with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
+      describe 'with allow_any_crl_auth' do
+        let :pre_condition do
+          'class {"::puppet": allow_any_crl_auth => true}'
+        end
+
+        it 'should contain auth.conf with auth any' do
+          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nauth any$})
+        end
       end
 
-      it 'should_not contain default_manifest setting in puppet.conf' do
-        should_not contain_concat__fragment('puppet.conf+10-main').with_content(/default_manifest = .*/)
+      describe 'with auth_allowed' do
+        let :pre_condition do
+          'class {"::puppet": auth_allowed => [\'$1\', \'puppetproxy\']}'
+        end
+
+        it 'should contain auth.conf with allow' do
+          should contain_file("#{confdir}/auth.conf").with_content(%r{^allow \$1, puppetproxy$})
+        end
       end
 
-      it 'should_not contain default manifest /etc/puppet/manifests/default_manifest.pp' do
-        should_not contain_file('/etc/puppet/manifests/default_manifest.pp')
-      end
+      describe "when autosign => true" do
+        let :pre_condition do
+          'class { "::puppet": autosign => true }'
+        end
 
-      it 'should contain puppet.conf [main]' do
-        concat_fragment_content = [
-          '[main]',
-          '    vardir = /var/puppet',
-          '    logdir = /var/log/puppet',
-          '    rundir = /var/run/puppet',
-          '    ssldir = /var/puppet/ssl',
-          '    privatekeydir = $ssldir/private_keys { group = service }',
-          '    hostprivkey = $privatekeydir/$certname.pem { mode = 640 }',
-          '    autosign       = $confdir/autosign.conf { mode = 664 }',
-          '    show_diff     = false',
-          '    hiera_config = $confdir/hiera.yaml'
-        ]
-        if Puppet.version >= '3.6'
-          concat_fragment_content.concat([
-            '    environmentpath  = /usr/local/etc/puppet/environments',
-            '    basemodulepath   = /usr/local/etc/puppet/environments/common:/usr/local/etc/puppet/modules:/usr/local/share/puppet/modules',
+        it 'should contain puppet.conf [main] with autosign = true' do
+          verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+            '[main]',
+            '    autosign       = true',
           ])
         end
-        verify_concat_fragment_exact_contents(catalogue, 'puppet.conf+10-main', concat_fragment_content)
       end
+
+      describe 'when autosign => $confdir/custom_autosign {mode = 664}' do
+        let :pre_condition do
+          %q{class { "::puppet": autosign => '$confdir/custom_autosign {mode = 664}'}}
+        end
+
+        it 'should contain puppet.conf [main] with autosign = $confdir/custom_autosign {mode = 664}' do
+          verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+            '[main]',
+            '    autosign       = $confdir/custom_autosign {mode = 664}',
+          ])
+        end
+      end
+
+      describe "when dns_alt_names => ['foo','bar']" do
+        let :pre_condition do
+          "class { 'puppet': dns_alt_names => ['foo','bar'] }"
+        end
+
+        it 'should contain puppet.conf [main] with dns_alt_names' do
+          verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+            '[main]',
+            '    dns_alt_names = foo,bar',
+          ])
+        end
+      end
+
+      describe "when syslogfacility => 'local6'" do
+        let :pre_condition do
+          "class { 'puppet': syslogfacility => 'local6' }"
+        end
+
+        it 'should contain puppet.conf [main] with syslogfacility' do
+          verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+            '[main]',
+            '    syslogfacility = local6',
+          ])
+        end
+      end
+
+      describe "when module_repository => 'https://myforgeapi.example.com'" do
+        let :pre_condition do
+          "class { 'puppet': module_repository => 'https://myforgeapi.example.com' }"
+        end
+
+        it 'should contain puppet.conf [main] with module_repository' do
+          verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+            '[main]',
+            '    module_repository = https://myforgeapi.example.com',
+          ])
+        end
+      end
+
+      describe "when hiera_config => '$confdir/hiera.yaml'" do
+        let :pre_condition do
+          "class { 'puppet': hiera_config => '/etc/puppet/hiera/production/hiera.yaml' }"
+        end
+
+        it 'should contain puppet.conf [main] with non-default hiera_config' do
+          verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+            '[main]',
+            '    hiera_config = /etc/puppet/hiera/production/hiera.yaml',
+          ])
+        end
+      end
+
+      describe "when use_srv_records => true" do
+        let :pre_condition do
+          "class { 'puppet': use_srv_records => true }"
+        end
+
+        it 'should contain puppet.conf [main] with SRV settings' do
+          verify_concat_fragment_contents(catalogue, 'puppet.conf+10-main', [
+            '[main]',
+            '    use_srv_records = true',
+            '    srv_domain = example.org',
+            '    pluginsource = puppet:///plugins',
+            '    pluginfactsource = puppet:///pluginfacts',
+          ])
+        end
+      end
+
+      describe 'when listen and listen_to has values' do
+        let :pre_condition do
+          'class {"::puppet": listen => true, listen_to => ["node1.example.com","node2.example.com",],}'
+        end
+
+        it 'should contain auth.conf with auth any' do
+          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow node1.example.com,node2.example.com$})
+        end
+      end
+
+      describe 'when listen and puppetmaster has value' do
+        let :pre_condition do
+          'class {"::puppet": listen => true, puppetmaster => "master.example.com",}'
+        end
+
+        it 'should contain auth.conf with auth any' do
+          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow master.example.com$})
+        end
+      end
+
+      describe 'when listen => true and default value is used' do
+        let :pre_condition do
+          'class {"::puppet": listen => true}'
+        end
+
+        it 'should contain auth.conf with auth any' do
+          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow #{facts[:fqdn]}$})
+        end
+      end
+
+      describe 'with additional settings' do
+        let :pre_condition do
+          "class {'puppet':
+              additional_settings => {disable_warnings => deprecations},
+           }"
+        end
+
+        it 'should configure puppet.conf' do
+          should contain_concat__fragment('puppet.conf+10-main').
+            with_content(/^\s+disable_warnings\s+= deprecations$/).
+            with({}) # So we can use a trailing dot on each with_content line
+        end
+      end
+
     end
-
-    describe 'with server_default_manifest => true and undef content' do
-      let :pre_condition do
-        'class { "::puppet": server_default_manifest => true }'
-      end
-
-      it 'should contain default_manifest setting in puppet.conf' do
-        should contain_concat__fragment('puppet.conf+10-main').with_content(/\s+default_manifest = \/etc\/puppet\/manifests\/default_manifest\.pp$/)
-      end
-
-      it 'should_not contain default manifest /etc/puppet/manifests/default_manifest.pp' do
-        should_not contain_file('/etc/puppet/manifests/default_manifest.pp')
-      end
-    end
-
-    describe 'with server_default_manifest => true and server_default_manifest_content => "include foo"' do
-      let :pre_condition do
-        'class { "::puppet": server_default_manifest => true, server_default_manifest_content => "include foo" }'
-      end
-
-      it 'should contain default_manifest setting in puppet.conf' do
-        should contain_concat__fragment('puppet.conf+10-main').with_content(/\s+default_manifest = \/etc\/puppet\/manifests\/default_manifest\.pp$/)
-      end
-
-      it 'should contain default manifest /etc/puppet/manifests/default_manifest.pp' do
-        should contain_file('/etc/puppet/manifests/default_manifest.pp').with_content(/include foo/)
-      end
-    end
-
   end
 
   context "on a Windows family OS" do

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -77,10 +77,12 @@ describe 'puppet::config' do
             '    show_diff     = false',
             '    hiera_config = $confdir/hiera.yaml'
           ]
-          concat_fragment_content.concat([
-            "    environmentpath  = #{codedir}/environments",
-            "    basemodulepath   = #{codedir}/environments/common:#{codedir}/modules:#{sharedir}/modules",
-          ])
+          if Puppet.version >= '3.6'
+              concat_fragment_content.concat([
+                "    environmentpath  = #{codedir}/environments",
+                "    basemodulepath   = #{codedir}/environments/common:#{codedir}/modules:#{sharedir}/modules",
+              ])
+          end
           verify_concat_fragment_exact_contents(catalogue, 'puppet.conf+10-main', concat_fragment_content)
         end
       end

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::config' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -1,12 +1,15 @@
 require 'spec_helper'
 
 describe 'puppet' do
-  context 'on RedHat' do
-      let :default_facts do on_supported_os['centos-6-x86_64'].merge({
-        :clientcert             => 'puppetmaster.example.com',
-        :concat_basedir         => '/nonexistant',
-        :fqdn                   => 'puppetmaster.example.com',
-        :puppetversion          => Puppet.version,
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do 
+        os_facts.merge({
+          :clientcert             => 'puppetmaster.example.com',
+          :concat_basedir         => '/nonexistant',
+          :fqdn                   => 'puppetmaster.example.com',
+          :puppetversion          => Puppet.version,
       }) end
 
       if Puppet.version < '4.0'
@@ -21,6 +24,11 @@ describe 'puppet' do
         additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
+      if os_facts[:osfamily] == 'FreeBSD'
+        puppet_directory = '/usr/local/etc/puppet'
+        puppet_concat    = '/usr/local/etc/puppet/puppet.conf'
+      end
+
       let :facts do
         default_facts.merge(additional_facts)
       end
@@ -28,13 +36,13 @@ describe 'puppet' do
       describe 'with no custom parameters' do
         it { should contain_class('puppet::config') }
         if Puppet.version < '4.0'
-          it { should contain_file('/etc/puppet').with_ensure('directory') }
-          it { should contain_concat('/etc/puppet/puppet.conf') }
-          it { should contain_package('puppet').with_ensure('present') }
+          it { should contain_file(puppet_directory).with_ensure('directory') }
+          it { should contain_concat(puppet_concat) }
+          it { should contain_package(puppet_package).with_ensure('present') }
         else
-          it { should contain_file('/etc/puppetlabs/puppet').with_ensure('directory') }
-          it { should contain_concat('/etc/puppetlabs/puppet/puppet.conf') }
-          it { should contain_package('puppet-agent').with_ensure('present') }
+          it { should contain_file(puppet_directory).with_ensure('directory') }
+          it { should contain_concat(puppet_concat) }
+          it { should contain_package(puppet_package).with_ensure('present') }
         end
       end
 
@@ -127,6 +135,7 @@ describe 'puppet' do
           it { should raise_error(Puppet::Error, /does not match "\^\[0-9\]\+\[kKmMgG\]\$"/) }
         end
       end
+    end
   end
 
   context 'on Windows' do

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do 
         os_facts.merge({

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -1,475 +1,495 @@
 require 'spec_helper'
 
 describe 'puppet::server::config' do
-  let :default_facts do on_supported_os['centos-6-x86_64'].merge({
-    :clientcert             => 'puppetmaster.example.com',
-    :concat_basedir         => '/nonexistant',
-    :fqdn                   => 'puppetmaster.example.com',
-    :rubyversion            => '1.9.3',
-    :puppetversion          => Puppet.version,
-  }) end
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :clientcert             => 'puppetmaster.example.com',
+          :concat_basedir         => '/nonexistant',
+          :fqdn                   => 'puppetmaster.example.com',
+          :rubyversion            => '1.9.3',
+          :puppetversion          => Puppet.version,
+      }) end
 
-  if Puppet.version < '4.0'
-    codedir          = '/etc/puppet'
-    conf_file        = '/etc/puppet/puppet.conf'
-    environments_dir = '/etc/puppet/environments'
-    logdir           = '/var/log/puppet'
-    rundir           = '/var/run/puppet'
-    vardir           = '/var/lib/puppet'
-    ssldir           = '/var/lib/puppet/ssl'
-    sharedir         = '/usr/share/puppet'
-    nodepath         = '\/etc\/puppet\/node.rb'
-    additional_facts = {}
-  else
-    codedir          = '/etc/puppetlabs/code'
-    conf_file        = '/etc/puppetlabs/puppet/puppet.conf'
-    environments_dir = '/etc/puppetlabs/code/environments'
-    logdir           = '/var/log/puppetlabs/puppet'
-    rundir           = '/var/run/puppetlabs'
-    vardir           = '/opt/puppetlabs/puppet/cache'
-    ssldir           = '/etc/puppetlabs/puppet/ssl'
-    sharedir         = '/opt/puppetlabs/puppet'
-    nodepath         = '\/etc\/puppetlabs\/puppet\/node.rb'
-    additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+      if Puppet.version < '4.0'
+        codedir          = '/etc/puppet'
+        conf_file        = '/etc/puppet/puppet.conf'
+        environments_dir = '/etc/puppet/environments'
+        logdir           = '/var/log/puppet'
+        rundir           = '/var/run/puppet'
+        vardir           = '/var/lib/puppet'
+        ssldir           = '/var/lib/puppet/ssl'
+        sharedir         = '/usr/share/puppet'
+        nodepath         = '\/etc\/puppet\/node.rb'
+        additional_facts = {}
+      else
+        codedir          = '/etc/puppetlabs/code'
+        conf_file        = '/etc/puppetlabs/puppet/puppet.conf'
+        environments_dir = '/etc/puppetlabs/code/environments'
+        logdir           = '/var/log/puppetlabs/puppet'
+        rundir           = '/var/run/puppetlabs'
+        vardir           = '/opt/puppetlabs/puppet/cache'
+        ssldir           = '/etc/puppetlabs/puppet/ssl'
+        sharedir         = '/opt/puppetlabs/puppet'
+        nodepath         = '\/etc\/puppetlabs\/puppet\/node.rb'
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+      end
+
+      if os_facts[:osfamily] == 'FreeBSD'
+        codedir          = '/usr/local/etc/puppet'
+        conf_file        = '/usr/local/etc/puppet/puppet.conf'
+        environments_dir = '/usr/local/etc/puppet/environments'
+        logdir           = '/var/log/puppet'
+        rundir           = '/var/run/puppet'
+        vardir           = '/var/puppet'
+        ssldir           = '/var/puppet/ssl'
+        sharedir         = '/usr/local/share/puppet'
+        nodepath         = '\/usr\/local\/etc\/puppet\/node.rb'
+      end
+
+      let(:facts) { default_facts.merge(additional_facts) }
+
+      describe 'with no custom parameters' do
+        let :pre_condition do
+          "class {'puppet': server => true}"
+        end
+
+        it 'should set up SSL permissions' do
+          should contain_file("#{ssldir}/private_keys").with({
+            :group => 'puppet',
+            :mode  => '0750',
+          })
+
+          should contain_file("#{ssldir}/private_keys/puppetmaster.example.com.pem").with({
+            :group => 'puppet',
+            :mode  => '0640',
+          })
+
+          should contain_exec('puppet_server_config-create_ssl_dir').with({
+            :creates => ssldir,
+            :command => "/bin/mkdir -p #{ssldir}",
+          })
+
+          puppetcacmd = Puppet.version >= '4' ? '/opt/puppetlabs/bin/puppet cert' : ( Puppet.version >= '3' ? '/usr/bin/puppet cert' : '/usr/sbin/puppetca' )
+          should contain_exec('puppet_server_config-generate_ca_cert').with({
+            :creates => "#{ssldir}/certs/puppetmaster.example.com.pem",
+            :command => "#{puppetcacmd} --generate puppetmaster.example.com",
+            :require => ["Concat[#{conf_file}]", "Exec[puppet_server_config-create_ssl_dir]"],
+          }).that_notifies('Service[httpd]')
+        end
+
+        context 'on Puppet 3.4+', :if => (Puppet.version >= '3.4.0') do
+          it 'should set sane umask on execs' do
+            should contain_exec('puppet_server_config-create_ssl_dir').with_umask('0022')
+            should contain_exec('puppet_server_config-generate_ca_cert').with_umask('0022')
+          end
+        end
+
+        it 'should set up the ENC' do
+          should contain_class('foreman::puppetmaster').with({
+            :foreman_url    => "https://puppetmaster.example.com",
+            :receive_facts  => true,
+            :puppet_home    => vardir,
+            # Since this is managed inside the foreman module it does not
+            # make sense to test it here
+            #:puppet_basedir => '/usr/lib/ruby/site_ruby/1.9/puppet',
+            :timeout        => 60,
+          })
+        end
+
+        it 'should set up the environments' do
+          should contain_file(environments_dir).with({
+            :ensure => 'directory',
+            :owner => 'puppet',
+            :group => nil,
+            :mode => '0755',
+          })
+          should contain_file(sharedir).with_ensure('directory')
+          should contain_file("#{codedir}/environments/common").with({
+            :ensure => 'directory',
+            :owner => 'puppet',
+            :group => nil,
+            :mode => '0755',
+          })
+
+          should contain_file("#{sharedir}/modules").with({
+            :ensure => 'directory',
+            :owner => 'puppet',
+            :group => nil,
+            :mode => '0755',
+          })
+
+          should contain_file("#{codedir}/manifests/site.pp").with({
+            :ensure  => 'file',
+            :replace => false,
+            :content => "# site.pp must exist (puppet #15106, foreman #1708)\n",
+          })
+
+          should contain_puppet__server__env('development')
+          should contain_puppet__server__env('production')
+
+        end
+
+        it 'should configure puppet' do
+          should contain_concat__fragment('puppet.conf+10-main').
+            with_content(/^\s+logdir\s+= #{logdir}$/).
+            with_content(/^\s+rundir\s+= #{rundir}$/).
+            with_content(/^\s+ssldir\s+= #{ssldir}$/).
+            with_content(/^\s+privatekeydir\s+= \$ssldir\/private_keys { group = service }$/).
+            with_content(/^\s+hostprivkey\s+= \$privatekeydir\/\$certname.pem { mode = 640 }$/).
+            with_content(/^\s+autosign\s+= \$confdir\/autosign.conf { mode = 664 }$/).
+            with({}) # So we can use a trailing dot on each with_content line
+
+          should contain_concat__fragment('puppet.conf+20-agent').
+            with_content(/^\s+classfile\s+= \$statedir\/classes.txt/).
+            with({}) # So we can use a trailing dot on each with_content line
+
+          should contain_concat__fragment('puppet.conf+30-master').
+            with_content(/^\s+reports\s+= foreman$/).
+            with_content(/^\s+external_nodes\s+= #{nodepath}$/).
+            with_content(/^\s+node_terminus\s+= exec$/).
+            with_content(/^\s+ca\s+= true$/).
+            with_content(/^\s+ssldir\s+= #{ssldir}$/).
+            with_content(/^\s+parser\s+=\s+current$/).
+            with({}) # So we can use a trailing dot on each with_content line
+
+          should contain_concat(conf_file)
+
+          should_not contain_file('/etc/puppet/puppet.conf').with_content(/storeconfigs/)
+        end
+
+        context 'on Puppet < 4.0.0', :if => (Puppet.version < '4.0.0') do
+          it 'should set configtimeout' do
+            should contain_concat__fragment('puppet.conf+20-agent').
+              with_content(/^\s+configtimeout\s+= 120$/)
+          end
+        end
+
+        context 'on Puppet >= 4.0.0', :if => (Puppet.version >= '4.0.0') do
+          it 'should not set configtimeout' do
+            should contain_concat__fragment('puppet.conf+20-agent').
+              without_content(/^\s+configtimeout\s+= 120$/)
+          end
+        end
+
+        it 'should not configure PuppetDB' do
+          should_not contain_class('puppetdb')
+          should_not contain_class('puppetdb::master::config')
+        end
+      end
+
+      describe 'without foreman' do
+        let :pre_condition do
+          "class {'puppet':
+              server                => true,
+              server_reports        => 'store',
+              server_external_nodes => '',
+           }"
+        end
+
+        it 'should store reports' do
+          should contain_concat__fragment('puppet.conf+30-master').with_content(/^\s+reports\s+= store$/)
+        end
+
+        it 'should contain an empty external_nodes' do
+          should contain_concat__fragment('puppet.conf+30-master').with_content(/^\s+external_nodes\s+=\s+$/)
+        end
+      end
+
+      describe 'without external_nodes' do
+        let :pre_condition do
+          "class {'puppet':
+              server                => true,
+              server_external_nodes => '',
+           }"
+        end
+
+        it 'should not contain external_nodes' do
+          should contain_concat__fragment('puppet.conf+30-master').
+            with_content(/^\s+external_nodes\s+= $/).
+            with_content(/^\s+node_terminus\s+= plain$/).
+            with({})
+        end
+      end
+
+      describe 'with git repo' do
+        let :pre_condition do
+          "class {'puppet':
+              server          => true,
+              server_git_repo => true,
+           }"
+        end
+
+        it 'should set up the environments directory' do
+          should contain_file(environments_dir).with({
+            :ensure => 'directory',
+            :owner  => 'puppet',
+          })
+        end
+
+        it 'should create the git repo' do
+          should contain_file(vardir).with({
+            :ensure => 'directory',
+            :owner  => 'puppet',
+          })
+
+          should contain_git__repo('puppet_repo').with({
+            :bare    => true,
+            :target  => "#{vardir}/puppet.git",
+            :user    => 'puppet',
+            :require => %r{File\[#{environments_dir}\]},
+          })
+
+          should contain_file("#{vardir}/puppet.git/hooks/post-receive").with({
+            :owner   => 'puppet',
+            :mode    => '0755',
+            :require => %r{Git::Repo\[puppet_repo\]},
+            :content => %r{BRANCH_MAP = \{[^a-zA-Z=>]\}},
+          })
+        end
+
+        it { should_not contain_puppet__server__env('development') }
+        it { should_not contain_puppet__server__env('production') }
+
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet':
+               server                        => true,
+               server_git_repo               => true,
+               server_directory_environments => true,
+             }"
+          end
+
+          it 'should configure puppet.conf' do
+            should_not contain_concat__fragment('puppet.conf+30-master').with_content(%r{^\s+config_version\s+=$})
+
+            should contain_concat__fragment('puppet.conf+10-main').
+              with_content(%r{^\s+environmentpath\s+= #{environments_dir}$})
+          end
+        end
+
+        context 'with config environments' do
+          let :pre_condition do
+            "class {'puppet':
+               server                        => true,
+               server_git_repo               => true,
+               server_directory_environments => false,
+             }"
+          end
+
+          it 'should configure puppet.conf' do
+            should contain_concat__fragment('puppet.conf+30-master').
+              with_content(%r{^\s+manifest\s+= #{environments_dir}/\$environment/manifests/site.pp\n\s+modulepath\s+= #{environments_dir}/\$environment/modules$}).
+              with_content(%r{^\s+config_version\s+= git --git-dir #{environments_dir}/\$environment/.git describe --all --long$})
+          end
+        end
+      end
+
+      describe 'with dynamic environments' do
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet':
+               server                        => true,
+               server_dynamic_environments   => true,
+               server_directory_environments => true,
+               server_environments_owner     => 'apache',
+             }"
+          end
+
+          it 'should set up the environments directory' do
+            should contain_file(environments_dir).with({
+              :ensure => 'directory',
+              :owner  => 'apache',
+            })
+          end
+
+          it 'should configure puppet.conf' do
+            should contain_concat__fragment('puppet.conf+10-main').
+              with_content(%r{^\s+environmentpath\s+= #{environments_dir}\n\s+basemodulepath\s+= #{environments_dir}/common:#{codedir}/modules:#{sharedir}/modules$})
+          end
+
+          it { should_not contain_puppet__server__env('development') }
+          it { should_not contain_puppet__server__env('production') }
+        end
+
+        context 'with config environments' do
+          let :pre_condition do
+            "class {'puppet':
+               server                        => true,
+               server_dynamic_environments   => true,
+               server_directory_environments => false,
+               server_environments_owner     => 'apache',
+             }"
+          end
+
+          it 'should set up the environments directory' do
+            should contain_file(environments_dir).with({
+              :ensure => 'directory',
+              :owner  => 'apache',
+            })
+          end
+
+          it 'should configure puppet.conf' do
+            should contain_concat__fragment('puppet.conf+30-master').
+              with_content(%r{^\s+manifest\s+= #{environments_dir}/\$environment/manifests/site.pp\n\s+modulepath\s+= #{environments_dir}/\$environment/modules$})
+          end
+
+          it { should_not contain_puppet__server__env('development') }
+          it { should_not contain_puppet__server__env('production') }
+        end
+      end
+
+      describe 'with SSL path overrides' do
+        let :pre_condition do
+          "class {'puppet':
+              server                  => true,
+              server_foreman_ssl_ca   => '/etc/example/ca.pem',
+              server_foreman_ssl_cert => '/etc/example/cert.pem',
+              server_foreman_ssl_key  => '/etc/example/key.pem',
+           }"
+        end
+
+        it 'should pass SSL parameters to the ENC' do
+          should contain_class('foreman::puppetmaster').with({
+            :ssl_ca   => '/etc/example/ca.pem',
+            :ssl_cert => '/etc/example/cert.pem',
+            :ssl_key  => '/etc/example/key.pem',
+          })
+        end
+      end
+
+      describe 'with a PuppetDB host set' do
+        let :pre_condition do
+          "class {'puppet':
+              server                      => true,
+              server_puppetdb_host        => 'mypuppetdb.example.com',
+              server_storeconfigs_backend => 'puppetdb',
+           }"
+        end
+
+        it 'should configure PuppetDB' do
+          should contain_class('puppetdb::master::config').with({
+            :puppetdb_server             => 'mypuppetdb.example.com',
+            :puppetdb_port               => 8081,
+            :puppetdb_soft_write_failure => false,
+            :manage_storeconfigs         => false,
+            :restart_puppet              => false,
+          })
+        end
+      end
+
+      describe 'with a puppet git branch map' do
+        let :pre_condition do
+          "class {'puppet':
+              server                => true,
+              server_git_repo       => true,
+              server_git_branch_map => { 'a' => 'b', 'c' => 'd' }
+           }"
+        end
+
+        it 'should add the branch map to the post receive hook' do
+          should contain_file("#{vardir}/puppet.git/hooks/post-receive").
+            with_content(/BRANCH_MAP = {\n  "a" => "b",\n  "c" => "d",\n}/)
+        end
+      end
+
+      describe 'with additional settings' do
+        let :pre_condition do
+          "class {'puppet':
+              server                      => true,
+              server_additional_settings => {stringify_facts => true},
+           }"
+        end
+
+        it 'should configure puppet.conf' do
+          should contain_concat__fragment('puppet.conf+30-master').
+            with_content(/^\s+stringify_facts\s+= true$/).
+            with({}) # So we can use a trailing dot on each with_content line
+        end
+      end
+
+      describe 'directory environments default' do
+        let :pre_condition do
+          "class {'puppet':
+             server => true,
+           }"
+        end
+
+        context 'on old Puppet', :if => (Puppet.version < '3.6.0') do
+          it 'should be disabled' do
+            should contain_concat__fragment('puppet.conf+30-master').
+              without_content(%r{^\s+environmentpath\s+=$})
+          end
+        end
+
+        context 'on Puppet 3.6.0+', :if => (Puppet.version >= '3.6.0') do
+          it 'should be enabled' do
+            should contain_concat__fragment('puppet.conf+10-main').
+              with_content(%r{^\s+environmentpath\s+= #{environments_dir}$})
+          end
+        end
+      end
+
+      describe 'with server_parser => future' do
+        let :pre_condition do
+          "class {'puppet':
+            server => true,
+            server_parser => 'future',
+          }"
+        end
+
+        it 'should configure future parser' do
+          should contain_concat__fragment('puppet.conf+30-master').
+            with_content(/^\s+parser\s+=\s+future$/)
+        end
+      end
+
+      describe 'with server_environment_timeout set' do
+        let :pre_condition do
+          "class {'puppet':
+            server => true,
+            server_environment_timeout => '10m',
+          }"
+        end
+
+        it 'should configure environment_timeout accordingly' do
+          should contain_concat__fragment('puppet.conf+30-master').
+            with_content(/^\s+environment_timeout\s+=\s+10m$/)
+        end
+      end
+
+      describe 'with no ssldir managed for master' do
+        let :pre_condition do
+          "class {'puppet': server => true, server_ssl_dir_manage => false}"
+        end
+
+        it 'should not contain ssl_dir configuration setting in the master section' do
+          should_not contain_concat__fragment('puppet.conf+30-master').
+            with_content(/^\s+ssl_dir\s+=\s+.*$/)
+        end
+      end
+
+      describe 'with nondefault CA settings' do
+        context 'with server_ca => false' do
+          let :pre_condition do
+            "class {'puppet':
+              server => true,
+              server_ca => false,
+            }"
+          end
+
+          it 'should create the ssl directory' do
+            should contain_exec('puppet_server_config-create_ssl_dir')
+          end
+
+          it 'should not generate CA certificates' do
+            should_not contain_exec('puppet_server_config-generate_ca_cert')
+          end
+        end
+      end
+
+    end
   end
-
-  let(:facts) { default_facts.merge(additional_facts) }
-
-  describe 'with no custom parameters' do
-    let :pre_condition do
-      "class {'puppet': server => true}"
-    end
-
-    it 'should set up SSL permissions' do
-      should contain_file("#{ssldir}/private_keys").with({
-        :group => 'puppet',
-        :mode  => '0750',
-      })
-
-      should contain_file("#{ssldir}/private_keys/#{facts[:fqdn]}.pem").with({
-        :group => 'puppet',
-        :mode  => '0640',
-      })
-
-      should contain_exec('puppet_server_config-create_ssl_dir').with({
-        :creates => ssldir,
-        :command => "/bin/mkdir -p #{ssldir}",
-      })
-
-      puppetcacmd = Puppet.version >= '4' ? '/opt/puppetlabs/bin/puppet cert' : ( Puppet.version >= '3' ? '/usr/bin/puppet cert' : '/usr/sbin/puppetca' )
-      should contain_exec('puppet_server_config-generate_ca_cert').with({
-        :creates => "#{ssldir}/certs/#{facts[:fqdn]}.pem",
-        :command => "#{puppetcacmd} --generate #{facts[:fqdn]}",
-        :require => ["Concat[#{conf_file}]", "Exec[puppet_server_config-create_ssl_dir]"],
-      }).that_notifies('Service[httpd]')
-    end
-
-    context 'on Puppet 3.4+', :if => (Puppet.version >= '3.4.0') do
-      it 'should set sane umask on execs' do
-        should contain_exec('puppet_server_config-create_ssl_dir').with_umask('0022')
-        should contain_exec('puppet_server_config-generate_ca_cert').with_umask('0022')
-      end
-    end
-
-    it 'should set up the ENC' do
-      should contain_class('foreman::puppetmaster').with({
-        :foreman_url    => "https://#{facts[:fqdn]}",
-        :receive_facts  => true,
-        :puppet_home    => vardir,
-        :puppet_basedir => '/usr/lib/ruby/site_ruby/1.9/puppet',
-        :timeout        => 60,
-      })
-    end
-
-    it 'should set up the environments' do
-      should contain_file(environments_dir).with({
-        :ensure => 'directory',
-        :owner => 'puppet',
-        :group => nil,
-        :mode => '0755',
-      })
-      should contain_file(sharedir).with_ensure('directory')
-      should contain_file("#{codedir}/environments/common").with({
-        :ensure => 'directory',
-        :owner => 'puppet',
-        :group => nil,
-        :mode => '0755',
-      })
-
-      should contain_file("#{sharedir}/modules").with({
-        :ensure => 'directory',
-        :owner => 'puppet',
-        :group => nil,
-        :mode => '0755',
-      })
-
-      should contain_file("#{codedir}/manifests/site.pp").with({
-        :ensure  => 'file',
-        :replace => false,
-        :content => "# site.pp must exist (puppet #15106, foreman #1708)\n",
-      })
-
-      should contain_puppet__server__env('development')
-      should contain_puppet__server__env('production')
-
-    end
-
-    it 'should configure puppet' do
-      should contain_concat__fragment('puppet.conf+10-main').
-        with_content(/^\s+logdir\s+= #{logdir}$/).
-        with_content(/^\s+rundir\s+= #{rundir}$/).
-        with_content(/^\s+ssldir\s+= #{ssldir}$/).
-        with_content(/^\s+privatekeydir\s+= \$ssldir\/private_keys { group = service }$/).
-        with_content(/^\s+hostprivkey\s+= \$privatekeydir\/\$certname.pem { mode = 640 }$/).
-        with_content(/^\s+autosign\s+= \$confdir\/autosign.conf { mode = 664 }$/).
-        with({}) # So we can use a trailing dot on each with_content line
-
-      should contain_concat__fragment('puppet.conf+20-agent').
-        with_content(/^\s+classfile\s+= \$statedir\/classes.txt/).
-        with({}) # So we can use a trailing dot on each with_content line
-
-      should contain_concat__fragment('puppet.conf+30-master').
-        with_content(/^\s+reports\s+= foreman$/).
-        with_content(/^\s+external_nodes\s+= #{nodepath}$/).
-        with_content(/^\s+node_terminus\s+= exec$/).
-        with_content(/^\s+ca\s+= true$/).
-        with_content(/^\s+ssldir\s+= #{ssldir}$/).
-        with_content(/^\s+parser\s+=\s+current$/).
-        with({}) # So we can use a trailing dot on each with_content line
-
-      should contain_concat(conf_file)
-
-      should_not contain_file('/etc/puppet/puppet.conf').with_content(/storeconfigs/)
-    end
-
-    context 'on Puppet < 4.0.0', :if => (Puppet.version < '4.0.0') do
-      it 'should set configtimeout' do
-        should contain_concat__fragment('puppet.conf+20-agent').
-          with_content(/^\s+configtimeout\s+= 120$/)
-      end
-    end
-
-    context 'on Puppet >= 4.0.0', :if => (Puppet.version >= '4.0.0') do
-      it 'should not set configtimeout' do
-        should contain_concat__fragment('puppet.conf+20-agent').
-          without_content(/^\s+configtimeout\s+= 120$/)
-      end
-    end
-
-    it 'should not configure PuppetDB' do
-      should_not contain_class('puppetdb')
-      should_not contain_class('puppetdb::master::config')
-    end
-  end
-
-  describe 'without foreman' do
-    let :pre_condition do
-      "class {'puppet':
-          server                => true,
-          server_reports        => 'store',
-          server_external_nodes => '',
-       }"
-    end
-
-    it 'should store reports' do
-      should contain_concat__fragment('puppet.conf+30-master').with_content(/^\s+reports\s+= store$/)
-    end
-
-    it 'should contain an empty external_nodes' do
-      should contain_concat__fragment('puppet.conf+30-master').with_content(/^\s+external_nodes\s+=\s+$/)
-    end
-  end
-
-  describe 'without external_nodes' do
-    let :pre_condition do
-      "class {'puppet':
-          server                => true,
-          server_external_nodes => '',
-       }"
-    end
-
-    it 'should not contain external_nodes' do
-      should contain_concat__fragment('puppet.conf+30-master').
-        with_content(/^\s+external_nodes\s+= $/).
-        with_content(/^\s+node_terminus\s+= plain$/).
-        with({})
-    end
-  end
-
-  describe 'with git repo' do
-    let :pre_condition do
-      "class {'puppet':
-          server          => true,
-          server_git_repo => true,
-       }"
-    end
-
-    it 'should set up the environments directory' do
-      should contain_file(environments_dir).with({
-        :ensure => 'directory',
-        :owner  => 'puppet',
-      })
-    end
-
-    it 'should create the git repo' do
-      should contain_file(vardir).with({
-        :ensure => 'directory',
-        :owner  => 'puppet',
-      })
-
-      should contain_git__repo('puppet_repo').with({
-        :bare    => true,
-        :target  => "#{vardir}/puppet.git",
-        :user    => 'puppet',
-        :require => %r{File\[#{environments_dir}\]},
-      })
-
-      should contain_file("#{vardir}/puppet.git/hooks/post-receive").with({
-        :owner   => 'puppet',
-        :mode    => '0755',
-        :require => %r{Git::Repo\[puppet_repo\]},
-        :content => %r{BRANCH_MAP = \{[^a-zA-Z=>]\}},
-      })
-    end
-
-    it { should_not contain_puppet__server__env('development') }
-    it { should_not contain_puppet__server__env('production') }
-
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet':
-           server                        => true,
-           server_git_repo               => true,
-           server_directory_environments => true,
-         }"
-      end
-
-      it 'should configure puppet.conf' do
-        should_not contain_concat__fragment('puppet.conf+30-master').with_content(%r{^\s+config_version\s+=$})
-
-        should contain_concat__fragment('puppet.conf+10-main').
-          with_content(%r{^\s+environmentpath\s+= #{environments_dir}$})
-      end
-    end
-
-    context 'with config environments' do
-      let :pre_condition do
-        "class {'puppet':
-           server                        => true,
-           server_git_repo               => true,
-           server_directory_environments => false,
-         }"
-      end
-
-      it 'should configure puppet.conf' do
-        should contain_concat__fragment('puppet.conf+30-master').
-          with_content(%r{^\s+manifest\s+= #{environments_dir}/\$environment/manifests/site.pp\n\s+modulepath\s+= #{environments_dir}/\$environment/modules$}).
-          with_content(%r{^\s+config_version\s+= git --git-dir #{environments_dir}/\$environment/.git describe --all --long$})
-      end
-    end
-  end
-
-  describe 'with dynamic environments' do
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet':
-           server                        => true,
-           server_dynamic_environments   => true,
-           server_directory_environments => true,
-           server_environments_owner     => 'apache',
-         }"
-      end
-
-      it 'should set up the environments directory' do
-        should contain_file(environments_dir).with({
-          :ensure => 'directory',
-          :owner  => 'apache',
-        })
-      end
-
-      it 'should configure puppet.conf' do
-        should contain_concat__fragment('puppet.conf+10-main').
-          with_content(%r{^\s+environmentpath\s+= #{environments_dir}\n\s+basemodulepath\s+= #{environments_dir}/common:#{codedir}/modules:#{sharedir}/modules$})
-      end
-
-      it { should_not contain_puppet__server__env('development') }
-      it { should_not contain_puppet__server__env('production') }
-    end
-
-    context 'with config environments' do
-      let :pre_condition do
-        "class {'puppet':
-           server                        => true,
-           server_dynamic_environments   => true,
-           server_directory_environments => false,
-           server_environments_owner     => 'apache',
-         }"
-      end
-
-      it 'should set up the environments directory' do
-        should contain_file(environments_dir).with({
-          :ensure => 'directory',
-          :owner  => 'apache',
-        })
-      end
-
-      it 'should configure puppet.conf' do
-        should contain_concat__fragment('puppet.conf+30-master').
-          with_content(%r{^\s+manifest\s+= #{environments_dir}/\$environment/manifests/site.pp\n\s+modulepath\s+= #{environments_dir}/\$environment/modules$})
-      end
-
-      it { should_not contain_puppet__server__env('development') }
-      it { should_not contain_puppet__server__env('production') }
-    end
-  end
-
-  describe 'with SSL path overrides' do
-    let :pre_condition do
-      "class {'puppet':
-          server                  => true,
-          server_foreman_ssl_ca   => '/etc/example/ca.pem',
-          server_foreman_ssl_cert => '/etc/example/cert.pem',
-          server_foreman_ssl_key  => '/etc/example/key.pem',
-       }"
-    end
-
-    it 'should pass SSL parameters to the ENC' do
-      should contain_class('foreman::puppetmaster').with({
-        :ssl_ca   => '/etc/example/ca.pem',
-        :ssl_cert => '/etc/example/cert.pem',
-        :ssl_key  => '/etc/example/key.pem',
-      })
-    end
-  end
-
-  describe 'with a PuppetDB host set' do
-    let :pre_condition do
-      "class {'puppet':
-          server                      => true,
-          server_puppetdb_host        => 'mypuppetdb.example.com',
-          server_storeconfigs_backend => 'puppetdb',
-       }"
-    end
-
-    it 'should configure PuppetDB' do
-      should contain_class('puppetdb::master::config').with({
-        :puppetdb_server             => 'mypuppetdb.example.com',
-        :puppetdb_port               => 8081,
-        :puppetdb_soft_write_failure => false,
-        :manage_storeconfigs         => false,
-        :restart_puppet              => false,
-      })
-    end
-  end
-
-  describe 'with a puppet git branch map' do
-    let :pre_condition do
-      "class {'puppet':
-          server                => true,
-          server_git_repo       => true,
-          server_git_branch_map => { 'a' => 'b', 'c' => 'd' }
-       }"
-    end
-
-    it 'should add the branch map to the post receive hook' do
-      should contain_file("#{vardir}/puppet.git/hooks/post-receive").
-        with_content(/BRANCH_MAP = {\n  "a" => "b",\n  "c" => "d",\n}/)
-    end
-  end
-
-  describe 'with additional settings' do
-    let :pre_condition do
-      "class {'puppet':
-          server                      => true,
-          server_additional_settings => {stringify_facts => true},
-       }"
-    end
-
-    it 'should configure puppet.conf' do
-      should contain_concat__fragment('puppet.conf+30-master').
-        with_content(/^\s+stringify_facts\s+= true$/).
-        with({}) # So we can use a trailing dot on each with_content line
-    end
-  end
-
-  describe 'directory environments default' do
-    let :pre_condition do
-      "class {'puppet':
-         server => true,
-       }"
-    end
-
-    context 'on old Puppet', :if => (Puppet.version < '3.6.0') do
-      it 'should be disabled' do
-        should contain_concat__fragment('puppet.conf+30-master').
-          without_content(%r{^\s+environmentpath\s+=$})
-      end
-    end
-
-    context 'on Puppet 3.6.0+', :if => (Puppet.version >= '3.6.0') do
-      it 'should be enabled' do
-        should contain_concat__fragment('puppet.conf+10-main').
-          with_content(%r{^\s+environmentpath\s+= #{environments_dir}$})
-      end
-    end
-  end
-
-  describe 'with server_parser => future' do
-    let :pre_condition do
-      "class {'puppet':
-        server => true,
-        server_parser => 'future',
-      }"
-    end
-
-    it 'should configure future parser' do
-      should contain_concat__fragment('puppet.conf+30-master').
-        with_content(/^\s+parser\s+=\s+future$/)
-    end
-  end
-
-  describe 'with server_environment_timeout set' do
-    let :pre_condition do
-      "class {'puppet':
-        server => true,
-        server_environment_timeout => '10m',
-      }"
-    end
-
-    it 'should configure environment_timeout accordingly' do
-      should contain_concat__fragment('puppet.conf+30-master').
-        with_content(/^\s+environment_timeout\s+=\s+10m$/)
-    end
-  end
-
-  describe 'with no ssldir managed for master' do
-    let :pre_condition do
-      "class {'puppet': server => true, server_ssl_dir_manage => false}"
-    end
-
-    it 'should not contain ssl_dir configuration setting in the master section' do
-      should_not contain_concat__fragment('puppet.conf+30-master').
-        with_content(/^\s+ssl_dir\s+=\s+.*$/)
-    end
-  end
-
-  describe 'with nondefault CA settings' do
-    context 'with server_ca => false' do
-      let :pre_condition do
-        "class {'puppet':
-          server => true,
-          server_ca => false,
-        }"
-      end
-
-      it 'should create the ssl directory' do
-        should contain_exec('puppet_server_config-create_ssl_dir')
-      end
-
-      it 'should not generate CA certificates' do
-        should_not contain_exec('puppet_server_config-generate_ca_cert')
-      end
-    end
-  end
-
 end

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -10,7 +10,7 @@ describe 'puppet::server::config' do
           :clientcert             => 'puppetmaster.example.com',
           :concat_basedir         => '/nonexistant',
           :fqdn                   => 'puppetmaster.example.com',
-          :rubyversion            => '1.9.3',
+#          :rubyversion            => '1.9.3',
           :puppetversion          => Puppet.version,
       }) end
 

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -23,6 +23,7 @@ describe 'puppet::server::config' do
         ssldir           = '/var/lib/puppet/ssl'
         sharedir         = '/usr/share/puppet'
         nodepath         = '\/etc\/puppet\/node.rb'
+        puppetcacmd      = '/usr/bin/puppet cert'
         additional_facts = {}
       else
         codedir          = '/etc/puppetlabs/code'
@@ -34,7 +35,12 @@ describe 'puppet::server::config' do
         ssldir           = '/etc/puppetlabs/puppet/ssl'
         sharedir         = '/opt/puppetlabs/puppet'
         nodepath         = '\/etc\/puppetlabs\/puppet\/node.rb'
+        puppetcacmd      = '/opt/puppetlabs/bin/puppet cert'
         additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+      end
+
+      if Puppet.version < '3.0'
+        puppetcacmd      = '/usr/sbin/puppetca'
       end
 
       if os_facts[:osfamily] == 'FreeBSD'
@@ -46,6 +52,7 @@ describe 'puppet::server::config' do
         vardir           = '/var/puppet'
         ssldir           = '/var/puppet/ssl'
         sharedir         = '/usr/local/share/puppet'
+        puppetcacmd      = '/usr/local/bin/puppet cert'
         nodepath         = '\/usr\/local\/etc\/puppet\/node.rb'
       end
 
@@ -72,7 +79,6 @@ describe 'puppet::server::config' do
             :command => "/bin/mkdir -p #{ssldir}",
           })
 
-          puppetcacmd = Puppet.version >= '4' ? '/opt/puppetlabs/bin/puppet cert' : ( Puppet.version >= '3' ? '/usr/bin/puppet cert' : '/usr/sbin/puppetca' )
           should contain_exec('puppet_server_config-generate_ca_cert').with({
             :creates => "#{ssldir}/certs/puppetmaster.example.com.pem",
             :command => "#{puppetcacmd} --generate puppetmaster.example.com",

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -53,7 +53,9 @@ describe 'puppet::server::config' do
         vardir           = '/var/puppet'
         ssldir           = '/var/puppet/ssl'
         sharedir         = '/usr/local/share/puppet'
-        puppetcacmd      = '/usr/local/bin/puppet cert'
+        if Puppet.version < '4.0'
+          puppetcacmd      = '/usr/local/bin/puppet cert'
+        end
         nodepath         = '\/usr\/local\/etc\/puppet\/node.rb'
       end
 

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::server::config' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_server_passenger_spec.rb
+++ b/spec/classes/puppet_server_passenger_spec.rb
@@ -1,55 +1,69 @@
 require 'spec_helper'
 
 describe 'puppet::server::passenger' do
-  on_supported_os.each do |os, facts|
-    let(:facts) do
-      facts.merge({
-        :concat_basedir => '/foo/bar',
-        :puppetversion  => Puppet.version,
-      })
-    end
-    let(:default_params) do {
-      :app_root => '/etc/puppet/rack'
-    } end
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :concat_basedir         => '/foo/bar',
+          :puppetversion          => Puppet.version,
+      }) end
 
-    describe 'without parameters' do
-      let(:params) { default_params }
-      it 'should include the puppet vhost' do
-        should contain_apache__vhost('puppet').with({
-          :ssl_proxyengine => false,
-          :ssl_crl_check => nil,
-        })
-      end
-    end
-
-    describe 'with puppet ca proxy' do
-      let :params do
-        default_params.merge({
-          :puppet_ca_proxy => 'https://ca.example.org:8140',
-        })
+      if Puppet.version < '4.0'
+        additional_facts = {}
+      else
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
-      it 'should include the puppet vhost' do
-        should contain_apache__vhost('puppet').with({
-          :ssl_proxyengine => true,
-          :custom_fragment => "ProxyPassMatch ^/([^/]+/certificate.*)$ https://ca.example.org:8140/$1",
-        })
-      end
-    end
-
-    describe 'with SSL CRL' do
-      let :params do
-        default_params.merge({
-          :ssl_ca_crl => '/var/lib/puppet/ssl/ca/ca_crl.pem',
-        })
+      let :facts do
+        default_facts.merge(additional_facts)
       end
 
-      it 'should include the puppet vhost' do
-        should contain_apache__vhost('puppet').with({
-          :ssl_crl => '/var/lib/puppet/ssl/ca/ca_crl.pem',
-          :ssl_crl_check => 'chain',
-        })
+      let(:default_params) do {
+        :app_root => '/etc/puppet/rack'
+      } end
+
+      describe 'without parameters' do
+        let(:params) { default_params }
+        it 'should include the puppet vhost' do
+          should contain_apache__vhost('puppet').with({
+            :ssl_proxyengine => false,
+            :ssl_crl_check => nil,
+          })
+        end
       end
+
+      describe 'with puppet ca proxy' do
+        let :params do
+          default_params.merge({
+            :puppet_ca_proxy => 'https://ca.example.org:8140',
+          })
+        end
+
+        it 'should include the puppet vhost' do
+          should contain_apache__vhost('puppet').with({
+            :ssl_proxyengine => true,
+            :custom_fragment => "ProxyPassMatch ^/([^/]+/certificate.*)$ https://ca.example.org:8140/$1",
+          })
+        end
+      end
+
+      describe 'with SSL CRL' do
+        let :params do
+          default_params.merge({
+            :ssl_ca_crl => '/var/lib/puppet/ssl/ca/ca_crl.pem',
+          })
+        end
+
+        it 'should include the puppet vhost' do
+          should contain_apache__vhost('puppet').with({
+            :ssl_crl => '/var/lib/puppet/ssl/ca/ca_crl.pem',
+            :ssl_crl_check => 'chain',
+          })
+        end
+      end
+
     end
   end
 end

--- a/spec/classes/puppet_server_passenger_spec.rb
+++ b/spec/classes/puppet_server_passenger_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::server::passenger' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::server::puppetserver' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -1,58 +1,77 @@
 require 'spec_helper'
 
 describe 'puppet::server::puppetserver' do
-  let(:default_params) do {
-    :java_bin          => '/usr/bin/java',
-    :config            => '/etc/default/puppetserver',
-    :jvm_min_heap_size => '2G',
-    :jvm_max_heap_size => '2G',
-    :jvm_extra_args    => '',
-  } end
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :puppetversion          => Puppet.version,
+      }) end
 
-  describe 'with default parameters' do
-    let(:params) { default_params }
-    it { should contain_augeas('puppet::server::puppetserver::jvm').
-            with_changes([
-              'set JAVA_ARGS \'"-Xms2G -Xmx2G"\'',
-              'set JAVA_BIN /usr/bin/java',
-            ]).
-            with_context('/files/etc/default/puppetserver').
-            with_incl('/etc/default/puppetserver').
-            with_lens('Shellvars.lns').
-            with({})
-    }
-  end
+      if Puppet.version < '4.0'
+        additional_facts = {}
+      else
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+      end
 
-  describe 'with extra_args parameter' do
-    let :params do
-      default_params.merge({
-        :jvm_extra_args => ['-XX:foo=bar', '-XX:bar=foo'],
-      })
+      let(:facts) { default_facts.merge(additional_facts) }
+
+      let(:default_params) do {
+        :java_bin          => '/usr/bin/java',
+        :config            => '/etc/default/puppetserver',
+        :jvm_min_heap_size => '2G',
+        :jvm_max_heap_size => '2G',
+        :jvm_extra_args    => '',
+      } end
+
+      describe 'with default parameters' do
+        let(:params) { default_params }
+        it { should contain_augeas('puppet::server::puppetserver::jvm').
+                with_changes([
+                  'set JAVA_ARGS \'"-Xms2G -Xmx2G"\'',
+                  'set JAVA_BIN /usr/bin/java',
+                ]).
+                with_context('/files/etc/default/puppetserver').
+                with_incl('/etc/default/puppetserver').
+                with_lens('Shellvars.lns').
+                with({})
+        }
+      end
+
+      describe 'with extra_args parameter' do
+        let :params do
+          default_params.merge({
+            :jvm_extra_args => ['-XX:foo=bar', '-XX:bar=foo'],
+          })
+        end
+
+        it { should contain_augeas('puppet::server::puppetserver::jvm').
+                with_changes([
+                  'set JAVA_ARGS \'"-Xms2G -Xmx2G -XX:foo=bar -XX:bar=foo"\'',
+                  'set JAVA_BIN /usr/bin/java',
+                ]).
+                with_context('/files/etc/default/puppetserver').
+                with_incl('/etc/default/puppetserver').
+                with_lens('Shellvars.lns').
+                with({})
+        }
+      end
+
+      describe 'with jvm_config file parameter' do
+        let :params do
+          default_params.merge({
+            :config => '/etc/custom/puppetserver',
+          })
+        end
+        it { should contain_augeas('puppet::server::puppetserver::jvm').
+                with_context('/files/etc/custom/puppetserver').
+                with_incl('/etc/custom/puppetserver').
+                with_lens('Shellvars.lns').
+                with({})
+        }
+      end
+
     end
-
-    it { should contain_augeas('puppet::server::puppetserver::jvm').
-            with_changes([
-              'set JAVA_ARGS \'"-Xms2G -Xmx2G -XX:foo=bar -XX:bar=foo"\'',
-              'set JAVA_BIN /usr/bin/java',
-            ]).
-            with_context('/files/etc/default/puppetserver').
-            with_incl('/etc/default/puppetserver').
-            with_lens('Shellvars.lns').
-            with({})
-    }
-  end
-
-  describe 'with jvm_config file parameter' do
-    let :params do
-      default_params.merge({
-        :config => '/etc/custom/puppetserver',
-      })
-    end
-    it { should contain_augeas('puppet::server::puppetserver::jvm').
-            with_context('/files/etc/custom/puppetserver').
-            with_incl('/etc/custom/puppetserver').
-            with_lens('Shellvars.lns').
-            with({})
-    }
   end
 end

--- a/spec/classes/puppet_server_rack_spec.rb
+++ b/spec/classes/puppet_server_rack_spec.rb
@@ -69,31 +69,45 @@ describe 'puppet::server::rack' do
           })
         end
 
-        it 'should manage config.ru contents' do
-          verify_exact_contents(catalogue, '/etc/puppet/rack/config.ru', [
-            '$0 = "master"',
-            'ARGV << "--rack"',
-            'ARGV << "--confdir" << "/etc/puppet"',
-            'ARGV << "--vardir"  << "/var/lib/puppet"',
-            'Encoding.default_external = Encoding::UTF_8 if defined? Encoding',
-            'require \'puppet/util/command_line\'',
-            'run Puppet::Util::CommandLine.new.execute',
-          ])
+        if Puppet.version >= '3.0'
+          it 'should manage config.ru contents' do
+            verify_exact_contents(catalogue, '/etc/puppet/rack/config.ru', [
+              '$0 = "master"',
+              'ARGV << "--rack"',
+              'ARGV << "--confdir" << "/etc/puppet"',
+              'ARGV << "--vardir"  << "/var/lib/puppet"',
+              'Encoding.default_external = Encoding::UTF_8 if defined? Encoding',
+              'require \'puppet/util/command_line\'',
+              'run Puppet::Util::CommandLine.new.execute',
+            ])
+          end
+        else
+          it 'should manage config.ru contents' do
+            verify_exact_contents(catalogue, '/etc/puppet/rack/config.ru', [
+              '$0 = "master"',
+              'ARGV << "--rack"',
+              'require \'puppet/application/master\'',
+              'run Puppet::Application[:master].run',
+            ])
+          end
         end
       end
 
-      describe 'when rack_arguments defined' do
-        let(:params) { default_params.merge(:rack_arguments => ['--profile', '--logdest', '/dne/log']) }
+      # The Puppet 2.X template does not support rack_arguments
+      if Puppet.version >= '3.0'
+        describe 'when rack_arguments defined' do
+          let(:params) { default_params.merge(:rack_arguments => ['--profile', '--logdest', '/dne/log']) }
 
-        it 'should set ARGV values' do
-          verify_contents(catalogue, '/etc/puppet/rack/config.ru', [
-            'ARGV << "--rack"',
-            'ARGV << "--confdir" << "/etc/puppet"',
-            'ARGV << "--vardir"  << "/var/lib/puppet"',
-            'ARGV << "--profile"',
-            'ARGV << "--logdest"',
-            'ARGV << "/dne/log"',
-          ])
+          it 'should set ARGV values' do
+            verify_contents(catalogue, '/etc/puppet/rack/config.ru', [
+              'ARGV << "--rack"',
+              'ARGV << "--confdir" << "/etc/puppet"',
+              'ARGV << "--vardir"  << "/var/lib/puppet"',
+              'ARGV << "--profile"',
+              'ARGV << "--logdest"',
+              'ARGV << "/dne/log"',
+            ])
+          end
         end
       end
 

--- a/spec/classes/puppet_server_rack_spec.rb
+++ b/spec/classes/puppet_server_rack_spec.rb
@@ -1,84 +1,101 @@
 require 'spec_helper'
 
 describe 'puppet::server::rack' do
-  on_supported_os.each do |os, facts|
-    let(:default_params) do {
-      :app_root => '/etc/puppet/rack',
-      :confdir  => '/etc/puppet',
-      :vardir   => '/var/lib/puppet',
-      :user     => 'puppet',
-    } end
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :puppetversion          => Puppet.version,
+      }) end
 
-    describe 'defaults' do
-      let(:params) { default_params }
-
-      it 'should define Exec[puppet_server_rack-restart]' do
-        should contain_exec('puppet_server_rack-restart').with({
-          :command      => 'touch /etc/puppet/rack/tmp/restart.txt',
-          :path         => '/bin:/usr/bin',
-          :refreshonly  => true,
-          :cwd          => '/etc/puppet/rack',
-          :require      => ['Class[Puppet::Server::Install]', 'File[/etc/puppet/rack/tmp]'],
-        })
+      if Puppet.version < '4.0'
+        additional_facts = {}
+      else
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
-      it 'should create server_app_root' do
-        should contain_file('/etc/puppet/rack').with({
-          :ensure => 'directory',
-          :owner  => 'puppet',
-          :mode   => '0755',
-        })
+      let(:facts) { default_facts.merge(additional_facts) }
+
+      let(:default_params) do {
+        :app_root => '/etc/puppet/rack',
+        :confdir  => '/etc/puppet',
+        :vardir   => '/var/lib/puppet',
+        :user     => 'puppet',
+      } end
+
+      describe 'defaults' do
+        let(:params) { default_params }
+
+        it 'should define Exec[puppet_server_rack-restart]' do
+          should contain_exec('puppet_server_rack-restart').with({
+            :command      => 'touch /etc/puppet/rack/tmp/restart.txt',
+            :path         => '/bin:/usr/bin',
+            :refreshonly  => true,
+            :cwd          => '/etc/puppet/rack',
+            :require      => ['Class[Puppet::Server::Install]', 'File[/etc/puppet/rack/tmp]'],
+          })
+        end
+
+        it 'should create server_app_root' do
+          should contain_file('/etc/puppet/rack').with({
+            :ensure => 'directory',
+            :owner  => 'puppet',
+            :mode   => '0755',
+          })
+        end
+
+        it 'should create server_app_root public' do
+          should contain_file('/etc/puppet/rack/public').with({
+            :ensure => 'directory',
+            :owner  => 'puppet',
+            :mode   => '0755',
+          })
+        end
+
+        it 'should create server_app_root tmp' do
+          should contain_file('/etc/puppet/rack/tmp').with({
+            :ensure => 'directory',
+            :owner  => 'puppet',
+            :mode   => '0755',
+          })
+        end
+
+        it 'should create config.ru' do
+          should contain_file('/etc/puppet/rack/config.ru').with({
+            :owner  => 'puppet',
+            :notify => 'Exec[puppet_server_rack-restart]',
+          })
+        end
+
+        it 'should manage config.ru contents' do
+          verify_exact_contents(catalogue, '/etc/puppet/rack/config.ru', [
+            '$0 = "master"',
+            'ARGV << "--rack"',
+            'ARGV << "--confdir" << "/etc/puppet"',
+            'ARGV << "--vardir"  << "/var/lib/puppet"',
+            'Encoding.default_external = Encoding::UTF_8 if defined? Encoding',
+            'require \'puppet/util/command_line\'',
+            'run Puppet::Util::CommandLine.new.execute',
+          ])
+        end
       end
 
-      it 'should create server_app_root public' do
-        should contain_file('/etc/puppet/rack/public').with({
-          :ensure => 'directory',
-          :owner  => 'puppet',
-          :mode   => '0755',
-        })
+      describe 'when rack_arguments defined' do
+        let(:params) { default_params.merge(:rack_arguments => ['--profile', '--logdest', '/dne/log']) }
+
+        it 'should set ARGV values' do
+          verify_contents(catalogue, '/etc/puppet/rack/config.ru', [
+            'ARGV << "--rack"',
+            'ARGV << "--confdir" << "/etc/puppet"',
+            'ARGV << "--vardir"  << "/var/lib/puppet"',
+            'ARGV << "--profile"',
+            'ARGV << "--logdest"',
+            'ARGV << "/dne/log"',
+          ])
+        end
       end
 
-      it 'should create server_app_root tmp' do
-        should contain_file('/etc/puppet/rack/tmp').with({
-          :ensure => 'directory',
-          :owner  => 'puppet',
-          :mode   => '0755',
-        })
-      end
-
-      it 'should create config.ru' do
-        should contain_file('/etc/puppet/rack/config.ru').with({
-          :owner  => 'puppet',
-          :notify => 'Exec[puppet_server_rack-restart]',
-        })
-      end
-
-      it 'should manage config.ru contents' do
-        verify_exact_contents(catalogue, '/etc/puppet/rack/config.ru', [
-          '$0 = "master"',
-          'ARGV << "--rack"',
-          'ARGV << "--confdir" << "/etc/puppet"',
-          'ARGV << "--vardir"  << "/var/lib/puppet"',
-          'Encoding.default_external = Encoding::UTF_8 if defined? Encoding',
-          'require \'puppet/util/command_line\'',
-          'run Puppet::Util::CommandLine.new.execute',
-        ])
-      end
-    end
-
-    describe 'when rack_arguments defined' do
-      let(:params) { default_params.merge(:rack_arguments => ['--profile', '--logdest', '/dne/log']) }
-
-      it 'should set ARGV values' do
-        verify_contents(catalogue, '/etc/puppet/rack/config.ru', [
-          'ARGV << "--rack"',
-          'ARGV << "--confdir" << "/etc/puppet"',
-          'ARGV << "--vardir"  << "/var/lib/puppet"',
-          'ARGV << "--profile"',
-          'ARGV << "--logdest"',
-          'ARGV << "/dne/log"',
-        ])
-      end
     end
   end
 end

--- a/spec/classes/puppet_server_rack_spec.rb
+++ b/spec/classes/puppet_server_rack_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::server::rack' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -1,78 +1,85 @@
 require 'spec_helper'
 
 describe 'puppet::server::service' do
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :clientcert             => 'puppetmaster.example.com',
+          :concat_basedir         => '/nonexistant',
+          :fqdn                   => 'puppetmaster.example.com',
+          :puppetversion          => Puppet.version,
+      }) end
 
-  if Puppet.version < '4.0'
-    additional_facts = {}
-  else
-    additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-  end
+      if Puppet.version < '4.0'
+        additional_facts = {}
+      else
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+      end
 
-  let :facts do on_supported_os['centos-6-x86_64'].merge({
-    :clientcert     => 'puppetmaster.example.com',
-    :concat_basedir => '/nonexistant',
-    :fqdn           => 'puppetmaster.example.com',
-    :puppetversion  => Puppet.version,
-  }).merge(additional_facts) end
+      let(:facts) { default_facts.merge(additional_facts) }
 
-  describe 'default_parameters' do
-    it { should_not contain_service('puppetmaster') }
-    it { should_not contain_service('puppetserver') }
-  end
+      describe 'default_parameters' do
+        it { should_not contain_service('puppetmaster') }
+        it { should_not contain_service('puppetserver') }
+      end
 
-  describe 'when puppetmaster => true' do
-    let(:params) { {:puppetmaster => true, :puppetserver => Undef.new} }
-    it do
-      should contain_service('puppetmaster').with({
-        :ensure => 'running',
-        :enable => 'true',
-      })
+      describe 'when puppetmaster => true' do
+        let(:params) { {:puppetmaster => true, :puppetserver => Undef.new} }
+        it do
+          should contain_service('puppetmaster').with({
+            :ensure => 'running',
+            :enable => 'true',
+          })
+        end
+      end
+
+      describe 'when puppetserver => true' do
+        let(:params) { {:puppetserver => true, :puppetmaster => Undef.new} }
+        it do
+          should contain_service('puppetserver').with({
+            :ensure => 'running',
+            :enable => 'true',
+          })
+        end
+      end
+
+      describe 'when puppetmaster => false' do
+        let(:params) { {:puppetmaster => false} }
+        it do
+          should contain_service('puppetmaster').with({
+            :ensure => 'stopped',
+            :enable => 'false',
+          })
+        end
+      end
+
+      describe 'when puppetserver => false' do
+        let(:params) { {:puppetserver => false} }
+        it do
+          should contain_service('puppetserver').with({
+            :ensure => 'stopped',
+            :enable => 'false',
+          })
+        end
+      end
+
+      describe 'when puppetmaster => undef' do
+        let(:params) { {:puppetmaster => Undef.new} }
+        it { should_not contain_service('puppetmaster') }
+      end
+
+      describe 'when puppetserver => undef' do
+        let(:params) { {:puppetserver => Undef.new} }
+        it { should_not contain_service('puppetserver') }
+      end
+
+      describe 'when puppetmaster => true and puppetserver => true' do
+        let(:params) { {:puppetserver => true, :puppetmaster => true} }
+        it { should raise_error(Puppet::Error, /Both puppetmaster and puppetserver cannot be enabled simultaneously/) }
+      end
+
     end
   end
-
-  describe 'when puppetserver => true' do
-    let(:params) { {:puppetserver => true, :puppetmaster => Undef.new} }
-    it do
-      should contain_service('puppetserver').with({
-        :ensure => 'running',
-        :enable => 'true',
-      })
-    end
-  end
-
-  describe 'when puppetmaster => false' do
-    let(:params) { {:puppetmaster => false} }
-    it do
-      should contain_service('puppetmaster').with({
-        :ensure => 'stopped',
-        :enable => 'false',
-      })
-    end
-  end
-
-  describe 'when puppetserver => false' do
-    let(:params) { {:puppetserver => false} }
-    it do
-      should contain_service('puppetserver').with({
-        :ensure => 'stopped',
-        :enable => 'false',
-      })
-    end
-  end
-
-  describe 'when puppetmaster => undef' do
-    let(:params) { {:puppetmaster => Undef.new} }
-    it { should_not contain_service('puppetmaster') }
-  end
-
-  describe 'when puppetserver => undef' do
-    let(:params) { {:puppetserver => Undef.new} }
-    it { should_not contain_service('puppetserver') }
-  end
-
-  describe 'when puppetmaster => true and puppetserver => true' do
-    let(:params) { {:puppetserver => true, :puppetmaster => true} }
-    it { should raise_error(Puppet::Error, /Both puppetmaster and puppetserver cannot be enabled simultaneously/) }
-  end
-
 end

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::server::service' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -1,153 +1,166 @@
 require 'spec_helper'
 
 describe 'puppet::server' do
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let (:default_facts) do
+        os_facts.merge({
+          :clientcert             => 'puppetmaster.example.com',
+          :concat_basedir         => '/nonexistant',
+          :fqdn                   => 'puppetmaster.example.com',
+          :puppetversion          => Puppet.version,
+      }) end
 
-  let :common_facts do on_supported_os['centos-6-x86_64'].merge({
-    :concat_basedir         => '/nonexistant',
-    :clientcert             => 'puppetmaster.example.com',
-    :fqdn                   => 'puppetmaster.example.com',
-    :puppetversion          => Puppet.version,
-  }) end
-
-  if Puppet.version < '4.0'
-    ssldir = '/var/lib/puppet/ssl'
-    additional_facts = {}
-  else
-    ssldir = '/etc/puppetlabs/puppet/ssl'
-    additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-  end
-
-  let :default_facts do
-    common_facts.merge(additional_facts)
-  end
-
-  let :facts do
-    default_facts
-  end
-
-  context 'basic case' do
-    let :pre_condition do
-      "class {'puppet': server => true}"
-    end
-
-    describe 'with no custom parameters' do
-      it { should compile.with_all_deps }
-      it 'should include classes' do
-        should contain_class('puppet::server::install')
-        should contain_class('puppet::server::config')
-        should contain_class('puppet::server::service').
-          with_puppetmaster(false).
-          with_puppetserver(nil)
-      end
-      it { should contain_package('puppet-server') }
-    end
-  end
-
-  context 'with uppercase hostname' do
-    let :pre_condition do
-      "class {'puppet': server => true}"
-    end
-
-    let(:facts) do
-      default_facts.merge(
-        :clientcert => 'PUPPETMASTER.example.com',
-        :fqdn       => 'PUPPETMASTER.example.com'
-      )
-    end
-
-    describe 'with no custom parameters' do
-      it 'should use lowercase certificates' do
-        should contain_class('puppet::server::passenger').
-          with_ssl_cert("#{ssldir}/certs/puppetmaster.example.com.pem").
-          with_ssl_cert_key("#{ssldir}/private_keys/puppetmaster.example.com.pem").
-          with_ssl_ca_crl("#{ssldir}/ca/ca_crl.pem")
-      end
-    end
-  end
-
-  describe 'with server_passenger => false' do
-    let :pre_condition do
-      "class {'puppet': server => true, server_passenger => false}"
-    end
-
-    it { should compile.with_all_deps }
-    it { should_not contain_class('apache') }
-    it do
-      should contain_class('puppet::server::service').
-        with_puppetmaster(true).
-        with_puppetserver(nil)
-    end
-
-    describe "and server_service_fallback => false" do
-      let :pre_condition do
-        "class {'puppet': server => true, server_passenger => false, server_service_fallback => false}"
+      if Puppet.version < '4.0'
+        ssldir           = '/var/lib/puppet/ssl'
+        additional_facts = {}
+      else
+        ssldir           = '/etc/puppetlabs/puppet/ssl'
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
-      it { should compile.with_all_deps }
-      it do
-        should contain_class('puppet::server::service').
-          with_puppetmaster(false).
-          with_puppetserver(nil)
+      if os_facts[:osfamily] == 'FreeBSD'
+        ssldir = '/var/puppet/ssl'
       end
-    end
-  end
 
-  describe 'with server_implementation => "puppetserver"' do
-    let :pre_condition do
-      "class {'puppet': server => true, server_implementation => 'puppetserver'}"
-    end
+      server_package = 'puppet-server'
+      if os_facts[:osfamily] == 'Debian'
+        server_package = 'puppetmaster'
+      end
 
-    it { should compile.with_all_deps }
-    it { should_not contain_class('apache') }
-    it do
-      should contain_class('puppet::server::service').
-        with_puppetmaster(nil).
-        with_puppetserver(true)
-    end
-    it { should contain_class('puppet::server::puppetserver') }
-    it { should contain_package('puppetserver') }
-  end
+      let(:facts) { default_facts.merge(additional_facts) }
 
-  describe 'with unknown server_implementation' do
-    let :pre_condition do
-      "class {'puppet': server => true, server_implementation => 'golang'}"
-    end
-    it { should raise_error(Puppet::Error, /"golang" does not match/) }
-  end
+      describe 'basic case' do
+        let :pre_condition do
+          "class {'puppet': server => true}"
+        end
 
-  describe "when manage_packages => false" do
-    let :pre_condition do
-      "class { 'puppet': server => true, manage_packages => false,
-                         server_implementation => 'master' }"
-    end
+        describe 'with no custom parameters' do
+          it { should compile.with_all_deps }
+          it 'should include classes' do
+            should contain_class('puppet::server::install')
+            should contain_class('puppet::server::config')
+            should contain_class('puppet::server::service').
+              with_puppetmaster(false).
+              with_puppetserver(nil)
+          end
+          # No server_package for FreeBSD
+          if not os_facts[:osfamily] == 'FreeBSD'
+            it { should contain_package(server_package) }
+          end
+        end
+      end
 
-    it { should compile.with_all_deps }
-    it 'should not contain Package[puppet-server]' do
-      should_not contain_package('puppet-server')
-    end
-  end
+      describe 'with uppercase hostname' do
+        let :pre_condition do
+          "class {'puppet': server => true}"
+        end
 
-  describe "when manage_packages => 'agent'" do
-    let :pre_condition do
-      "class { 'puppet': server => true, manage_packages => 'agent',
-                         server_implementation => 'master' }"
-    end
+        let(:facts) do
+          super().merge({
+            :clientcert => 'PUPPETMASTER.example.com',
+            :fqdn       => 'PUPPETMASTER.example.com',
+          })
+        end
 
-    it { should compile.with_all_deps }
-    it 'should not contain Package[puppet-server]' do
-      should_not contain_package('puppet-server')
-    end
-  end
+        describe 'with no custom parameters' do
+          it 'should use lowercase certificates' do
+            should contain_class('puppet::server::passenger').
+              with_ssl_cert("#{ssldir}/certs/puppetmaster.example.com.pem").
+              with_ssl_cert_key("#{ssldir}/private_keys/puppetmaster.example.com.pem").
+              with_ssl_ca_crl("#{ssldir}/ca/ca_crl.pem")
+          end
+        end
+      end
 
-  describe "when manage_packages => 'server'" do
-    let :pre_condition do
-      "class { 'puppet': server => true, manage_packages => 'server',
-                         server_implementation => 'master' }"
-    end
+      describe 'with server_passenger => false' do
+        let :pre_condition do
+          "class {'puppet': server => true, server_passenger => false}"
+        end
 
-    it { should compile.with_all_deps }
-    it 'should contain Package[puppet-server]' do
-      should contain_package('puppet-server')
+        it { should compile.with_all_deps }
+        it { should_not contain_class('apache') }
+        it do
+          should contain_class('puppet::server::service').
+            with_puppetmaster(true).
+            with_puppetserver(nil)
+        end
+
+        describe "and server_service_fallback => false" do
+          let :pre_condition do
+            "class {'puppet': server => true, server_passenger => false, server_service_fallback => false}"
+          end
+
+          it { should compile.with_all_deps }
+          it do
+            should contain_class('puppet::server::service').
+              with_puppetmaster(false).
+              with_puppetserver(nil)
+          end
+        end
+      end
+
+      describe 'with server_implementation => "puppetserver"' do
+        let :pre_condition do
+          "class {'puppet': server => true, server_implementation => 'puppetserver'}"
+        end
+
+        it { should compile.with_all_deps }
+        it { should_not contain_class('apache') }
+        it do
+          should contain_class('puppet::server::service').
+            with_puppetmaster(nil).
+            with_puppetserver(true)
+        end
+        it { should contain_class('puppet::server::puppetserver') }
+        it { should contain_package('puppetserver') }
+      end
+
+      describe 'with unknown server_implementation' do
+        let :pre_condition do
+          "class {'puppet': server => true, server_implementation => 'golang'}"
+        end
+        it { should raise_error(Puppet::Error, /"golang" does not match/) }
+      end
+
+      describe "when manage_packages => false" do
+        let :pre_condition do
+          "class { 'puppet': server => true, manage_packages => false,
+                             server_implementation => 'master' }"
+        end
+
+        it { should compile.with_all_deps }
+        it "should not contain Package[#{server_package}]" do
+          should_not contain_package(server_package)
+        end
+      end
+
+      describe "when manage_packages => 'agent'" do
+        let :pre_condition do
+          "class { 'puppet': server => true, manage_packages => 'agent',
+                             server_implementation => 'master' }"
+        end
+
+        it { should compile.with_all_deps }
+        it "should not contain Package[#{server_package}]" do
+          should_not contain_package(server_package)
+        end
+      end
+
+      describe "when manage_packages => 'server'" do
+        let :pre_condition do
+          "class { 'puppet': server => true, manage_packages => 'server',
+                             server_implementation => 'master' }"
+        end
+
+        it { should compile.with_all_deps }
+        # Puppetmaster not supported on FreeBSD
+        if not os_facts[:osfamily] == 'FreeBSD'
+          it { should contain_package(server_package) }
+        end
+      end
+
     end
   end
 end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::server' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let (:default_facts) do
         os_facts.merge({

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'puppet::server::env' do
   on_supported_os.each do |os, os_facts|
-    next if limit_test_os() and not limit_test_os.include?(os)
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
     context "on #{os}" do
       let(:default_facts) do
         os_facts.merge({

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -1,223 +1,262 @@
 require 'spec_helper'
 
 describe 'puppet::server::env' do
-
-  let(:title) { 'foo' }
-
-  let :facts do {
-    :clientcert             => 'puppetmaster.example.com',
-    :concat_basedir         => '/nonexistant',
-    :fqdn                   => 'puppetmaster.example.com',
-    :rubyversion            => '1.9.3',
-    :operatingsystemrelease => '6.5',
-    :osfamily               => 'RedHat',
-  } end
-
-  context 'with no custom parameters' do
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => true}"
-      end
-
-      it 'should only deploy directories' do
-        should contain_file('/etc/puppet/environments/foo').with({
-          :ensure => 'directory',
-          :owner => 'puppet',
-          :group => nil,
-          :mode => '0755',
+  on_supported_os.each do |os, os_facts|
+    next if limit_test_os() and not limit_test_os.include?(os)
+    context "on #{os}" do
+      let(:default_facts) do
+        os_facts.merge({
+          :clientcert       => 'puppetmaster.example.com',
+          :concat_basedir   => '/nonexistant',
+          :fqdn             => 'puppetmaster.example.com',
+          :rubyversion      => '1.9.3',
+          :concat_basedir   => '/foo/bar',
+          :puppetversion    => Puppet.version,
         })
-
-        should contain_file('/etc/puppet/environments/foo/manifests').with({
-          :ensure => 'directory',
-          :owner => 'puppet',
-          :group => nil,
-          :mode => '0755',
-        })
-
-        should contain_file('/etc/puppet/environments/foo/modules').with({
-          :ensure => 'directory',
-          :owner => 'puppet',
-          :group => nil,
-          :mode => '0755',
-        })
-
-        should_not contain_file('/etc/puppet/environments/foo/environment.conf')
-        should_not contain_concat__fragment('puppet.conf+40-foo')
-      end
-    end
-
-    context 'with config environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => false}"
       end
 
-      it 'should add an env section' do
-        should contain_file('/etc/puppet/environments/foo').with({
-          :ensure => 'directory',
-          :owner => 'puppet',
-          :group => nil,
-          :mode => '0755',
-        })
-
-        should contain_file('/etc/puppet/environments/foo/modules').with({
-          :ensure => 'directory',
-          :owner => 'puppet',
-          :group => nil,
-          :mode => '0755',
-        })
-
-        should contain_concat__fragment('puppet.conf+40-foo').
-          without_content(/^\s+manifest\s+=/).
-          without_content(/^\s+manifestdir\s+=/).
-          with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/etc/puppet/modules:/usr/share/puppet/modules$}).
-          without_content(/^\s+templatedir\s+=/).
-          without_content(/^\s+config_version\s+=/).
-          with({}) # So we can use a trailing dot on each with_content line
-
-        should_not contain_file('/etc/puppet/environments/foo/environment.conf')
-      end
-    end
-  end
-
-  context 'with server_config_version' do
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => true, server_config_version => 'bar'}"
+      if Puppet.version < '4.0'
+        codedir = '/etc/puppet'
+        confdir = '/etc/puppet'
+        logdir  = '/var/log/puppet'
+        rundir  = '/var/run/puppet'
+        ssldir  = '/var/lib/puppet/ssl'
+        vardir  = '/var/lib/puppet'
+        sharedir = '/usr/share/puppet'
+        additional_facts = {}
+      else
+        codedir = '/etc/puppetlabs/code'
+        confdir = '/etc/puppetlabs/puppet'
+        logdir  = '/var/log/puppetlabs/puppet'
+        rundir  = '/var/run/puppetlabs'
+        ssldir  = '/etc/puppetlabs/puppet/ssl'
+        vardir  = '/opt/puppetlabs/puppet/cache'
+        sharedir = '/opt/puppetlabs/puppet'
+        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
-      it 'should set config_version in environment.conf' do
-        should contain_file('/etc/puppet/environments/foo/environment.conf').
-          with_content(%r{\Aconfig_version\s+= bar\n\z}).
-          with({}) # So we can use a trailing dot on each with_content line
-      end
-    end
-
-    context 'with config environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => false, server_config_version => 'bar'}"
+      if os_facts[:osfamily] == 'FreeBSD'
+        codedir = '/usr/local/etc/puppet'
+        confdir = '/usr/local/etc/puppet'
+        logdir  = '/var/log/puppet'
+        rundir  = '/var/run/puppet'
+        ssldir  = '/var/puppet/ssl'
+        vardir  = '/var/puppet'
+        sharedir = '/usr/local/share/puppet'
       end
 
-      it 'should add config_version to an env section' do
-        should contain_concat__fragment('puppet.conf+40-foo').
-          without_content(/^\s+manifest\s+=/).
-          without_content(/^\s+manifestdir\s+=/).
-          with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/etc/puppet/modules:/usr/share/puppet/modules$}).
-          without_content(/^\s+templatedir\s+=/).
-          with_content(/^\s+config_version\s+= bar/).
-          with({}) # So we can use a trailing dot on each with_content line
-      end
-    end
-  end
+      let(:facts) { default_facts.merge(additional_facts) }
 
-  context 'with config_version' do
-    let :params do
-      {
-        :config_version => 'bar',
-      }
-    end
+      let(:title) { 'foo' }
 
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => true}"
-      end
+      context 'with no custom parameters' do
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => true}"
+          end
 
-      it 'should set config_version in environment.conf' do
-        should contain_file('/etc/puppet/environments/foo/environment.conf').
-          with_content(%r{\Aconfig_version\s+= bar\n\z}).
-          with({}) # So we can use a trailing dot on each with_content line
-      end
-    end
+          it 'should only deploy directories' do
+            should contain_file("#{codedir}/environments/foo").with({
+              :ensure => 'directory',
+              :owner => 'puppet',
+              :group => nil,
+              :mode => '0755',
+            })
 
-    context 'with config environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => false}"
-      end
+            should contain_file("#{codedir}/environments/foo/manifests").with({
+              :ensure => 'directory',
+              :owner => 'puppet',
+              :group => nil,
+              :mode => '0755',
+            })
 
-      it 'should add config_version to an env section' do
-        should contain_concat__fragment('puppet.conf+40-foo').
-          without_content(/^\s+manifest\s+=/).
-          without_content(/^\s+manifestdir\s+=/).
-          with_content(%r{^\s+modulepath\s+= /etc/puppet/environments/foo/modules:/etc/puppet/environments/common:/etc/puppet/modules:/usr/share/puppet/modules$}).
-          without_content(/^\s+templatedir\s+=/).
-          with_content(/^\s+config_version\s+= bar/).
-          with({}) # So we can use a trailing dot on each with_content line
-      end
-    end
-  end
+            should contain_file("#{codedir}/environments/foo/modules").with({
+              :ensure => 'directory',
+              :owner => 'puppet',
+              :group => nil,
+              :mode => '0755',
+            })
 
-  context 'with modulepath' do
-    let :params do
-      {
-        :modulepath => ['/etc/puppet/example/modules', '/etc/puppet/vendor/modules'],
-      }
-    end
+            should_not contain_file("#{codedir}/environments/foo/environment.conf")
+            should_not contain_concat__fragment('puppet.conf+40-foo')
+          end
+        end
 
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => true}"
-      end
+        context 'with config environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => false}"
+          end
 
-      it 'should set modulepath in environment.conf' do
-        should contain_file('/etc/puppet/environments/foo/environment.conf').
-          with_content(%r{\Amodulepath\s+= /etc/puppet/example/modules:/etc/puppet/vendor/modules\n}).
-          with({}) # So we can use a trailing dot on each with_content line
-      end
-    end
-  end
+          it 'should add an env section' do
+            should contain_file("#{codedir}/environments/foo").with({
+              :ensure => 'directory',
+              :owner => 'puppet',
+              :group => nil,
+              :mode => '0755',
+            })
 
-  context 'with undef modulepath' do
-    let :params do
-      {
-        :modulepath => Undef.new,
-      }
-    end
+            should contain_file("#{codedir}/environments/foo/modules").with({
+              :ensure => 'directory',
+              :owner => 'puppet',
+              :group => nil,
+              :mode => '0755',
+            })
 
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => true}"
+            should contain_concat__fragment('puppet.conf+40-foo').
+              without_content(/^\s+manifest\s+=/).
+              without_content(/^\s+manifestdir\s+=/).
+              with_content(%r{^\s+modulepath\s+= #{codedir}/environments/foo/modules:#{codedir}/environments/common:#{codedir}/modules:#{sharedir}/modules$}).
+              without_content(/^\s+templatedir\s+=/).
+              without_content(/^\s+config_version\s+=/).
+              with({}) # So we can use a trailing dot on each with_content line
+
+            should_not contain_file("#{codedir}/environments/foo/environment.conf")
+          end
+        end
       end
 
-      it { should_not contain_file('/etc/puppet/environments/foo/environment.conf') }
-    end
-  end
+      context 'with server_config_version' do
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => true, server_config_version => 'bar'}"
+          end
 
-  context 'with manifest' do
-    let :params do
-      {
-        :manifest => 'manifests/local.pp',
-      }
-    end
+          it 'should set config_version in environment.conf' do
+            should contain_file("#{codedir}/environments/foo/environment.conf").
+              with_content(%r{\Aconfig_version\s+= bar\n\z}).
+              with({}) # So we can use a trailing dot on each with_content line
+          end
+        end
 
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => true}"
+        context 'with config environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => false, server_config_version => 'bar'}"
+          end
+
+          it 'should add config_version to an env section' do
+            should contain_concat__fragment('puppet.conf+40-foo').
+              without_content(/^\s+manifest\s+=/).
+              without_content(/^\s+manifestdir\s+=/).
+              with_content(%r{^\s+modulepath\s+= #{codedir}/environments/foo/modules:#{codedir}/environments/common:#{codedir}/modules:#{sharedir}/modules$}).
+              without_content(/^\s+templatedir\s+=/).
+              with_content(/^\s+config_version\s+= bar/).
+              with({}) # So we can use a trailing dot on each with_content line
+          end
+        end
       end
 
-      it 'should set manifest in environment.conf' do
-        should contain_file('/etc/puppet/environments/foo/environment.conf').
-          with_content(%r{\Amanifest\s+= manifests/local.pp\n\z}).
-          with({}) # So we can use a trailing dot on each with_content line
-      end
-    end
-  end
+      context 'with config_version' do
+        let :params do
+          {
+            :config_version => 'bar',
+          }
+        end
 
-  context 'with environment_timeout' do
-    let :params do
-      {
-        :environment_timeout => 'unlimited',
-      }
-    end
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => true}"
+          end
 
-    context 'with directory environments' do
-      let :pre_condition do
-        "class {'puppet': server => true, server_directory_environments => true}"
+          it 'should set config_version in environment.conf' do
+            should contain_file("#{codedir}/environments/foo/environment.conf").
+              with_content(%r{\Aconfig_version\s+= bar\n\z}).
+              with({}) # So we can use a trailing dot on each with_content line
+          end
+        end
+
+        context 'with config environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => false}"
+          end
+
+          it 'should add config_version to an env section' do
+            should contain_concat__fragment('puppet.conf+40-foo').
+              without_content(/^\s+manifest\s+=/).
+              without_content(/^\s+manifestdir\s+=/).
+              with_content(%r{^\s+modulepath\s+= #{codedir}/environments/foo/modules:#{codedir}/environments/common:#{codedir}/modules:#{sharedir}/modules$}).
+              without_content(/^\s+templatedir\s+=/).
+              with_content(/^\s+config_version\s+= bar/).
+              with({}) # So we can use a trailing dot on each with_content line
+          end
+        end
       end
 
-      it 'should set environment_timeout in environment.conf' do
-        should contain_file('/etc/puppet/environments/foo/environment.conf').
-          with_content(%r{\Aenvironment_timeout\s+= unlimited\n\z}).
-          with({}) # So we can use a trailing dot on each with_content line
+      context 'with modulepath' do
+        let :params do
+          {
+            :modulepath => ['/etc/puppet/example/modules', '/etc/puppet/vendor/modules'],
+          }
+        end
+
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => true}"
+          end
+
+          it 'should set modulepath in environment.conf' do
+            should contain_file("#{codedir}/environments/foo/environment.conf").
+              with_content(%r{\Amodulepath\s+= /etc/puppet/example/modules:/etc/puppet/vendor/modules\n}).
+              with({}) # So we can use a trailing dot on each with_content line
+          end
+        end
       end
+
+      context 'with undef modulepath' do
+        let :params do
+          {
+            :modulepath => Undef.new,
+          }
+        end
+
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => true}"
+          end
+
+          it { should_not contain_file("#{codedir}/environments/foo/environment.conf") }
+        end
+      end
+
+      context 'with manifest' do
+        let :params do
+          {
+            :manifest => 'manifests/local.pp',
+          }
+        end
+
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => true}"
+          end
+
+          it 'should set manifest in environment.conf' do
+            should contain_file("#{codedir}/environments/foo/environment.conf").
+              with_content(%r{\Amanifest\s+= manifests/local.pp\n\z}).
+              with({}) # So we can use a trailing dot on each with_content line
+          end
+        end
+      end
+
+      context 'with environment_timeout' do
+        let :params do
+          {
+            :environment_timeout => 'unlimited',
+          }
+        end
+
+        context 'with directory environments' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_directory_environments => true}"
+          end
+
+          it 'should set environment_timeout in environment.conf' do
+            should contain_file("#{codedir}/environments/foo/environment.conf").
+              with_content(%r{\Aenvironment_timeout\s+= unlimited\n\z}).
+              with({}) # So we can use a trailing dot on each with_content line
+          end
+        end
+      end
+
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,12 +11,21 @@ class Undef
   def inspect; 'undef'; end
 end
 
-# Running tests with the LIMIT_OS environment variable set
+# Running tests with the ONLY_OS environment variable set
 # limits the tested platforms to the specified values.
-# Example: LIMIT_OS=centos-7-x86_64,ubuntu-14-x86_64
-def limit_test_os
-  if ENV.key?('LIMIT_OS')
-    ENV['LIMIT_OS'].split(',')
+# Example: ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64
+def only_test_os
+  if ENV.key?('ONLY_OS')
+    ENV['ONLY_OS'].split(',')
+  end
+end
+
+# Running tests with the EXCLUDE_OS environment variable set
+# limits the tested platforms to all but the specified values.
+# Example: EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64
+def exclude_test_os
+  if ENV.key?('EXCLUDE_OS')
+    ENV['EXCLUDE_OS'].split(',')
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,15 @@ class Undef
   def inspect; 'undef'; end
 end
 
+# Running tests with the LIMIT_OS environment variable set
+# limits the tested platforms to the specified values.
+# Example: LIMIT_OS=centos-7-x86_64,ubuntu-14-x86_64
+def limit_test_os
+  if ENV.key?('LIMIT_OS')
+    ENV['LIMIT_OS'].split(',')
+  end
+end
+
 def get_content(subject, title)
   content = subject.resource('file', title).send(:parameters)[:content]
   content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }
@@ -28,4 +37,20 @@ end
 def verify_concat_fragment_exact_contents(subject, title, expected_lines)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
     content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end
+
+# See https://github.com/rodjek/rspec-puppet/issues/215
+# Without this patch the @@cache variable grows huge and causes memory usage issues
+# with a large amount of examples.
+module RSpec::Puppet
+  module Support
+    def build_catalog(*args)
+      if @@cache.has_key?(args)
+        @@cache[args]
+      else
+        @@cache = {}
+        @@cache[args] ||= self.build_catalog_without_cache(*args)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Before this change most tests would only run on centos-6-x86_64 and take a long time to run since on_supported_os would be evaluated for each example.

This change reduces the time to run tests as on_supported_os is only evaluated once per file as well as testing all OSes that on_supported_os returns.  When enabling testing other platforms various failures emerged, mostly for FreeBSD, that were fixed by adjusting variables where they were either missing or needed to be adjusted for e.g. FreeBSD. Redundant examples were removed but since Windows is not currently supported by on_supported_os all Windows specific tests are
left untouched.

This increases the test examples from 431 to 2276 while lowering the current total execution time of the 431 examples. But since the execution time of the whole suite across the whole matrix of platforms still takes "too long" an option was introduced to reduce the set of tested platforms to a comma seperated list. The option can be set with the environment variable LIMIT_OS, e.g. `LIMIT_OS=centos-7-x86_64,ubuntu-14-x86_64.`