### PR TITLE
Swap hiera_config default values for Puppet 3.x and 4.x

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,13 +27,13 @@ class puppet::params {
     $server_puppetserver_dir = '/etc/puppetserver'
     $server_ruby_load_paths  = []
     $server_jruby_gem_home   = '/var/lib/puppet/jruby-gems'
-    $hiera_config            = '$codedir/hiera.yaml'
+    $hiera_config            = '$confdir/hiera.yaml'
   } else {
     $configtimeout           = undef
     $server_puppetserver_dir = '/etc/puppetlabs/puppetserver'
     $server_ruby_load_paths  = ['/opt/puppetlabs/puppet/lib/ruby/vendor_ruby']
     $server_jruby_gem_home   = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
-    $hiera_config            = '$confdir/hiera.yaml'
+    $hiera_config            = '$codedir/hiera.yaml'
   }
   $usecacheonfailure   = true
   $ca_server           = undef

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -21,7 +21,7 @@ describe 'puppet::config' do
         ssldir  = '/var/lib/puppet/ssl'
         vardir  = '/var/lib/puppet'
         sharedir = '/usr/share/puppet'
-        hiera_config = '$codedir/hiera.yaml'
+        hiera_config = '$confdir/hiera.yaml'
         additional_facts = {}
       else
         codedir = '/etc/puppetlabs/code'
@@ -31,7 +31,7 @@ describe 'puppet::config' do
         ssldir  = '/etc/puppetlabs/puppet/ssl'
         vardir  = '/opt/puppetlabs/puppet/cache'
         sharedir = '/opt/puppetlabs/puppet'
-        hiera_config = '$confdir/hiera.yaml'
+        hiera_config = '$codedir/hiera.yaml'
         additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
@@ -291,9 +291,9 @@ describe 'puppet::config' do
     } end
 
     if Puppet.version < '4.0'
-      hiera_config = '$codedir/hiera.yaml'
-    else
       hiera_config = '$confdir/hiera.yaml'
+    else
+      hiera_config = '$codedir/hiera.yaml'
     end
 
     describe 'with default parameters' do


### PR DESCRIPTION
`$codedir` should only be used on Puppet 4, and the Puppet 3 default
should be using `$confdir`.  This failed on Puppet 3 tests with:

    /Puppet::Server::Config/Exec[puppet_server_config-generate_ca_cert]/returns:
    Error converting value for param 'hiera_config': Could not find value for $codedir

Follows up #356.