### PR TITLE
Update puppetserver conf.d/auth.conf

### DIFF
--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -30,7 +30,7 @@ authorization: {
                 type: path
                 method: get
             }
-            allow: "*"
+            allow-unauthenticated: true
             sort-order: 500
             name: "puppetlabs crl"
         },
@@ -54,6 +54,16 @@ authorization: {
             allow: "*"
             sort-order: 500
             name: "puppetlabs environments"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/resource_type"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs resource type"
         },
         {
             # Allow nodes to access all file services; this is necessary for
@@ -100,6 +110,16 @@ authorization: {
             allow-unauthenticated: true
             sort-order: 500
             name: "puppetlabs status"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/static_file_content"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs static file content"
         },
         {
           # Deny everything else. This ACL is not strictly


### PR DESCRIPTION
Taken from the puppetserver 2.3.1 RPM.
In particular, I ran into problems with the 'puppetlabs crl' rule not
allowing unauthenticated access.  This is required when proxying CA
endpoints from another puppet master.

https://docs.puppet.com/guides/scaling_multiple_masters.html#option-2-proxy-certificate-traffic

I'm not sure about the new "puppetlabs static file content" rule.  But I
guess if it's in the RPMs being shipped someone will probably miss it if
it's omitted.