### PR TITLE
Support http to https proxying

### DIFF
--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -133,6 +133,7 @@ class puppet::server::passenger (
       docroot                 => "${app_root}/public/",
       directories             => $directories_http,
       port                    => $http_port,
+      ssl_proxyengine         => $ssl_proxyengine,
       custom_fragment         => join([
           $custom_fragment ? {
             undef   => '',


### PR DESCRIPTION
Puppet masters can't forward requests to a https puppet CA server
using 'server_ca_proxy', when they're running on plain http, HTTP
500 is presented. Fixes [GH-396](https://github.com/theforeman/puppet-puppet/issues/396).

* Enables SSLProxyEngine directive on puppet-http vhost