### PR TITLE
Introduce parameter 'server_envs_target' that, when set, turns puppet's …

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -329,6 +329,10 @@
 # $server_envs_dir::                  Directory that holds puppet environments
 #                                     type:string
 #
+# $server_envs_target::               Indicates that $envs_dir should be
+#                                     a symbolic link to this target
+#                                     type:string
+#
 # $server_common_modules_path::       Common modules paths (only when
 #                                     $server_git_repo_path and $server_dynamic_environments
 #                                     are false)
@@ -702,6 +706,7 @@ class puppet (
   $server_environments_group       = $puppet::params::server_environments_group,
   $server_environments_mode        = $puppet::params::server_environments_mode,
   $server_envs_dir                 = $puppet::params::server_envs_dir,
+  $server_envs_target              = $puppet::params::server_envs_target,
   $server_common_modules_path      = $puppet::params::server_common_modules_path,
   $server_git_repo_mode            = $puppet::params::server_git_repo_mode,
   $server_git_repo_path            = $puppet::params::server_git_repo_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -228,6 +228,7 @@ class puppet::params {
   $server_environments_mode    = '0755'
   # Where we store our puppet environments
   $server_envs_dir             = "${codedir}/environments"
+  $server_envs_target          = undef
   # Modules in this directory would be shared across all environments
   $server_common_modules_path  = ["${server_envs_dir}/common", "${codedir}/modules", "${sharedir}/modules"]
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -102,6 +102,10 @@
 # $envs_dir::                  Directory that holds puppet environments
 #                              type:string
 #
+# $envs_target::               Indicates that $envs_dir should be
+#                              a symbolic link to this target
+#                              type:string
+#
 # $common_modules_path::       Common modules paths (only when
 #                              $git_repo_path and $dynamic_environments
 #                              are false)
@@ -399,6 +403,7 @@ class puppet::server(
   $environments_group       = $::puppet::server_environments_group,
   $environments_mode        = $::puppet::server_environments_mode,
   $envs_dir                 = $::puppet::server_envs_dir,
+  $envs_target              = $::puppet::server_envs_target,
   $common_modules_path      = $::puppet::server_common_modules_path,
   $git_repo_mode            = $::puppet::server_git_repo_mode,
   $git_repo_path            = $::puppet::server_git_repo_path,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -145,7 +145,7 @@ class puppet::server::config inherits puppet::config {
     group  => $::puppet::server::environments_group,
     mode   => $::puppet::server::environments_mode,
     target => $::puppet::server::envs_target,
-    force  => true
+    force  => true,
   }
 
   if $::puppet::server::git_repo {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -133,11 +133,19 @@ class puppet::server::config inherits puppet::config {
 
   ## Environments
   # location where our puppet environments are located
+  if $::puppet::server::envs_target and $::puppet::server::envs_target != '' {
+    $ensure = 'link'
+  } else {
+    $ensure = 'directory'
+  }
+
   file { $::puppet::server::envs_dir:
-    ensure => directory,
+    ensure => $ensure,
     owner  => $::puppet::server::environments_owner,
     group  => $::puppet::server::environments_group,
     mode   => $::puppet::server::environments_mode,
+    target => $::puppet::server::envs_target,
+    force  => true
   }
 
   if $::puppet::server::git_repo {

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,10 @@
 {
-  "name": "desiderius-puppet",
+  "name": "theforeman-puppet",
   "version": "6.0.0",
   "author": "theforeman",
-  "summary": "foreman-puppet clone: Puppet agent and server configuration",
+  "summary": "Puppet agent and server configuration",
   "license": "GPL-3.0+",
-  "source": "git://github.com/pkranenburg/puppet-puppet",
+  "source": "git://github.com/theforeman/puppet-puppet",
   "project_page": "https://github.com/theforeman/puppet-puppet",
   "issues_url": "https://github.com/theforeman/puppet-puppet/issues",
   "description": "Module for installing the Puppet agent and Puppet server",

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,10 @@
 {
-  "name": "theforeman-puppet",
+  "name": "desiderius-puppet",
   "version": "6.0.0",
   "author": "theforeman",
-  "summary": "Puppet agent and server configuration",
+  "summary": "foreman-puppet clone: Puppet agent and server configuration",
   "license": "GPL-3.0+",
-  "source": "git://github.com/theforeman/puppet-puppet",
+  "source": "git://github.com/pkranenburg/puppet-puppet",
   "project_page": "https://github.com/theforeman/puppet-puppet",
   "issues_url": "https://github.com/theforeman/puppet-puppet/issues",
   "description": "Module for installing the Puppet agent and Puppet server",

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -57,6 +57,13 @@ describe 'puppet::server::env' do
           end
 
           it 'should only deploy directories' do
+            should contain_file("#{codedir}/environments").with({
+              :ensure => 'directory',
+              :owner => 'puppet',
+              :group => nil,
+              :mode => '0755',
+            })
+
             should contain_file("#{codedir}/environments/foo").with({
               :ensure => 'directory',
               :owner => 'puppet',
@@ -183,12 +190,13 @@ describe 'puppet::server::env' do
 
         context 'with directory environments link' do
           let :pre_condition do
-            "class {'puppet': server => true, server_envs_target => /foo}"
+            "class {'puppet': server => true, server_envs_target => '/foo'}"
           end
 
           it 'should produce a symbolic link "environments" in codedir' do
-            should be_symlink("#{codedir}/environments").
-              be_linked_to('/foo').
+            should contain_file("#{codedir}/environments").
+              with_target('/foo').
+              with_ensure('link').
               with({}) # So we can use a trailing dot on each with_content line
           end
         end

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -180,6 +180,18 @@ describe 'puppet::server::env' do
               with({}) # So we can use a trailing dot on each with_content line
           end
         end
+
+        context 'with directory environments link' do
+          let :pre_condition do
+            "class {'puppet': server => true, server_envs_target => /foo}"
+          end
+
+          it 'should produce a symbolic link "environments" in codedir' do
+            should be_symlink("#{codedir}/environments").
+              be_linked_to('/foo').
+              with({}) # So we can use a trailing dot on each with_content line
+          end
+        end
       end
 
       context 'with modulepath' do


### PR DESCRIPTION
… environments directory into a symbolic link. Useful for referring to remote storage holding the puppet code.