### PR TITLE
fixes #15132 - support services.d/ configuration in Puppet Server 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ The Puppet master is configured under Apache and Passenger by default, unless
 to switch to the JVM-based Puppet Server.
 
 When using Puppet Server 2 (version 2.0 was the first version to support Puppet 4),
-the module supports and assumes you will be installing the latest version (currently 2.3.1).
-If you know you'll be installing an earlier version, you will need to override
-`server_puppetserver_version`.
+the module supports and assumes you will be installing the latest version.
+If you know you'll be installing an earlier or specific version, you will
+need to override `server_puppetserver_version`. More information in the Puppet
+Server section below.
 
 Many puppet.conf options for agents, masters and other are parameterized, with
 class documentation provided at the top of the manifests. In addition, there
@@ -160,6 +161,23 @@ host can access all client catalogues and client certificates. **
       server_http_port     => 8130, # default: 8139
       server_http_allow    => ['10.20.30.1', 'puppetbalancer.my.corp'],
     }
+
+## Puppet Server configuration
+
+Puppet Server requires slightly different configuration between different
+versions, which this module supports. It's recommended that you set the
+`server_puppetserver_version` parameter to the MAJOR.MINOR.PATCH version
+you have installed. By default the module will configure for the latest
+version available.
+
+Currently supported values and configuration behaviours are:
+
+* `2.5.x` - configures the certificate authority in `ca.cfg`
+* `2.4.99` (default) - configures for both 2.4 and 2.5, with `bootstrap.cfg`
+  and `ca.cfg`
+* `2.3.x`, `2.4.x` - configures the certificate authority and
+  versioned-code-service in `bootstrap.cfg`
+* `2.2.x` or lower - configures the certificate authority in `bootstrap.cfg`
 
 # Contributing
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -361,5 +361,5 @@ class puppet::params {
   $server_use_legacy_auth_conf     = false
 
   # For puppetserver 2, certain configuration parameters are version specific. We assume a particular version here.
-  $server_puppetserver_version     = '2.3.1'
+  $server_puppetserver_version     = '2.4.99'
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -510,7 +510,7 @@ class puppet::server(
     validate_bool($enable_ruby_profiler)
     validate_bool($ca_auth_required)
     validate_bool($use_legacy_auth_conf)
-    validate_re($puppetserver_version, '^[\d]\.[\d]\.[\d]$')
+    validate_re($puppetserver_version, '^[\d]\.[\d]+\.[\d]+$')
   } else {
     if $ip != $puppet::params::ip {
       notify {

--- a/templates/server/puppetserver/services.d/ca.cfg.erb
+++ b/templates/server/puppetserver/services.d/ca.cfg.erb
@@ -1,0 +1,5 @@
+# To enable the CA service, leave the following line uncommented
+<%= '#' unless @server_ca -%>puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+# To disable the CA service, comment out the above line and uncomment the line below
+<%= '#' if @server_ca -%>puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+


### PR DESCRIPTION
PS 2.5 moves CA configuration from bootstrap.cfg to a services.d/ca.cfg
file, separating user config (CA) from app config (e.g. versioned code
service). This is now configured instead of bootstrap.cfg when the
server_puppetserver_version parameter is set to 2.5.

A special version value of 2.4.99 (now the default) configures both the
2.4 and 2.5 files simultaneously, creating both bootstrap.cfg and
services.d/ca.cfg so the module works across both versions, albeit with
logged warnings about duplicate CA definitions. This ensures the module
will still work on the release of 2.5, after which time the parameter
default can be changed to 2.5.0 to remove the duplicate configuration.