### PR TITLE
Add aio_package to be a parameter of the base class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,9 @@
 # $additional_settings::              A hash of additional main settings.
 #                                     type:hash
 #
+# $aio_package::                      Use the aio package. Defaults to false on puppet < 4
+#                                     type:boolean
+#
 # == puppet::agent parameters
 #
 # $agent::                            Should a puppet agent be installed
@@ -445,6 +448,7 @@ class puppet (
   $dir_group                       = $puppet::params::dir_group,
   $package_provider                = $puppet::params::package_provider,
   $package_source                  = $puppet::params::package_source,
+  $aio_package                     = $puppet::params::aio_package,
   $port                            = $puppet::params::port,
   $listen                          = $puppet::params::listen,
   $listen_to                       = $puppet::params::listen_to,
@@ -576,6 +580,7 @@ class puppet (
   validate_bool($server_puppetdb_swf)
   validate_bool($server_default_manifest)
   validate_bool($server_ssl_dir_manage)
+  validate_bool($aio_package)
 
   validate_hash($additional_settings)
   validate_hash($agent_additional_settings)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,9 @@ class puppet::params {
   $hiera_config        = '$confdir/hiera.yaml'
   $syslogfacility      = undef
   $environment         = $::environment
-  if versioncmp($::puppetversion, '4.0') < 0 {
+  if versioncmp($::puppetversion, '4.0') >= 0 {
+    $aio_package = true
+  } elsif versioncmp($::puppetversion, '4.0') < 0 {
     $aio_package = false
   } elsif $::osfamily == 'Windows' or $::rubysitedir =~ /\/opt\/puppetlabs\/puppet/ {
     $aio_package = true
@@ -305,5 +307,4 @@ class puppet::params {
   $server_default_manifest = false
   $server_default_manifest_path = '/etc/puppet/manifests/default_manifest.pp'
   $server_default_manifest_content = '' # lint:ignore:empty_string_assignment
-
 }


### PR DESCRIPTION
Hello:

I noticed that whenever I went to use this on my puppet 4 server, this happened:

````
[root@puppet-infra puppetserver]# puppet agent -t --environment puppetserver --server `hostname --fqdn` --noop
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Left match operand must result in a String value. Got an Undef Value. at /etc/puppetlabs/code/environments/puppetserver/modules/puppet/manifests/params.pp:227:12 on node puppet-infra.domain.com
````
While this doesn't appear to be related directly, I noticed that it got to the elsif in the first place because aio_package was false. This allows the user to define it.