### PR TITLE
remove duplicate concat_basedir

### DIFF
--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -11,7 +11,6 @@ describe 'puppet::server::env' do
           :concat_basedir   => '/nonexistant',
           :fqdn             => 'puppetmaster.example.com',
           :rubyversion      => '1.9.3',
-          :concat_basedir   => '/foo/bar',
           :puppetversion    => Puppet.version,
         })
       end


### PR DESCRIPTION
>/Users/weeks/Development/puppet-puppet/spec/defines/puppet_server_env_spec.rb:11: warning: duplicated key at line 14 ignored: :concat_basedir

Fixes this warning when running tests.