### PR TITLE
Start working on systemd timer support

### DIFF
--- a/manifests/agent/service/cron.pp
+++ b/manifests/agent/service/cron.pp
@@ -1,0 +1,32 @@
+class puppet::agent::service::cron (
+  $enabled = false,
+) {
+
+  case $enabled {
+    true: {
+      $command = $puppet::cron_cmd ? {
+        undef   => "/usr/bin/env puppet agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize",
+        default => $puppet::cron_cmd,
+      }
+
+      if $::osfamily == 'windows' {
+        fail("Currently we don't support setting cron on windows.")
+      } else {
+        $times = ip_to_cron($puppet::runinterval)
+        cron { 'puppet':
+          command => $command,
+          user    => root,
+          hour    => $times[0],
+          minute  => $times[1],
+        }
+      }
+    }
+    false: {
+      if $::osfamily != 'windows' {
+        cron { 'puppet':
+          ensure => absent,
+        }
+      }
+    }
+  }
+}

--- a/manifests/agent/service/daemon.pp
+++ b/manifests/agent/service/daemon.pp
@@ -1,0 +1,24 @@
+class puppet::agent::service::daemon (
+  $enabled = false,
+) {
+  case $enabled {
+    true: {
+      service {'puppet':
+        ensure     => running,
+        name       => $puppet::service_name,
+        hasstatus  => true,
+        hasrestart => $puppet::agent_restart_command != undef,
+        enable     => true,
+        restart    => $puppet::agent_restart_command,
+      }
+    }
+    false: {
+      service {'puppet':
+        ensure    => stopped,
+        name      => $puppet::service_name,
+        hasstatus => true,
+        enable    => false,
+      }
+    }
+  }
+}

--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -1,0 +1,70 @@
+class puppet::agent::service::systemd (
+  $enabled = false,
+) {
+  case $enabled {
+    true: {
+      # Use the same times as for cron
+      $times = ip_to_cron($puppet::runinterval)
+
+      $command = $puppet::cron_cmd ? {
+        undef   => "/usr/bin/env puppet agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize",
+        default => $puppet::cron_cmd,
+      }
+
+      file { '/etc/systemd/system/puppetcron.timer':
+        content => template('puppet/agent/systemd.puppetcron.timer.erb'),
+        notify  => Exec['systemctl-daemon-reload'],
+      }
+
+      file { '/etc/systemd/system/puppetcron.service':
+        content => template('puppet/agent/systemd.puppetcron.service.erb'),
+        notify  => Exec['systemctl-daemon-reload'],
+      }
+
+      exec { 'systemctl-daemon-reload':
+        refreshonly => true,
+        path        => $::path,
+        command     => 'systemctl daemon-reload',
+      }
+
+      service { 'puppetcron.timer':
+        provider  => 'systemd',
+        ensure    => running,
+        enable    => true,
+        subscribe => [
+          File['/etc/systemd/system/puppetcron.timer'],
+          File['/etc/systemd/system/puppetcron.service'],
+          Exec['systemctl-daemon-reload'],
+        ],
+      }
+    }
+    false: {
+      # Reverse order - stop, delete files, exec
+      service { 'puppetcron.timer':
+        provider => 'systemd',
+        ensure   => stopped,
+        enable   => false,
+        before   => [
+          File['/etc/systemd/system/puppetcron.timer'],
+          File['/etc/systemd/system/puppetcron.service'],
+        ],
+      }
+
+      file { '/etc/systemd/system/puppetcron.timer':
+        ensure => absent,
+        notify => Exec['systemctl-daemon-reload'],
+      }
+
+      file { '/etc/systemd/system/puppetcron.service':
+        ensure => absent,
+        notify  => Exec['systemctl-daemon-reload'],
+      }
+
+      exec { 'systemctl-daemon-reload':
+        refreshonly => true,
+        path        => $::path,
+        command     => 'systemctl daemon-reload',
+      }
+    }
+  }
+}

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -20,7 +20,7 @@ describe 'puppet::agent::service' do
       "class {'puppet': agent => true}"
     end
 
-    it do
+    it 'should enable daemon' do
       should contain_service('puppet').with({
         :ensure     => 'running',
         :name       => 'puppet',
@@ -29,7 +29,26 @@ describe 'puppet::agent::service' do
       })
     end
 
-    it { should contain_cron('puppet').with_ensure('absent') }
+    it 'should disable cron' do
+      should contain_cron('puppet').with_ensure('absent')
+    end
+
+    it 'should disable systemd timer' do
+      should contain_service('puppetcron.timer').with({
+        :provider => 'systemd',
+        :ensure   => 'stopped',
+        :name     => 'puppetcron.timer',
+        :enable   => 'false',
+      })
+
+      should contain_file('/etc/systemd/system/puppetcron.timer').with_ensure(:absent)
+      should contain_file('/etc/systemd/system/puppetcron.service').with_ensure(:absent)
+
+      should contain_exec('systemctl-daemon-reload').with({
+        :refreshonly => true,
+        :command     => 'systemctl daemon-reload',
+      })
+    end
   end
 
   describe 'when runmode => cron' do
@@ -37,7 +56,7 @@ describe 'puppet::agent::service' do
       "class {'puppet': agent => true, runmode => 'cron'}"
     end
 
-    it do
+    it 'should disable daemon' do
       should contain_service('puppet').with({
         :ensure     => 'stopped',
         :name       => 'puppet',
@@ -46,7 +65,7 @@ describe 'puppet::agent::service' do
       })
     end
 
-    it do
+    it 'should enable cron' do
       if Puppet.version < '4.0'
         confdir = '/etc/puppet'
       else
@@ -59,14 +78,31 @@ describe 'puppet::agent::service' do
         :hour     => '*',
       })
     end
+
+    it 'should disable systemd timer' do
+      should contain_service('puppetcron.timer').with({
+        :provider => 'systemd',
+        :ensure   => 'stopped',
+        :name     => 'puppetcron.timer',
+        :enable   => 'false',
+      })
+
+      should contain_file('/etc/systemd/system/puppetcron.timer').with_ensure(:absent)
+      should contain_file('/etc/systemd/system/puppetcron.service').with_ensure(:absent)
+
+      should contain_exec('systemctl-daemon-reload').with({
+        :refreshonly => true,
+        :command     => 'systemctl daemon-reload',
+      })
+    end
   end
 
-  describe 'when runmode => none' do
+  describe 'when runmode => systemd.timer' do
     let :pre_condition do
-      "class {'puppet': agent => true, runmode => 'none'}"
+      "class {'puppet': agent => true, runmode => 'systemd.timer'}"
     end
 
-    it do
+    it 'should disable daemon' do
       should contain_service('puppet').with({
         :ensure     => 'stopped',
         :name       => 'puppet',
@@ -75,7 +111,71 @@ describe 'puppet::agent::service' do
       })
     end
 
-    it { should contain_cron('puppet').with_ensure('absent') }
+    it 'should disable cron' do
+      should contain_cron('puppet').with_ensure('absent')
+    end
+
+    it 'should enable systemd timer' do
+      if Puppet.version < '4.0'
+        confdir = '/etc/puppet'
+      else
+        confdir = '/etc/puppetlabs/puppet'
+      end
+
+      should contain_file('/etc/systemd/system/puppetcron.timer')
+        .with_content(/.*OnCalendar\=\*\:15,45.*/)
+      should contain_file('/etc/systemd/system/puppetcron.service')
+        .with_content(/.*ExecStart=\/usr\/bin\/env puppet agent --config #{confdir}\/puppet.conf --onetime --no-daemonize.*/)
+
+      should contain_exec('systemctl-daemon-reload').with({
+        :refreshonly => true,
+        :command     => 'systemctl daemon-reload',
+      })
+
+      should contain_service('puppetcron.timer').with({
+        :provider => 'systemd',
+        :ensure   => 'running',
+        :name     => 'puppetcron.timer',
+        :enable   => 'true',
+      })
+    end
+  end
+
+  describe 'when runmode => none' do
+    let :pre_condition do
+      "class {'puppet': agent => true, runmode => 'none'}"
+    end
+
+    it 'should disable daemon' do
+      should contain_service('puppet').with({
+        :ensure     => 'stopped',
+        :name       => 'puppet',
+        :hasstatus  => 'true',
+        :enable     => 'false',
+      })
+    end
+
+    it 'should disable cron' do
+      should contain_cron('puppet').with_ensure('absent')
+    end
+
+    it 'should disable systemd timer' do
+      should contain_service('puppetcron.timer').with({
+        :provider => 'systemd',
+        :ensure   => 'stopped',
+        :name     => 'puppetcron.timer',
+        :enable   => 'false',
+      })
+
+      should contain_file('/etc/systemd/system/puppetcron.timer').with_ensure(:absent)
+      should contain_file('/etc/systemd/system/puppetcron.service').with_ensure(:absent)
+
+      should contain_exec('systemctl-daemon-reload').with({
+        :refreshonly => true,
+        :command     => 'systemctl daemon-reload',
+      })
+    end
+
   end
 
   describe 'when runmode => foo' do

--- a/templates/agent/systemd.puppetcron.service.erb
+++ b/templates/agent/systemd.puppetcron.service.erb
@@ -1,0 +1,8 @@
+[Unit]
+Description=Systemd Timer Service for Puppet Agent
+
+[Service]
+Type=oneshot
+ExecStart=<%= @command %>
+User=root
+Group=root

--- a/templates/agent/systemd.puppetcron.timer.erb
+++ b/templates/agent/systemd.puppetcron.timer.erb
@@ -1,0 +1,14 @@
+<%# ip_to_cron can return strings or arrays depending on the request -%>
+<%# so we make them always be strings, in the right format -%>
+<% @times[0] = @times[0].join(",") if @times[0].kind_of? Array -%>
+<% @times[1] = @times[1].join(",") if @times[1].kind_of? Array -%>
+[Unit]
+Description=Systemd Timer for Puppet Agent
+
+[Timer]
+OnActiveSec=0m
+OnCalendar=<%= @times[0] %>:<%= @times[1] %>
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This is a start, just to see if upstream want such a patch - I'm using it to good effect on my local systems.

For background, systemd can replicate the functionality of cron, which has some pros and some cons. Further, Archlinux is no longer shipping a cron daemon by default, and moving over to systemd timers. This patch adds support for a scheduled run of the agent via systemd timers.

This is a PoC. If there's upstream interest, then I still need to:

* correctly use `$puppet@::cron_cmd
* correctly clean up files/services depending on which option is used
* Add tests
* [optional] Split each of the three options to it's own subclass

Happy to do so if this is the right direction. Thoughts?