### PR TITLE
Add support for puppet agent certname

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -229,6 +229,10 @@
 # $remove_lock::                      Remove the agent lock when running.
 #                                     type:boolean
 #
+# $client_certname::                  The node’s certificate name, and the unique
+#                                     identifier it uses when requesting catalogs.
+#                                     type:string
+#
 # $dir_owner::                        Owner of the base puppet directory, used when
 #                                     puppet::server is false.
 #                                     type:string
@@ -638,6 +642,7 @@ class puppet (
   $client_package                  = $puppet::params::client_package,
   $agent                           = $puppet::params::agent,
   $remove_lock                     = $puppet::params::remove_lock,
+  $client_certname                 = $puppet::params::client_certname,
   $puppetmaster                    = $puppet::params::puppetmaster,
   $systemd_unit_name               = $puppet::params::systemd_unit_name,
   $service_name                    = $puppet::params::service_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,6 +151,7 @@ class puppet::params {
   # Will this host be a puppet agent ?
   $agent                     = true
   $remove_lock               = true
+  $client_certname           = $::clientcert
 
   # Custom puppetmaster
   if defined('$trusted') and $::trusted['authenticated'] == 'local' {

--- a/templates/agent/puppet.conf.erb
+++ b/templates/agent/puppet.conf.erb
@@ -22,7 +22,7 @@
     pluginsync        = <%= scope.lookupvar('::puppet::pluginsync') %>
     masterport        = <%= scope.lookupvar("::puppet::port") rescue 8140 %>
     environment       = <%= scope.lookupvar("::puppet::environment") %>
-    certname          = <%= @clientcert %>
+    certname          = <%= scope.lookupvar("::puppet::client_certname") %>
 <% if !@use_srv_records -%>
     server            = <%= if ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>
 <% end -%>


### PR DESCRIPTION
In some cases you need to set custom client cert name in agent section of puppet.conf file.
For example if you are using pre-generated or generic certificate