### PR TITLE
puppetserver AIO uses a different vardir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -528,7 +528,6 @@
 #                                     type:boolean
 #
 # $server_puppetserver_vardir::       The path of the puppetserver var dir
-#                                     Defaults to '/opt/puppetlabs/server/data/puppetserver'
 #                                     type:string
 #
 # $server_puppetserver_dir::          The path of the puppetserver config dir

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -527,6 +527,10 @@
 #                                     disable in case CA is delegated to a separate instance
 #                                     type:boolean
 #
+# $server_puppetserver_vardir::       The path of the puppetserver var dir
+#                                     Defaults to '/opt/puppetlabs/server/data/puppetserver'
+#                                     type:string
+#
 # $server_puppetserver_dir::          The path of the puppetserver config dir
 #                                     type:string
 #
@@ -679,6 +683,7 @@ class puppet (
   $server_implementation           = $puppet::params::server_implementation,
   $server_passenger                = $puppet::params::server_passenger,
   $server_puppetserver_dir         = $puppet::params::server_puppetserver_dir,
+  $server_puppetserver_vardir      = $puppet::params::server_puppetserver_vardir,
   $server_puppetserver_version     = $puppet::params::server_puppetserver_version,
   $server_service_fallback         = $puppet::params::server_service_fallback,
   $server_passenger_min_instances  = $puppet::params::server_passenger_min_instances,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,15 +23,17 @@ class puppet::params {
   $show_diff           = false
   $module_repository   = undef
   if versioncmp($::puppetversion, '4.0') < 0 {
-    $configtimeout           = 120
-    $server_puppetserver_dir = '/etc/puppetserver'
-    $server_ruby_load_paths  = []
-    $server_jruby_gem_home   = '/var/lib/puppet/jruby-gems'
+    $configtimeout              = 120
+    $server_puppetserver_dir    = '/etc/puppetserver'
+    $server_puppetserver_vardir = undef
+    $server_ruby_load_paths     = []
+    $server_jruby_gem_home      = '/var/lib/puppet/jruby-gems'
   } else {
-    $configtimeout           = undef
-    $server_puppetserver_dir = '/etc/puppetlabs/puppetserver'
-    $server_ruby_load_paths  = ['/opt/puppetlabs/puppet/lib/ruby/vendor_ruby']
-    $server_jruby_gem_home   = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
+    $configtimeout              = undef
+    $server_puppetserver_dir    = '/etc/puppetlabs/puppetserver'
+    $server_puppetserver_vardir = '/opt/puppetlabs/server/data/puppetserver'
+    $server_ruby_load_paths     = ['/opt/puppetlabs/puppet/lib/ruby/vendor_ruby']
+    $server_jruby_gem_home      = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
   }
   if versioncmp($::puppetversion, '4.0') < 0 or versioncmp($::puppetversion, '4.5') >= 0 {
     $hiera_config            = '$confdir/hiera.yaml'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,19 +22,6 @@ class puppet::params {
   $agent_noop          = false
   $show_diff           = false
   $module_repository   = undef
-  if versioncmp($::puppetversion, '4.0') < 0 {
-    $configtimeout              = 120
-    $server_puppetserver_dir    = '/etc/puppetserver'
-    $server_puppetserver_vardir = undef
-    $server_ruby_load_paths     = []
-    $server_jruby_gem_home      = '/var/lib/puppet/jruby-gems'
-  } else {
-    $configtimeout              = undef
-    $server_puppetserver_dir    = '/etc/puppetlabs/puppetserver'
-    $server_puppetserver_vardir = '/opt/puppetlabs/server/data/puppetserver'
-    $server_ruby_load_paths     = ['/opt/puppetlabs/puppet/lib/ruby/vendor_ruby']
-    $server_jruby_gem_home      = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
-  }
   if versioncmp($::puppetversion, '4.0') < 0 or versioncmp($::puppetversion, '4.5') >= 0 {
     $hiera_config            = '$confdir/hiera.yaml'
   } else {
@@ -112,6 +99,20 @@ class puppet::params {
       }
       $root_group = undef
     }
+  }
+
+  if versioncmp($::puppetversion, '4.0') < 0 {
+    $configtimeout              = 120
+    $server_puppetserver_dir    = '/etc/puppetserver'
+    $server_puppetserver_vardir = $vardir
+    $server_ruby_load_paths     = []
+    $server_jruby_gem_home      = '/var/lib/puppet/jruby-gems'
+  } else {
+    $configtimeout              = undef
+    $server_puppetserver_dir    = '/etc/puppetlabs/puppetserver'
+    $server_puppetserver_vardir = '/opt/puppetlabs/server/data/puppetserver'
+    $server_ruby_load_paths     = ['/opt/puppetlabs/puppet/lib/ruby/vendor_ruby']
+    $server_jruby_gem_home      = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
   }
 
   $autosign      = "${dir}/autosign.conf"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,53 +66,54 @@ class puppet::params {
     }
 
     /^(FreeBSD|DragonFly)$/ : {
-      $dir               = '/usr/local/etc/puppet'
-      $codedir           = '/usr/local/etc/puppet'
-      $logdir            = '/var/log/puppet'
-      $rundir            = '/var/run/puppet'
-      $ssldir            = '/var/puppet/ssl'
-      $vardir            = '/var/puppet'
-      $sharedir          = '/usr/local/share/puppet'
-      $bindir            = '/usr/local/bin'
-      $root_group        = undef
+      $dir                        = '/usr/local/etc/puppet'
+      $codedir                    = '/usr/local/etc/puppet'
+      $logdir                     = '/var/log/puppet'
+      $rundir                     = '/var/run/puppet'
+      $ssldir                     = '/var/puppet/ssl'
+      $vardir                     = '/var/puppet'
+      $server_puppetserver_vardir = '/var/puppet'
+      $sharedir                   = '/usr/local/share/puppet'
+      $bindir                     = '/usr/local/bin'
+      $root_group                 = undef
     }
 
     default : {
       if $aio_package {
-        $dir               = '/etc/puppetlabs/puppet'
-        $codedir           = '/etc/puppetlabs/code'
-        $logdir            = '/var/log/puppetlabs/puppet'
-        $rundir            = '/var/run/puppetlabs'
-        $ssldir            = '/etc/puppetlabs/puppet/ssl'
-        $vardir            = '/opt/puppetlabs/puppet/cache'
-        $sharedir          = '/opt/puppetlabs/puppet'
-        $bindir            = '/opt/puppetlabs/bin'
+        $dir                        = '/etc/puppetlabs/puppet'
+        $codedir                    = '/etc/puppetlabs/code'
+        $logdir                     = '/var/log/puppetlabs/puppet'
+        $rundir                     = '/var/run/puppetlabs'
+        $ssldir                     = '/etc/puppetlabs/puppet/ssl'
+        $vardir                     = '/opt/puppetlabs/puppet/cache'
+        $sharedir                   = '/opt/puppetlabs/puppet'
+        $bindir                     = '/opt/puppetlabs/bin'
+        $server_puppetserver_dir    = '/etc/puppetlabs/puppetserver'
+        $server_puppetserver_vardir = '/opt/puppetlabs/server/data/puppetserver'
+        $server_ruby_load_paths     = ['/opt/puppetlabs/puppet/lib/ruby/vendor_ruby']
+        $server_jruby_gem_home      = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
       } else {
-        $dir               = '/etc/puppet'
-        $codedir           = '/etc/puppet'
-        $logdir            = '/var/log/puppet'
-        $rundir            = '/var/run/puppet'
-        $ssldir            = '/var/lib/puppet/ssl'
-        $vardir            = '/var/lib/puppet'
-        $sharedir          = '/usr/share/puppet'
-        $bindir            = '/usr/bin'
+        $dir                        = '/etc/puppet'
+        $codedir                    = '/etc/puppet'
+        $logdir                     = '/var/log/puppet'
+        $rundir                     = '/var/run/puppet'
+        $ssldir                     = '/var/lib/puppet/ssl'
+        $vardir                     = '/var/lib/puppet'
+        $sharedir                   = '/usr/share/puppet'
+        $bindir                     = '/usr/bin'
+        $server_puppetserver_dir    = '/etc/puppetserver'
+        $server_puppetserver_vardir = $vardir
+        $server_ruby_load_paths     = []
+        $server_jruby_gem_home      = '/var/lib/puppet/jruby-gems'
       }
       $root_group = undef
     }
   }
 
   if versioncmp($::puppetversion, '4.0') < 0 {
-    $configtimeout              = 120
-    $server_puppetserver_dir    = '/etc/puppetserver'
-    $server_puppetserver_vardir = $vardir
-    $server_ruby_load_paths     = []
-    $server_jruby_gem_home      = '/var/lib/puppet/jruby-gems'
+    $configtimeout = 120
   } else {
-    $configtimeout              = undef
-    $server_puppetserver_dir    = '/etc/puppetlabs/puppetserver'
-    $server_puppetserver_vardir = '/opt/puppetlabs/server/data/puppetserver'
-    $server_ruby_load_paths     = ['/opt/puppetlabs/puppet/lib/ruby/vendor_ruby']
-    $server_jruby_gem_home      = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
+    $configtimeout = undef
   }
 
   $autosign      = "${dir}/autosign.conf"

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -299,6 +299,9 @@
 #                              disable in case CA is delegated to a separate instance
 #                              type:boolean
 #
+# $puppetserver_vardir::       The path of the puppetserver var dir
+#                              type:string
+#
 # $puppetserver_dir::          The path of the puppetserver config dir
 #                              type:string
 #
@@ -374,6 +377,7 @@ class puppet::server(
   $reports                  = $::puppet::server_reports,
   $implementation           = $::puppet::server_implementation,
   $passenger                = $::puppet::server_passenger,
+  $puppetserver_vardir      = $::puppet::server_puppetserver_vardir,
   $puppetserver_dir         = $::puppet::server_puppetserver_dir,
   $puppetserver_version     = $::puppet::server_puppetserver_version,
   $service_fallback         = $::puppet::server_service_fallback,
@@ -498,6 +502,7 @@ class puppet::server(
     validate_re($jvm_min_heap_size, '^[0-9]+[kKmMgG]$')
     validate_re($jvm_max_heap_size, '^[0-9]+[kKmMgG]$')
     validate_absolute_path($puppetserver_dir)
+    validate_absolute_path($puppetserver_vardir)
     validate_absolute_path($jruby_gem_home)
     validate_integer($max_active_instances)
     validate_integer($idle_timeout)

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -192,7 +192,7 @@ class puppet::server::config inherits puppet::config {
     class {'::foreman::puppetmaster':
       foreman_url    => $::puppet::server::foreman_url,
       receive_facts  => $::puppet::server::server_facts,
-      puppet_home    => $puppet::vardir,
+      puppet_home    => $::puppet::server::puppetserver_vardir,
       puppet_basedir => $::puppet::server::puppet_basedir,
       puppet_etcdir  => $puppet::dir,
       enc_api        => $::puppet::server::enc_api,

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -25,6 +25,9 @@
 # * `server_puppetserver_dir`
 # Puppetserver config directory
 #
+# * `server_puppetserver_vardir`
+# Puppetserver config directory
+#
 # * `server_jruby_gem_home`
 # Puppetserver jruby gemhome
 #
@@ -55,6 +58,7 @@ class puppet::server::puppetserver (
   $jvm_max_heap_size           = $::puppet::server::jvm_max_heap_size,
   $jvm_extra_args              = $::puppet::server::jvm_extra_args,
   $server_puppetserver_dir     = $::puppet::server::puppetserver_dir,
+  $server_puppetserver_vardir  = $::puppet::server::puppetserver_vardir,
   $server_jruby_gem_home       = $::puppet::server::jruby_gem_home,
   $server_ruby_load_paths      = $::puppet::server::ruby_load_paths,
   $server_cipher_suites        = $::puppet::server::cipher_suites,
@@ -65,7 +69,6 @@ class puppet::server::puppetserver (
   $server_idle_timeout         = $::puppet::server::idle_timeout,
   $server_connect_timeout      = $::puppet::server::connect_timeout,
   $server_enable_ruby_profiler = $::puppet::server::enable_ruby_profiler,
-  $vardir                      = $::puppet::vardir,
   $server_ca_client_whitelist  = $::puppet::server::ca_client_whitelist,
   $server_admin_api_whitelist  = $::puppet::server::admin_api_whitelist,
   $server_puppetserver_version = $::puppet::server::puppetserver_version,

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -26,7 +26,7 @@
 # Puppetserver config directory
 #
 # * `server_puppetserver_vardir`
-# Puppetserver config directory
+# Puppetserver var directory
 #
 # * `server_jruby_gem_home`
 # Puppetserver jruby gemhome

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "theforeman-puppet",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "author": "theforeman",
   "summary": "Puppet agent and server configuration",
   "license": "GPL-3.0+",

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -15,42 +15,45 @@ describe 'puppet::server::config' do
       }) end
 
       if Puppet.version < '4.0'
-        codedir          = '/etc/puppet'
-        conf_file        = '/etc/puppet/puppet.conf'
-        environments_dir = '/etc/puppet/environments'
-        logdir           = '/var/log/puppet'
-        rundir           = '/var/run/puppet'
-        vardir           = '/var/lib/puppet'
-        ssldir           = '/var/lib/puppet/ssl'
-        sharedir         = '/usr/share/puppet'
-        etcdir           = '/etc/puppet'
-        puppetcacmd      = '/usr/bin/puppet cert'
-        additional_facts = {}
+        codedir             = '/etc/puppet'
+        conf_file           = '/etc/puppet/puppet.conf'
+        environments_dir    = '/etc/puppet/environments'
+        logdir              = '/var/log/puppet'
+        rundir              = '/var/run/puppet'
+        vardir              = '/var/lib/puppet'
+        puppetserver_vardir = '/var/lib/puppet'
+        ssldir              = '/var/lib/puppet/ssl'
+        sharedir            = '/usr/share/puppet'
+        etcdir              = '/etc/puppet'
+        puppetcacmd         = '/usr/bin/puppet cert'
+        additional_facts    = {}
       else
-        codedir          = '/etc/puppetlabs/code'
-        conf_file        = '/etc/puppetlabs/puppet/puppet.conf'
-        environments_dir = '/etc/puppetlabs/code/environments'
-        logdir           = '/var/log/puppetlabs/puppet'
-        rundir           = '/var/run/puppetlabs'
-        vardir           = '/opt/puppetlabs/puppet/cache'
-        ssldir           = '/etc/puppetlabs/puppet/ssl'
-        sharedir         = '/opt/puppetlabs/puppet'
-        etcdir           = '/etc/puppetlabs/puppet'
-        puppetcacmd      = '/opt/puppetlabs/bin/puppet cert'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
+        codedir             = '/etc/puppetlabs/code'
+        conf_file           = '/etc/puppetlabs/puppet/puppet.conf'
+        environments_dir    = '/etc/puppetlabs/code/environments'
+        logdir              = '/var/log/puppetlabs/puppet'
+        rundir              = '/var/run/puppetlabs'
+        vardir              = '/opt/puppetlabs/puppet/cache'
+        puppetserver_vardir = '/opt/puppetlabs/server/data/puppetserver'
+        ssldir              = '/etc/puppetlabs/puppet/ssl'
+        sharedir            = '/opt/puppetlabs/puppet'
+        etcdir              = '/etc/puppetlabs/puppet'
+        puppetcacmd         = '/opt/puppetlabs/bin/puppet cert'
+        additional_facts    = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
       if os_facts[:osfamily] == 'FreeBSD'
-        codedir          = '/usr/local/etc/puppet'
-        conf_file        = '/usr/local/etc/puppet/puppet.conf'
-        environments_dir = '/usr/local/etc/puppet/environments'
-        logdir           = '/var/log/puppet'
-        rundir           = '/var/run/puppet'
-        vardir           = '/var/puppet'
-        ssldir           = '/var/puppet/ssl'
-        sharedir         = '/usr/local/share/puppet'
-        etcdir           = '/usr/local/etc/puppet'
-        puppetcacmd      = '/usr/local/bin/puppet cert'
+        codedir             = '/usr/local/etc/puppet'
+        conf_file           = '/usr/local/etc/puppet/puppet.conf'
+        environments_dir    = '/usr/local/etc/puppet/environments'
+        logdir              = '/var/log/puppet'
+        rundir              = '/var/run/puppet'
+        vardir              = '/var/puppet'
+        puppetserver_vardir = '/var/puppet'
+        ssldir              = '/var/puppet/ssl'
+        sharedir            = '/usr/local/share/puppet'
+        etcdir              = '/usr/local/etc/puppet'
+        puppetcacmd         = '/usr/local/bin/puppet cert'
       end
 
       let(:facts) { default_facts.merge(additional_facts) }
@@ -106,7 +109,7 @@ describe 'puppet::server::config' do
           should contain_class('foreman::puppetmaster').with({
             :foreman_url    => "https://puppetmaster.example.com",
             :receive_facts  => true,
-            :puppet_home    => vardir,
+            :puppet_home    => puppetserver_vardir,
             :puppet_etcdir  => etcdir,
             # Since this is managed inside the foreman module it does not
             # make sense to test it here

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -43,6 +43,7 @@ describe 'puppet::server::puppetserver' do
         :server_ca                   => true,
         :server_puppetserver_version => '2.4.99',
         :server_use_legacy_auth_conf => false,
+        :server_puppetserver_vardir  => '/opt/puppetlabs/server/data/puppetserver',
       } end
 
       describe 'with default parameters' do
@@ -78,6 +79,32 @@ describe 'puppet::server::puppetserver' do
         it { should contain_file('/etc/custom/puppetserver/conf.d/webserver.conf').
                                  with_content(/ssl-host\s+=\s0\.0\.0\.0/) }
         it { should contain_file('/etc/custom/puppetserver/conf.d/auth.conf') }
+      end
+
+      describe 'server_puppetserver_vardir' do
+        context 'with default parameters' do
+          let(:params) do
+            default_params.merge({
+              :server_puppetserver_dir => '/etc/custom/puppetserver',
+            })
+          end
+          it 'should have master-var-dir: /opt/puppetlabs/server/data/puppetserver' do
+            content = catalogue.resource('file', '/etc/custom/puppetserver/conf.d/puppetserver.conf').send(:parameters)[:content]
+            expect(content).to include(%Q[    master-var-dir: /opt/puppetlabs/server/data/puppetserver\n])
+          end
+        end
+        context 'with custom server_puppetserver_vardir' do
+          let(:params) do
+            default_params.merge({
+              :server_puppetserver_dir    => '/etc/custom/puppetserver',
+              :server_puppetserver_vardir => '/opt/custom/puppetlabs/server/data/puppetserver',
+            })
+          end
+          it 'should have master-var-dir: /opt/puppetlabs/server/data/puppetserver' do
+            content = catalogue.resource('file', '/etc/custom/puppetserver/conf.d/puppetserver.conf').send(:parameters)[:content]
+            expect(content).to include(%Q[    master-var-dir: /opt/custom/puppetlabs/server/data/puppetserver\n])
+          end
+        end
       end
 
       describe 'use-legacy-auth-conf' do

--- a/templates/server/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/puppetserver.conf.erb
@@ -17,7 +17,7 @@ jruby-puppet: {
     master-conf-dir: <%= @server_dir %>
 
     # (optional) path to puppet var dir; if not specified, will use the puppet default
-    master-var-dir: <%= @vardir %>
+    master-var-dir: <%= @server_puppetserver_vardir %>
 
     # (optional) maximum number of JRuby instances to allow
     max-active-instances: <%= @server_max_active_instances %>


### PR DESCRIPTION
puppetserver runs as the puppet user, the puppet agent normally runs as
the root user. When the two try to share the same vardir,
puppetserver (running as the puppet user) can't always read/write/create
directories if the puppet agent creates them as the root user. The
problem is described more thoroughly in
https://tickets.puppetlabs.com/browse/SERVER-357 .