### PR TITLE
reload the agent by sending a SIGHUP

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -34,19 +34,19 @@ class puppet::agent::service {
   anchor { 'puppet::agent::service_start': }
   anchor { 'puppet::agent::service_end': }
 
-  Anchor['puppet::agent::service_start'] ->
+  Anchor['puppet::agent::service_start'] ~>
   class { '::puppet::agent::service::daemon':
     enabled => $service_enabled,
   } ->
   Anchor['puppet::agent::service_end']
 
-  Anchor['puppet::agent::service_start'] ->
+  Anchor['puppet::agent::service_start'] ~>
   class { '::puppet::agent::service::systemd':
     enabled => $systemd_enabled,
   } ->
   Anchor['puppet::agent::service_end']
 
-  Anchor['puppet::agent::service_start'] ->
+  Anchor['puppet::agent::service_start'] ~>
   class { '::puppet::agent::service::cron':
     enabled => $cron_enabled,
   } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -272,8 +272,7 @@ class puppet::params {
       $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1') # workaround for the possibly missing operatingsystemmajrelease
       $agent_restart_command = $osreleasemajor ? {
         '6'     => "/sbin/service ${service_name} reload",
-        #'7'     => "/usr/bin/systemctl reload-or-restart ${service_name}",
-        '7'     => "/bin/kill -HUP $(pgrep -f '/usr/bin/ruby /usr/bin/puppet agent')",
+        '7'     => "/usr/bin/systemctl kill --signal SIGHUP --kill-who=main ${service_name}",
         default => undef,
       }
       $unavailable_runmodes = $osreleasemajor ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -272,7 +272,8 @@ class puppet::params {
       $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1') # workaround for the possibly missing operatingsystemmajrelease
       $agent_restart_command = $osreleasemajor ? {
         '6'     => "/sbin/service ${service_name} reload",
-        '7'     => "/usr/bin/systemctl reload-or-restart ${service_name}",
+        #'7'     => "/usr/bin/systemctl reload-or-restart ${service_name}",
+        '7'     => "/bin/kill -HUP $(pgrep -f '/usr/bin/ruby /usr/bin/puppet agent')",
         default => undef,
       }
       $unavailable_runmodes = $osreleasemajor ? {


### PR DESCRIPTION
Puppet does recognize this on its own and reloads the config.
```
puppet-agent[25329]: Config file /etc/puppet/puppet.conf changed;
triggering re-parse of all config files.
```