### PR TITLE
support Debian non-AIO Puppet 4.x packages

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -11,9 +11,13 @@ class puppet::server::install {
   }
 
   if $::puppet::manage_packages == true or $::puppet::manage_packages == 'server' {
+    $puppet4 = (versioncmp($::puppetversion, '4.0') > 0)
     $server_package_default = $::puppet::server::implementation ? {
       'master'       => $::osfamily ? {
-        'Debian'                => ['puppetmaster-common','puppetmaster'],
+        'Debian'                => $puppet4 ? {
+                                      true    => ['puppet-master'],
+                                      default => ['puppetmaster-common', 'puppetmaster'],
+                                    },
         /^(FreeBSD|DragonFly)$/ => [],
         default                 => ['puppet-server'],
       },

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -18,12 +18,18 @@ class puppet::server::service(
     fail('Both puppetmaster and puppetserver cannot be enabled simultaneously')
   }
 
+  if $::osfamily == 'Debian' and (versioncmp($::puppetversion, '4.0') > 0) {
+    $puppetmaster_service = 'puppet-master'
+  } else {
+    $puppetmaster_service = 'puppetmaster'
+  }
+
   if $puppetmaster != undef {
     $pm_ensure = $puppetmaster ? {
       true  => 'running',
       false => 'stopped',
     }
-    service { 'puppetmaster':
+    service { $puppetmaster_service:
       ensure => $pm_ensure,
       enable => $puppetmaster,
     }

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -22,15 +22,20 @@ describe 'puppet::server::service' do
 
       let(:facts) { default_facts.merge(additional_facts) }
 
+      master_service = 'puppetmaster'
+      if os_facts[:osfamily] == 'Debian' && os_facts[:puppetversion].to_f > 4.0
+        master_service = 'puppet-master'
+      end
+
       describe 'default_parameters' do
-        it { should_not contain_service('puppetmaster') }
+        it { should_not contain_service(master_service) }
         it { should_not contain_service('puppetserver') }
       end
 
       describe 'when puppetmaster => true' do
         let(:params) { {:puppetmaster => true, :puppetserver => Undef.new} }
         it do
-          should contain_service('puppetmaster').with({
+          should contain_service(master_service).with({
             :ensure => 'running',
             :enable => 'true',
           })
@@ -50,7 +55,7 @@ describe 'puppet::server::service' do
       describe 'when puppetmaster => false' do
         let(:params) { {:puppetmaster => false} }
         it do
-          should contain_service('puppetmaster').with({
+          should contain_service(master_service).with({
             :ensure => 'stopped',
             :enable => 'false',
           })
@@ -69,7 +74,7 @@ describe 'puppet::server::service' do
 
       describe 'when puppetmaster => undef' do
         let(:params) { {:puppetmaster => Undef.new} }
-        it { should_not contain_service('puppetmaster') }
+        it { should_not contain_service(master_service) }
       end
 
       describe 'when puppetserver => undef' do

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -23,6 +23,9 @@ describe 'puppet::server' do
       server_package = 'puppet-server'
       if os_facts[:osfamily] == 'Debian'
         server_package = 'puppetmaster'
+        if os_facts[:puppetversion].to_f > 4.0
+          server_package = 'puppet-master'
+        end
       end
 
       let(:facts) { default_facts }


### PR DESCRIPTION
@sathieu please test
4.5.2-1 packages are in the new queue for unstable at the moment, there were no changes that would affect this PR compared to 4.5.0-4.