### PR TITLE
add versioned-code-service on puppetserver >= 2.3

### DIFF
--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -110,6 +110,18 @@ class puppet::server::puppetserver (
     line   => 'puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service',
   }
 
+  if versioncmp($server_puppetserver_version, '2.3') >= 0 {
+    $versioned_code_service_ensure = present
+  } else {
+    $versioned_code_service_ensure = absent
+  }
+
+  file_line { 'versioned_code_service':
+    ensure => $versioned_code_service_ensure,
+    path   => "${server_puppetserver_dir}/bootstrap.cfg",
+    line   => 'puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service',
+  }
+
   file { "${server_puppetserver_dir}/conf.d/ca.conf":
     ensure  => file,
     content => template('puppet/server/puppetserver/conf.d/ca.conf.erb'),

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -115,6 +115,35 @@ describe 'puppet::server::puppetserver' do
         end
       end
 
+      describe 'versioned-code-service' do
+        context 'when server_puppetserver_version >= 2.3' do
+          let(:params) do
+            default_params.merge({
+                                     :server_puppetserver_dir => '/etc/custom/puppetserver',
+                                 })
+          end
+          it 'should have versioned-code-service in bootstrap.cfg' do
+            should contain_file_line('versioned_code_service').
+                with_ensure('present').
+                with_line('puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service')
+          end
+        end
+
+        context 'when server_puppetserver_version < 2.3' do
+          let(:params) do
+            default_params.merge({
+                                     :server_puppetserver_version => '2.2.2',
+                                     :server_puppetserver_dir     => '/etc/custom/puppetserver',
+                                 })
+          end
+          it 'should not have versioned-code-service in bootstrap.cfg' do
+            should contain_file_line('versioned_code_service').
+                with_ensure('absent').
+                with_line('puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service')
+          end
+        end
+      end
+
       describe 'with extra_args parameter' do
         let :params do
           default_params.merge({


### PR DESCRIPTION
This eases upgrades of puppetserver to 2.3, see
https://docs.puppet.com/puppetserver/2.3/release_notes.html#modifications-to-bootstrapcfg-might-cause-problems-during-upgrades-to-230

closes GH-373