### PR TITLE
Make sure puppet::server is included in puppet::server::puppetserver

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -6,8 +6,9 @@ class puppet::server::config inherits puppet::config {
   }
 
   if $puppet::server_implementation == 'puppetserver' {
+    include ::puppet::server::puppetserver
     anchor {'::puppet::server::puppetserver_start': } ->
-    class { '::puppet::server::puppetserver': } ~>
+    Class['::puppet::server::puppetserver'] ~>
     anchor {'::puppet::server::puppetserver_end': }
   }
 

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -70,6 +70,7 @@ class puppet::server::puppetserver (
   $server_admin_api_whitelist  = $::puppet::server_admin_api_whitelist,
 ) {
   require ::puppet::server::augeaslens
+  include ::puppet::server
 
   $puppetserver_package = pick($::puppet::server_package, 'puppetserver')
 


### PR DESCRIPTION
the issue was that the puppetserver tests included only ::puppet and ::puppet::server::puppetserver, but not ::puppet::server, which caused issues if ::puppet::server::puppetserver accessed variables from ::puppet::server such as in #364

Thanks to @roidelapluie 