### PR TITLE
refs #8389 - lower case FQDN in foreman_url parameter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -275,10 +275,11 @@ class puppet::params {
   }
 
   # Foreman parameters
+  $lower_fqdn              = downcase($::fqdn)
   $server_foreman          = true
   $server_facts            = true
   $server_puppet_basedir   = undef
-  $server_foreman_url      = "https://${::fqdn}"
+  $server_foreman_url      = "https://${lower_fqdn}"
   $server_foreman_ssl_ca   = undef
   $server_foreman_ssl_cert = undef
   $server_foreman_ssl_key  = undef


### PR DESCRIPTION
Ensures that the HTTP requests from ENC/report processors work
correctly and don't receive a 404.

Follow-up of https://github.com/theforeman/puppet-foreman_proxy/pull/148