### PR TITLE
remove useless parameter server_passenger_max_pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * New or changed parameters:
     * Add server_ip for configuring the listen IP (puppetserver only)
     * Add passenger_min_instances and passenger_pre_start for passenger tuning
+    * Remove passenger_max_pool which had no effect
 * Other features:
     * Support puppetserver 2.x
 * Other changes and fixes:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -419,11 +419,6 @@
 #                                     use the puppetmaster service. Defaults to true.
 #                                     type:boolean
 #
-# $server_passenger_max_pool::        The PassengerMaxPoolSize parameter. If your
-#                                     host is low on memory, it may be a good thing
-#                                     to lower this. Defaults to 12.
-#                                     type:integer
-#
 # $server_passenger_min_instances::   The PassengerMinInstances parameter. Sets the
 #                                     minimum number of application processes to run.
 #                                     Defaults to the number of processors on your
@@ -684,7 +679,6 @@ class puppet (
   $server_puppetserver_dir         = $puppet::params::server_puppetserver_dir,
   $server_puppetserver_version     = $puppet::params::server_puppetserver_version,
   $server_service_fallback         = $puppet::params::server_service_fallback,
-  $server_passenger_max_pool       = $puppet::params::server_passenger_max_pool,
   $server_passenger_min_instances  = $puppet::params::server_passenger_min_instances,
   $server_passenger_pre_start      = $puppet::params::server_passenger_pre_start,
   $server_httpd_service            = $puppet::params::server_httpd_service,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -167,7 +167,6 @@ class puppet::params {
   $server_reports             = 'foreman'
   $server_passenger           = true
   $server_service_fallback    = true
-  $server_passenger_max_pool  = 12
   $server_passenger_min_instances = $::processorcount
   $server_passenger_pre_start = true
   $server_httpd_service       = 'httpd'

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -4,7 +4,6 @@
 #
 class puppet::server::passenger (
   $app_root                = $::puppet::server_app_root,
-  $passenger_max_pool      = $::puppet::server_passenger_max_pool,
   $passenger_min_instances = $::puppet::server_passenger_min_instances,
   $passenger_pre_start     = $::puppet::server_passenger_pre_start,
   $port                    = $::puppet::server_port,


### PR DESCRIPTION
@mmoll: Just some cleanup :-)

```passenger_max_pool``` is a global passenger setting which we do not want to support. The parameter is not passed through to puppetlabs-apache module and therefore has no effect.