### PR TITLE
Remove management of systemd timer unit on non-systemd OSes

### DIFF
--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -38,8 +38,8 @@ describe 'puppet::agent::service' do
           should contain_class('puppet::agent::service::daemon').with(:enabled => true)
           should contain_class('puppet::agent::service::cron').with(:enabled => false)
         end
-        case os_facts[:kernel]
-        when 'Linux'
+        case os
+        when /\Adebian-8/, /\A(redhat|centos|scientific)-7/, /\Afedora-/
           it do
             should contain_class('puppet::agent::service::systemd').with(:enabled => false)
             should contain_service('puppet-run.timer').with(:ensure => :stopped)
@@ -60,8 +60,8 @@ describe 'puppet::agent::service' do
           should contain_class('puppet::agent::service::daemon').with(:enabled => false)
           should contain_class('puppet::agent::service::cron').with(:enabled => true)
         end
-        case os_facts[:kernel]
-        when 'Linux'
+        case os
+        when /\Adebian-8/, /\A(redhat|centos|scientific)-7/, /\Afedora-/
           it do
             should contain_class('puppet::agent::service::systemd').with(:enabled => false)
             should contain_service('puppet-run.timer').with(:ensure => :stopped)
@@ -78,8 +78,8 @@ describe 'puppet::agent::service' do
         let :pre_condition do
           "class {'puppet': agent => true, runmode => 'systemd.timer'}"
         end
-        case os_facts[:kernel]
-        when 'Linux'
+        case os
+        when /\Adebian-8/, /\A(redhat|centos|scientific)-7/, /\Afedora-/
           it do
             should contain_class('puppet::agent::service::daemon').with(:enabled => false)
             should contain_class('puppet::agent::service::cron').with(:enabled => false)
@@ -110,8 +110,8 @@ describe 'puppet::agent::service' do
           should contain_class('puppet::agent::service::daemon').with(:enabled => false)
           should contain_class('puppet::agent::service::cron').with(:enabled => false)
         end
-        case os_facts[:kernel]
-        when 'Linux'
+        case os
+        when /\Adebian-8/, /\A(redhat|centos|scientific)-7/, /\Afedora-/
           it do
             should contain_class('puppet::agent::service::systemd').with(:enabled => false)
             should contain_service('puppet-run.timer').with(:ensure => :stopped)

--- a/spec/classes/puppet_agent_service_systemd_spec.rb
+++ b/spec/classes/puppet_agent_service_systemd_spec.rb
@@ -34,8 +34,8 @@ describe 'puppet::agent::service::systemd' do
           "class {'puppet': agent => true}"
         end
 
-        case os_facts[:kernel]
-        when 'Linux'
+        case os
+        when /\Adebian-8/, /\A(redhat|centos|scientific)-7/, /\Afedora-/
           it 'should disable systemd timer' do
             should contain_class('puppet::agent::service::systemd').with({
               'enabled' => false,
@@ -71,8 +71,8 @@ describe 'puppet::agent::service::systemd' do
           "class {'puppet': agent => true, runmode => 'systemd.timer'}"
         end
 
-        case os_facts[:kernel]
-        when 'Linux'
+        case os
+        when /\Adebian-8/, /\A(redhat|centos|scientific)-7/, /\Afedora-/
           it 'should enable systemd timer' do
             should contain_class('puppet::agent::service::systemd').with({
               'enabled' => true,


### PR DESCRIPTION
Check specific versions of Debian and EL OSes to stop managing the
systemd timer, as a service resource with the systemd provider will
fail on older OS releases.

Fixes GH-334