### PR TITLE
Permit access to v3 resource_type API on Puppet 4

### DIFF
--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -63,6 +63,11 @@ describe 'puppet::config' do
 
         it 'should contain auth.conf' do
           should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
+          if Puppet.version >= '4.0'
+            should contain_file("#{confdir}/auth.conf").with_content(%r{/puppet/v3/})
+          else
+            should_not contain_file("#{confdir}/auth.conf").with_content(%r{/puppet/v3/})
+          end
         end
 
         it 'should_not contain default_manifest setting in puppet.conf' do

--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -63,6 +63,10 @@
 path /puppet/v3/environments
 method find
 allow *
+
+path /puppet/v3/resource_type
+method search
+allow *
 <% end -%>
 
 # allow nodes to retrieve their own catalog


### PR DESCRIPTION
When using Puppet 4 without Puppet Server (i.e. Rack configuration),
the resource_types API is still required by the smart proxy and is
configured in the regular auth.conf.