### PR TITLE
move authorization and whitelist settings to auth.conf for puppetserver >= 2.2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -377,8 +377,8 @@ class puppet::params {
   $server_connect_timeout          = 120000
   $server_enable_ruby_profiler     = false
   $server_ca_auth_required         = true
-  $server_admin_api_whitelist      = [ '127.0.0.1', '::1', $::ipaddress ]
-  $server_ca_client_whitelist      = [ '127.0.0.1', '::1', $::ipaddress ]
+  $server_admin_api_whitelist      = [ 'localhost', $lower_fqdn ]
+  $server_ca_client_whitelist      = [ 'localhost', $lower_fqdn ]
   $server_cipher_suites            = [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA', 'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA', ]
   $server_ssl_protocols            = [ 'TLSv1.2', ]
 

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -52,11 +52,11 @@
 #   }
 #
 class puppet::server::puppetserver (
-  $java_bin                    = $::puppet::server::jvm_java_bin,
   $config                      = $::puppet::server::jvm_config,
+  $java_bin                    = $::puppet::server::jvm_java_bin,
+  $jvm_extra_args              = $::puppet::server::jvm_extra_args,
   $jvm_min_heap_size           = $::puppet::server::jvm_min_heap_size,
   $jvm_max_heap_size           = $::puppet::server::jvm_max_heap_size,
-  $jvm_extra_args              = $::puppet::server::jvm_extra_args,
   $server_puppetserver_dir     = $::puppet::server::puppetserver_dir,
   $server_puppetserver_vardir  = $::puppet::server::puppetserver_vardir,
   $server_jruby_gem_home       = $::puppet::server::jruby_gem_home,
@@ -69,6 +69,7 @@ class puppet::server::puppetserver (
   $server_idle_timeout         = $::puppet::server::idle_timeout,
   $server_connect_timeout      = $::puppet::server::connect_timeout,
   $server_enable_ruby_profiler = $::puppet::server::enable_ruby_profiler,
+  $server_ca_auth_required     = $::puppet::server::ca_auth_required,
   $server_ca_client_whitelist  = $::puppet::server::ca_client_whitelist,
   $server_admin_api_whitelist  = $::puppet::server::admin_api_whitelist,
   $server_puppetserver_version = $::puppet::server::puppetserver_version,
@@ -169,8 +170,14 @@ class puppet::server::puppetserver (
     }
   }
 
+  if versioncmp($server_puppetserver_version, '2.2') < 0 {
+    $ca_conf_ensure = file
+  } else {
+    $ca_conf_ensure = absent
+  }
+
   file { "${server_puppetserver_dir}/conf.d/ca.conf":
-    ensure  => file,
+    ensure  => $ca_conf_ensure,
     content => template('puppet/server/puppetserver/conf.d/ca.conf.erb'),
   }
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -32,8 +32,9 @@ describe 'puppet::server::puppetserver' do
         :jvm_min_heap_size           => '2G',
         :jvm_max_heap_size           => '2G',
         :jvm_extra_args              => '',
-        :server_ca_client_whitelist  => [ '127.0.0.1', '::1', '192.0.2.10', ],
-        :server_admin_api_whitelist  => [ '127.0.0.1', '::1', '192.0.2.10', ],
+        :server_ca_auth_required     => true,
+        :server_ca_client_whitelist  => [ 'localhost', 'puppetserver123.example.com' ],
+        :server_admin_api_whitelist  => [ 'localhost', 'puppetserver123.example.com' ],
         :server_ruby_load_paths      => [ '/some/path', ],
         :server_ssl_protocols        => [ 'TLSv1.2', ],
         :server_cipher_suites        => [ 'TLS_RSA_WITH_AES_256_CBC_SHA256',
@@ -292,6 +293,77 @@ describe 'puppet::server::puppetserver' do
           it { should_not contain_file('/etc/custom/puppetserver/services.d/ca.cfg') }
           it { should_not contain_file('/opt/puppetlabs/server/apps/puppetserver/config') }
           it { should_not contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d') }
+        end
+      end
+
+      describe 'server_ca related settings' do
+        context 'when server_puppetserver_version >= 2.2' do
+          let(:params) do
+            default_params.merge({
+                                     :server_puppetserver_version => '2.2.0',
+                                     :server_puppetserver_dir => '/etc/custom/puppetserver',
+                                 })
+          end
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/auth.conf').
+              with_content(/^\s+path: "\/certificate_statuses\/"/).
+              with_content(/^\s+name: "certificate_status"/).
+              with_content(/^\s+path: "\/puppet-admin-api\/v1\/environment-cache"/).
+              with_content(/^\s+name: "environment-cache"/).
+              with_content(/^\s+path: "\/puppet-admin-api\/v1\/jruby-pool"/).
+              with_content(/^\s+name: "jruby-pool"/).
+              with({}) # So we can use a trailing dot on each with_content line
+          }
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/ca.conf').
+              with_ensure('absent').
+              with({}) # So we can use a trailing dot on each with_content line
+          }
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/puppetserver.conf').
+              without_content(/^# Settings related to the puppet-admin HTTP API$/).
+              without_content(/^puppet-admin: \{$/).
+              without_content(/^\s+client-whitelist: \[$/).
+              without_content(/^\s+"localhost"\,$/).
+              without_content(/^\s+"puppetserver123.example.com"\,$/).
+              with({}) # So we can use a trailing dot on each with_content line
+          }
+        end
+
+        context 'when server_puppetserver_version < 2.2' do
+          let(:params) do
+            default_params.merge({
+                                     :server_puppetserver_version => '2.1.1',
+                                     :server_puppetserver_dir => '/etc/custom/puppetserver',
+                                 })
+          end
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/auth.conf').
+              without_content(/^\s+path: "\/certificate_statuses\/"/).
+              without_content(/^\s+name: "certificate_status"/).
+              without_content(/^\s+path: "\/puppet-admin-api\/v1\/environment-cache"/).
+              without_content(/^\s+name: "environment-cache"/).
+              without_content(/^\s+path: "\/puppet-admin-api\/v1\/jruby-pool"/).
+              without_content(/^\s+name: "jruby-pool"/).
+              with({}) # So we can use a trailing dot on each with_content line
+          }
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/ca.conf').
+              with_content(/^\s+authorization-required: true$/).
+              with_content(/^\s+client-whitelist: \[$/).
+              with_content(/^\s+"localhost"\,$/).
+              with_content(/^\s+"puppetserver123.example.com"\,$/).
+              with({}) # So we can use a trailing dot on each with_content line
+          }
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/puppetserver.conf').
+              with_content(/^# Settings related to the puppet-admin HTTP API$/).
+              with_content(/^puppet-admin: \{$/).
+              with_content(/^\s+client-whitelist: \[$/).
+              with_content(/^\s+"localhost"\,$/).
+              with_content(/^\s+"puppetserver123.example.com"\,$/).
+              with({}) # So we can use a trailing dot on each with_content line
+          }
         end
       end
 

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -45,6 +45,74 @@ authorization: {
             sort-order: 500
             name: "puppetlabs csr"
         },
+<%- if scope.function_versioncmp([@server_puppetserver_version, '2.2']) > 0 -%>
+<%- if @server_ca -%>
+        {
+            match-request: {
+                path: "/certificate_status/"
+                type: path
+                method: [ get, put, delete ]
+            }
+<%- if @server_ca_auth_required == false -%>
+            allow-unauthenticated: true
+<%- else -%>
+            allow: [
+<%- @server_ca_client_whitelist.each do |client| -%>
+                "<%= client %>",
+<%- end -%>
+            ]
+<%- end -%>
+            sort-order: 200
+            name: "certificate_status"
+        },
+        {
+            match-request: {
+                path: "/certificate_statuses/"
+                type: path
+                method: get
+            }
+<%- if @server_ca_auth_required == false -%>
+            allow-unauthenticated: true
+<%- else -%>
+            allow: [
+<%- @server_ca_client_whitelist.each do |client| -%>
+                "<%= client %>",
+<%- end -%>
+            ]
+<%- end -%>
+            sort-order: 200
+            name: "certificate_statuses"
+        },
+<%- end -%>
+        {
+            match-request: {
+                path: "/puppet-admin-api/v1/environment-cache"
+                type: path
+                method: delete
+            }
+            allow: [
+<%- @server_admin_api_whitelist.each do |client| -%>
+                "<%= client %>",
+<%- end -%>
+            ]
+            sort-order: 200
+            name: "environment-cache"
+        },
+        {
+            match-request: {
+                path: "/puppet-admin-api/v1/jruby-pool"
+                type: path
+                method: delete
+            }
+            allow: [
+<%- @server_admin_api_whitelist.each do |client| -%>
+                "<%= client %>",
+<%- end -%>
+            ]
+            sort-order: 200
+            name: "jruby-pool"
+        },
+<%- end -%>
         {
             match-request: {
                 path: "/puppet/v3/environments"

--- a/templates/server/puppetserver/conf.d/ca.conf.erb
+++ b/templates/server/puppetserver/conf.d/ca.conf.erb
@@ -3,7 +3,6 @@ certificate-authority: {
 
     # settings for the certificate_status HTTP endpoint
     certificate-status: {
-
         # this setting contains a list of client certnames who are whitelisted to
         # have access to the certificate_status endpoint. Any requests made to
         # this endpoint that do not present a valid client cert mentioned in

--- a/templates/server/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/puppetserver.conf.erb
@@ -13,10 +13,12 @@ jruby-puppet: {
     # used by the `puppetserver gem` command line tool.
     gem-home: <%= @server_jruby_gem_home %>
 
-    # (optional) path to puppet conf dir; if not specified, will use the puppet default
+    # (optional) path to puppet conf dir; if not specified, will use
+    # the puppet default
     master-conf-dir: <%= @server_dir %>
 
-    # (optional) path to puppet var dir; if not specified, will use the puppet default
+    # (optional) path to puppet var dir; if not specified, will use
+    # the puppet default
     master-var-dir: <%= @server_puppetserver_vardir %>
 
     # (optional) maximum number of JRuby instances to allow
@@ -63,6 +65,7 @@ profiler: {
     # enable or disable profiling for the Ruby code; defaults to 'false'.
     enabled: <%= @server_enable_ruby_profiler %>
 }
+<%- if scope.function_versioncmp([@server_puppetserver_version, '2.2']) < 0 -%>
 
 # Settings related to the puppet-admin HTTP API
 puppet-admin: {
@@ -72,3 +75,4 @@ puppet-admin: {
     <%- end -%>
     ]
 }
+<%- end -%>


### PR DESCRIPTION
closes GH-403

the tests are not ideal, but I think it's better than what was there until now.