### PR TITLE
Contain service implementations inside puppet::agent::service

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -31,15 +31,24 @@ class puppet::agent::service {
     fail("Runmode of ${puppet::runmode} not supported on ${::kernel} operating systems!")
   }
 
+  anchor { 'puppet::agent::service_start': }
+  anchor { 'puppet::agent::service_end': }
+
+  Anchor['puppet::agent::service_start'] ->
   class { '::puppet::agent::service::daemon':
     enabled => $service_enabled,
-  }
+  } ->
+  Anchor['puppet::agent::service_end']
 
+  Anchor['puppet::agent::service_start'] ->
   class { '::puppet::agent::service::systemd':
     enabled => $systemd_enabled,
-  }
+  } ->
+  Anchor['puppet::agent::service_end']
 
+  Anchor['puppet::agent::service_start'] ->
   class { '::puppet::agent::service::cron':
     enabled => $cron_enabled,
-  }
+  } ->
+  Anchor['puppet::agent::service_end']
 }


### PR DESCRIPTION
Preserves ordering of the agent service(s) in relation to
puppet::agent::config etc.

Fixes GH-336