### PR TITLE
Allow both server and use_srv_records to be defined for compatibility with <3.0

### DIFF
--- a/templates/agent/puppet.conf.erb
+++ b/templates/agent/puppet.conf.erb
@@ -23,9 +23,7 @@
     masterport        = <%= scope.lookupvar("::puppet::port") rescue 8140 %>
     environment       = <%= scope.lookupvar("::puppet::environment") %>
     certname          = <%= @clientcert %>
-<% if !@use_srv_records -%>
     server            = <%= if ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>
-<% end -%>
     listen            = <%= scope.lookupvar('::puppet::listen') %>
     splay             = <%= scope.lookupvar('::puppet::splay') %>
     splaylimit        = <%= scope.lookupvar('::puppet::splaylimit') %>


### PR DESCRIPTION
This provides proper operation of older versions of puppet that do not support srv records without interfering with the operation of srv records.They are not mutually exclusive options. Understandably <=2.x is not supported but this avoids other various hacks required to maintain archaic infrastructure until it is upgraded. Upgrading to 3.x is not an option as the dependency chain falls to facter and virt-what. Virt-what is not available for me currently.