### PR TITLE
Reset environment to 'production' while proxing CA requests.

### DIFF
--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -59,7 +59,7 @@ class puppet::server::passenger (
     include ::apache::mod::proxy
     include ::apache::mod::proxy_http
 
-    $custom_fragment = "ProxyPassMatch ^/([^/]+/certificate.*)$ ${puppet_ca_proxy}/\$1"
+    $custom_fragment = "ProxyPassMatch ^/[^/]+/(certificate.*)$ ${puppet_ca_proxy}/production/\$1"
     $ssl_proxyengine = true
   } else {
     $custom_fragment = undef

--- a/spec/classes/puppet_server_passenger_spec.rb
+++ b/spec/classes/puppet_server_passenger_spec.rb
@@ -45,7 +45,7 @@ describe 'puppet::server::passenger' do
         it 'should include the puppet vhost' do
           should contain_apache__vhost('puppet').with({
             :ssl_proxyengine => true,
-            :custom_fragment => "ProxyPassMatch ^/([^/]+/certificate.*)$ https://ca.example.org:8140/$1",
+            :custom_fragment => "ProxyPassMatch ^/[^/]+/(certificate.*)$ https://ca.example.org:8140/production/$1",
           })
         end
       end


### PR DESCRIPTION
This changes make it possible do not deploy environments used on master to proxed CA