### PR TITLE
assume version 2.5.0 of puppetserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ version available.
 
 Currently supported values and configuration behaviours are:
 
-* `2.5.x` - configures the certificate authority in `ca.cfg`
-* `2.4.99` (default) - configures for both 2.4 and 2.5, with `bootstrap.cfg`
+* `2.5.x` (default) - configures the certificate authority in `ca.cfg`
+* `2.4.99` - configures for both 2.4 and 2.5, with `bootstrap.cfg`
   and `ca.cfg`
 * `2.3.x`, `2.4.x` - configures the certificate authority and
   versioned-code-service in `bootstrap.cfg`

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -385,5 +385,5 @@ class puppet::params {
   $server_use_legacy_auth_conf     = false
 
   # For puppetserver 2, certain configuration parameters are version specific. We assume a particular version here.
-  $server_puppetserver_version     = '2.4.99'
+  $server_puppetserver_version     = '2.5.0'
 }


### PR DESCRIPTION
closes GH-423