### PR TITLE
Replace UTF-8 apostrophe [skip ci]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -227,7 +227,7 @@
 # $remove_lock::                      Remove the agent lock when running.
 #                                     type:boolean
 #
-# $client_certname::                  The node’s certificate name, and the unique
+# $client_certname::                  The node's certificate name, and the unique
 #                                     identifier it uses when requesting catalogs.
 #                                     type:string
 #


### PR DESCRIPTION
The UTF-8 character has triggered a few interesting bugs, including
Kafo's #14473 and #14932, and also triggers PUP-5995 in earlier Puppet 4
releases which prevents the installer working with Puppet Strings as the
default values can't be determined.