### PR TITLE
Allow to specify the listen ip address of the puppetserver

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -251,6 +251,9 @@
 # $server_dir::                       Puppet configuration directory
 #                                     type:string
 #
+# $server_ip::                        Bind ip address of the puppetmaster
+#                                     type:string
+#
 # $server_port::                      Puppet master port
 #                                     type:integer
 #
@@ -645,6 +648,7 @@ class puppet (
   $server_user                     = $puppet::params::user,
   $server_group                    = $puppet::params::group,
   $server_dir                      = $puppet::params::dir,
+  $server_ip                       = $puppet::params::ip,
   $server_port                     = $puppet::params::port,
   $server_ca                       = $puppet::params::server_ca,
   $server_ca_auth_required         = $puppet::params::server_ca_auth_required,
@@ -815,6 +819,14 @@ class puppet (
     validate_array($server_admin_api_whitelist)
     validate_bool($server_enable_ruby_profiler)
     validate_bool($server_ca_auth_required)
+  } else {
+    if $server_ip != $puppet::params::ip {
+      notify {
+        'ip_not_supported':
+          message  => "Bind IP address is unsupported for the ${server_implementation} implementation.",
+          loglevel => 'warning',
+      }
+    }
   }
 
   include ::puppet::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class puppet::params {
   $version             = 'present'
   $user                = 'puppet'
   $group               = 'puppet'
+  $ip                  = '0.0.0.0'
   $port                = 8140
   $listen              = false
   $listen_to           = []

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -12,6 +12,10 @@ describe 'puppet::server::puppetserver' do
           :processorcount => 1,
       }) end
 
+      let :pre_condition do
+        "class {'puppet': server_implementation => 'puppetserver'}"
+      end
+
       if Puppet.version < '4.0'
         additional_facts = {}
       else
@@ -68,7 +72,8 @@ describe 'puppet::server::puppetserver' do
         it { should contain_file('/etc/custom/puppetserver/conf.d/ca.conf') }
         it { should contain_file('/etc/custom/puppetserver/conf.d/puppetserver.conf') }
         it { should contain_file('/etc/custom/puppetserver/conf.d/web-routes.conf') }
-        it { should contain_file('/etc/custom/puppetserver/conf.d/webserver.conf') }
+        it { should contain_file('/etc/custom/puppetserver/conf.d/webserver.conf').
+                                 with_content(/ssl-host\s+=\s0\.0\.0\.0/) }
         it { should contain_file('/etc/custom/puppetserver/conf.d/auth.conf') }
       end
 
@@ -92,8 +97,7 @@ describe 'puppet::server::puppetserver' do
       end
 
       describe 'with jvm_config file parameter' do
-        let :params do
-          default_params.merge({
+        let :params do default_params.merge({
             :config => '/etc/custom/puppetserver',
           })
         end
@@ -105,6 +109,21 @@ describe 'puppet::server::puppetserver' do
         }
       end
 
+      describe 'with server_ip parameter given to the puppet class' do
+        let(:params) do
+          default_params.merge({
+            :server_puppetserver_dir => '/etc/custom/puppetserver',
+          })
+        end
+
+        let :pre_condition do
+          "class {'puppet': server_ip => '127.0.0.1', server_implementation => 'puppetserver'}"
+        end
+
+        it 'should put the correct ip address in webserver.conf' do
+          should contain_file('/etc/custom/puppetserver/conf.d/webserver.conf').with_content(/ssl-host\s+=\s127\.0\.0\.1/)
+        end
+      end
     end
   end
 end

--- a/templates/server/puppetserver/conf.d/webserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/webserver.conf.erb
@@ -1,7 +1,7 @@
 webserver: {
     access-log-config = <%= scope.lookupvar('puppet::server_puppetserver_dir') %>/request-logging.xml
     client-auth       = want
-    ssl-host          = 0.0.0.0
+    ssl-host          = <%= scope.lookupvar('puppet::server_ip') %>
     ssl-port          = <%= scope.lookupvar('puppet::server_port') %>
     ssl-cert          = <%= scope.lookupvar('puppet::server::ssl_cert') %>
     ssl-key           = <%= scope.lookupvar('puppet::server::ssl_cert_key') %>


### PR DESCRIPTION
Such an attempt was done in the past (#200) but was very complex due to
the use of apache::vhost, which does mot allow mixing IP and non-IP
based vhosts.

This PR only takes care of the Puppetserver side and issues a warning if
users try to change the IP address with the puppetmaster implementation.