### PR TITLE
Ensure `$puppet::server_ssl_dir` is created before managing `private_…

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -48,10 +48,11 @@ class puppet::server::config inherits puppet::config {
   ## SSL and CA configuration
   # Open read permissions to private keys to puppet group for foreman, proxy etc.
   file { "${puppet::server_ssl_dir}/private_keys":
-    ensure => directory,
-    owner  => $puppet::server_user,
-    group  => $puppet::server_group,
-    mode   => '0750',
+    ensure  => directory,
+    owner   => $puppet::server_user,
+    group   => $puppet::server_group,
+    mode    => '0750',
+    require => Exec['puppet_server_config-create_ssl_dir'],
   }
 
   file { "${puppet::server_ssl_dir}/private_keys/${::puppet::server_certname}.pem":


### PR DESCRIPTION
This should prevent the following error when changing the location of server_ssl_dir:
```
Error: Cannot create /var/lib/puppet/ssl/private_keys; parent directory /var/lib/puppet/ssl does not exist
Error: /Stage[main]/Puppet::Server::Config/File[/var/lib/puppet/ssl/private_keys]/ensure: change from absent to directory failed: Cannot create /var/lib/puppet/ssl/private_keys; parent directory /var/lib/puppet/ssl does not exist
```