### PR TITLE
Expose v1 /status endpoint

### DIFF
--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -114,13 +114,19 @@ allow <%= @auth_allowed.join(', ') %>
 <% if @puppetversion.to_f >= 4.0 -%>
 path /puppet/v3/file
 allow *
+<% end -%>
 
+path /file
+allow *
+
+<% if @puppetversion.to_f >= 4.0 -%>
 path /puppet/v3/status
 method find
 allow *
 <% end -%>
 
-path /file
+path /status
+method find
 allow *
 
 ### Unauthenticated ACLs, for clients without valid certificates; authenticated


### PR DESCRIPTION
This is a departure from the default config in Puppet 3.x, however since Puppet 4 exposes the status endpoint by default I think this provides a more sane default.