### PR TITLE
Bump requirement of puppet to 3.1.0 and drop namespaceauth.conf.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,6 @@ class puppet::config(
   $listen_to          = $::puppet::listen_to,
   $main_template      = $::puppet::main_template,
   $module_repository  = $::puppet::module_repository,
-  $nsauth_template    = $::puppet::nsauth_template,
   $pluginsource       = $::puppet::pluginsource,
   $pluginfactsource   = $::puppet::pluginfactsource,
   $puppet_dir         = $::puppet::dir,
@@ -45,11 +44,5 @@ class puppet::config(
   } ~>
   file { "${puppet_dir}/auth.conf":
     content => template($auth_template),
-  }
-
-  if $puppet::listen {
-    file { "${puppet_dir}/namespaceauth.conf":
-      content => template($nsauth_template),
-    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,9 +162,6 @@
 #                                     configuration.
 #                                     type:string
 #
-# $nsauth_template::                  Use a custom template for the nsauth configuration.
-#                                     type:string
-#
 # $main_template::                    Use a custom template for the main puppet
 #                                     configuration.
 #                                     type:string
@@ -650,7 +647,6 @@ class puppet (
   $main_template                   = $puppet::params::main_template,
   $agent_template                  = $puppet::params::agent_template,
   $auth_template                   = $puppet::params::auth_template,
-  $nsauth_template                 = $puppet::params::nsauth_template,
   $allow_any_crl_auth              = $puppet::params::allow_any_crl_auth,
   $auth_allowed                    = $puppet::params::auth_allowed,
   $client_package                  = $puppet::params::client_package,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -138,7 +138,6 @@ class puppet::params {
   $main_template   = 'puppet/puppet.conf.erb'
   $agent_template  = 'puppet/agent/puppet.conf.erb'
   $auth_template   = 'puppet/auth.conf.erb'
-  $nsauth_template = 'puppet/namespaceauth.conf.erb'
 
   # Allow any to the CRL. Needed in case of puppet CA proxy
   $allow_any_crl_auth = false

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.1.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/templates/namespaceauth.conf.erb
+++ b/templates/namespaceauth.conf.erb
@@ -1,2 +1,0 @@
-[puppetrun]
-    allow <%= @puppetmaster rescue @fqdn %>


### PR DESCRIPTION
Replace `rescue` with `||` in namespaceauth template as it was probably intended.