### PR TITLE
Add new 'server_use_legacy_auth_conf' parameter.  Defaults to false.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ The Puppet master is configured under Apache and Passenger by default, unless
 3.x based installation, `server_implementation` can be set to `puppetserver`
 to switch to the JVM-based Puppet Server.
 
+When using Puppet Server 2 (version 2.0 was the first version to support Puppet 4),
+the module supports and assumes you will be installing the latest version (currently 2.3.1).
+If you know you'll be installing an earlier version, you will need to override
+`server_puppetserver_version`.
+
 Many puppet.conf options for agents, masters and other are parameterized, with
 class documentation provided at the top of the manifests. In addition, there
 are hash parameters for each configuration section that can be used to supply

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -523,6 +523,12 @@
 # $server_puppetserver_dir::          The path of the puppetserver config dir
 #                                     type:string
 #
+# $server_puppetserver_version::      The version of puppetserver 2 installed (or being installed)
+#                                     Unfortunately, different versions of puppetserver need configuring differently,
+#                                     and there's no easy way of determining which version is being installed.
+#                                     Defaults to '2.3.1' but can be overriden if you're installing an older version.
+#                                     type:string
+#
 # $server_max_active_instances::      Max number of active jruby instances. Defaults to
 #                                     processor count
 #                                     type:integer
@@ -562,6 +568,10 @@
 #
 # $server_ca_auth_required::          Whether client certificates are needed to access the puppet-admin api
 #                                     Defaults to true
+#                                     type:boolean
+#
+# $server_use_legacy_auth_conf::      Should the puppetserver use the legacy puppet auth.conf?
+#                                     Defaults to false (the puppetserver will use its own conf.d/auth.conf)
 #                                     type:boolean
 #
 # === Usage:
@@ -662,6 +672,7 @@ class puppet (
   $server_implementation           = $puppet::params::server_implementation,
   $server_passenger                = $puppet::params::server_passenger,
   $server_puppetserver_dir         = $puppet::params::server_puppetserver_dir,
+  $server_puppetserver_version     = $puppet::params::server_puppetserver_version,
   $server_service_fallback         = $puppet::params::server_service_fallback,
   $server_passenger_max_pool       = $puppet::params::server_passenger_max_pool,
   $server_httpd_service            = $puppet::params::server_httpd_service,
@@ -727,6 +738,7 @@ class puppet (
   $server_jvm_extra_args           = $puppet::params::server_jvm_extra_args,
   $server_jruby_gem_home           = $puppet::params::server_jruby_gem_home,
   $server_max_active_instances     = $puppet::params::server_max_active_instances,
+  $server_use_legacy_auth_conf     = $puppet::params::server_use_legacy_auth_conf,
 ) inherits puppet::params {
 
   validate_bool($listen)
@@ -819,6 +831,8 @@ class puppet (
     validate_array($server_admin_api_whitelist)
     validate_bool($server_enable_ruby_profiler)
     validate_bool($server_ca_auth_required)
+    validate_bool($server_use_legacy_auth_conf)
+    validate_re($server_puppetserver_version, '^[\d]\.[\d]\.[\d]$')
   } else {
     if $server_ip != $puppet::params::ip {
       notify {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -349,4 +349,10 @@ class puppet::params {
   $server_ca_client_whitelist      = [ '127.0.0.1', '::1', $::ipaddress ]
   $server_cipher_suites            = [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA', 'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA', ]
   $server_ssl_protocols            = [ 'TLSv1.2', ]
+
+  # Puppetserver >= 2.2  Which auth.conf shall we use? https://docs.puppetlabs.com/puppetserver/latest/config_file_auth.html#aside-changes-to-authorization-in-puppet-server-220
+  $server_use_legacy_auth_conf     = false
+
+  # For puppetserver 2, certain configuration parameters are version specific.  We assume a particular version here.
+  $server_puppetserver_version     = '2.3.1'
 }

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -68,6 +68,8 @@ class puppet::server::puppetserver (
   $vardir                      = $::puppet::vardir,
   $server_ca_client_whitelist  = $::puppet::server_ca_client_whitelist,
   $server_admin_api_whitelist  = $::puppet::server_admin_api_whitelist,
+  $server_puppetserver_version = $::puppet::server_puppetserver_version,
+  $server_use_legacy_auth_conf = $::puppet::server_use_legacy_auth_conf,
 ) {
   include ::puppet::server
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -77,6 +77,44 @@ describe 'puppet::server::puppetserver' do
         it { should contain_file('/etc/custom/puppetserver/conf.d/auth.conf') }
       end
 
+      describe 'use-legacy-auth-conf' do
+        context 'with default parameters' do
+          let(:params) do
+            default_params.merge({
+              :server_puppetserver_dir => '/etc/custom/puppetserver',
+            })
+          end
+          it 'should have use-legacy-auth-conf: false in puppetserver.conf' do
+            content = catalogue.resource('file', '/etc/custom/puppetserver/conf.d/puppetserver.conf').send(:parameters)[:content]
+            expect(content).to include(%Q[    use-legacy-auth-conf: false\n])
+          end
+        end
+        context 'when use-legacy-auth-conf = true' do
+          let(:params) do
+            default_params.merge({
+              :server_use_legacy_auth_conf => true,
+              :server_puppetserver_dir     => '/etc/custom/puppetserver',
+            })
+          end
+          it 'should have use-legacy-auth-conf: true in puppetserver.conf' do
+            content = catalogue.resource('file', '/etc/custom/puppetserver/conf.d/puppetserver.conf').send(:parameters)[:content]
+            expect(content).to include(%Q[    use-legacy-auth-conf: true\n])
+          end
+        end
+        context 'when server_puppetserver_version < 2.2' do
+          let(:params) do
+            default_params.merge({
+              :server_puppetserver_version => '2.1.2',
+              :server_puppetserver_dir     => '/etc/custom/puppetserver',
+            })
+          end
+          it 'should not have a use-legacy-auth-conf setting in puppetserver.conf' do
+            content = catalogue.resource('file', '/etc/custom/puppetserver/conf.d/puppetserver.conf').send(:parameters)[:content]
+            expect(content).not_to include('use-legacy-auth-conf')
+          end
+        end
+      end
+
       describe 'with extra_args parameter' do
         let :params do
           default_params.merge({

--- a/templates/server/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/puppetserver.conf.erb
@@ -21,6 +21,11 @@ jruby-puppet: {
 
     # (optional) maximum number of JRuby instances to allow
     max-active-instances: <%= @server_max_active_instances %>
+
+<%- if scope.function_versioncmp([@server_puppetserver_version, '2.2']) >= 0 -%>
+    use-legacy-auth-conf: <%= @server_use_legacy_auth_conf %>
+<%- end %>
+
 }
 
 # settings related to HTTP client requests made by Puppet Server


### PR DESCRIPTION
For puppetserver 2, ```/etc/puppetlabs/puppetserver/conf.d/auth.conf``` is
only used if ```use-legacy-auth-conf``` is set to false in puppetserver.conf

The second commit adjusts ```/etc/puppetlabs/puppetserver/conf.d/auth.conf``` to allow access to the [Resource Type API](https://docs.puppetlabs.com/puppet/latest/reference/http_api/http_resource_type.html) This will be needed by the foreman puppet smart-proxy if/when https://github.com/theforeman/smart-proxy/pull/376 is merged.