### PR TITLE
Add support for the PassengerRuby setting.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -431,6 +431,11 @@
 #                                     process during httpd start.
 #                                     type:boolean
 #
+# $server_passenger_ruby::            The PassengerRuby parameter. Sets the Ruby
+#                                     interpreter for serving the puppetmaster
+#                                     rack application.
+#                                     type:string
+#
 # $server_config_version::            How to determine the configuration version. When
 #                                     using git_repo, by default a git describe
 #                                     approach will be installed.
@@ -683,6 +688,7 @@ class puppet (
   $server_service_fallback         = $puppet::params::server_service_fallback,
   $server_passenger_min_instances  = $puppet::params::server_passenger_min_instances,
   $server_passenger_pre_start      = $puppet::params::server_passenger_pre_start,
+  $server_passenger_ruby           = $puppet::params::server_passenger_ruby,
   $server_httpd_service            = $puppet::params::server_httpd_service,
   $server_external_nodes           = $puppet::params::server_external_nodes,
   $server_template                 = $puppet::params::server_template,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -173,6 +173,7 @@ class puppet::params {
   $server_service_fallback    = true
   $server_passenger_min_instances = $::processorcount
   $server_passenger_pre_start = true
+  $server_passenger_ruby      = undef
   $server_httpd_service       = 'httpd'
   $server_external_nodes      = "${dir}/node.rb"
   $server_enc_api             = 'v2'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -203,6 +203,11 @@
 #                              process during httpd start.
 #                              type:boolean
 #
+# $passenger_ruby::            The PassengerRuby parameter. Sets the Ruby
+#                              interpreter for serving the puppetmaster rack
+#                              application.
+#                              type:string
+#
 # $config_version::            How to determine the configuration version. When
 #                              using git_repo, by default a git describe
 #                              approach will be installed.
@@ -379,6 +384,7 @@ class puppet::server(
   $service_fallback         = $::puppet::server_service_fallback,
   $passenger_min_instances  = $::puppet::server_passenger_min_instances,
   $passenger_pre_start      = $::puppet::server_passenger_pre_start,
+  $passenger_ruby           = $::puppet::server_passenger_ruby,
   $httpd_service            = $::puppet::server_httpd_service,
   $external_nodes           = $::puppet::server_external_nodes,
   $template                 = $::puppet::server_template,

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -6,6 +6,7 @@ class puppet::server::passenger (
   $app_root                = $::puppet::server::app_root,
   $passenger_min_instances = $::puppet::server::passenger_min_instances,
   $passenger_pre_start     = $::puppet::server::passenger_pre_start,
+  $passenger_ruby          = $::puppet::server::passenger_ruby,
   $port                    = $::puppet::server::port,
   $ssl_ca_cert             = $::puppet::server::ssl_ca_cert,
   $ssl_ca_crl              = $::puppet::server::ssl_ca_crl,
@@ -106,6 +107,7 @@ class puppet::server::passenger (
     options                 => ['None'],
     passenger_pre_start     => $https_pre_start,
     passenger_min_instances => $passenger_min_instances,
+    passenger_ruby          => $passenger_ruby,
     require                 => Class['::puppet::server::rack'],
   }
 
@@ -142,6 +144,7 @@ class puppet::server::passenger (
       options                 => ['None'],
       passenger_pre_start     => $http_pre_start,
       passenger_min_instances => $passenger_min_instances,
+      passenger_ruby          => $passenger_ruby,
       require                 => Class['::puppet::server::rack'],
     }
   }

--- a/spec/classes/puppet_server_passenger_spec.rb
+++ b/spec/classes/puppet_server_passenger_spec.rb
@@ -77,6 +77,7 @@ describe 'puppet::server::passenger' do
             :http => true,
             :passenger_min_instances => 10,
             :passenger_pre_start => true,
+            :passenger_ruby => '/opt/ruby2.0/bin/ruby',
           })
         end
 
@@ -84,6 +85,7 @@ describe 'puppet::server::passenger' do
           should contain_apache__vhost('puppet').with({
             :passenger_min_instances => 10,
             :passenger_pre_start     => 'https://puppet.example.com:8140',
+            :passenger_ruby          => '/opt/ruby2.0/bin/ruby',
           })
         end
 
@@ -91,6 +93,7 @@ describe 'puppet::server::passenger' do
           should contain_apache__vhost('puppet-http').with({
             :passenger_min_instances => 10,
             :passenger_pre_start     => 'http://puppet.example.com:8139',
+            :passenger_ruby          => '/opt/ruby2.0/bin/ruby',
           })
         end
       end


### PR DESCRIPTION
This allows setting the PassengerRuby setting in the vhost configuration for puppet's rack application.