### PR TITLE
add puppetserver 2.6.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
     * Enable HTTP to HTTPS proxying of CA requests on HTTP Puppet master vhost
     * List Fedora 24 compatibility
 * Other changes and fixes:
-    * Change default Puppet Server version to 2.5.0
+    * Change default Puppet Server version to 2.6.0
     * Move CA and admin authorization/whitelist settings to auth.conf on Puppet
       Server 2.2 or higher
     * Remove non-functional Puppet 3 endpoints from auth.conf when using

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ version available.
 
 Currently supported values and configuration behaviours are:
 
-* `2.5.x` (default) - configures the certificate authority in `ca.cfg`
+* `2.6.x` (default) - configures the /status API endpoint in `web-routes.conf`
+* `2.5.x` - configures the certificate authority in `ca.cfg`
 * `2.4.99` - configures for both 2.4 and 2.5, with `bootstrap.cfg`
   and `ca.cfg`
 * `2.3.x`, `2.4.x` - configures the certificate authority and

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -386,5 +386,5 @@ class puppet::params {
   $server_use_legacy_auth_conf     = false
 
   # For puppetserver 2, certain configuration parameters are version specific. We assume a particular version here.
-  $server_puppetserver_version     = '2.5.0'
+  $server_puppetserver_version     = '2.6.0'
 }

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -367,6 +367,33 @@ describe 'puppet::server::puppetserver' do
         end
       end
 
+      describe 'status API endpoint' do
+        context 'when server_puppetserver_version >= 2.6' do
+          let(:params) do
+            default_params.merge({
+                                     :server_puppetserver_version => '2.6.0',
+                                     :server_puppetserver_dir => '/etc/custom/puppetserver',
+                                 })
+          end
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/web-routes.conf').
+              with_content(/^\s+"puppetlabs.trapperkeeper.services.status.status-service\/status-service": "\/status"/)
+          }
+        end
+
+        context 'when server_puppetserver_version < 2.6' do
+          let(:params) do
+            default_params.merge({
+                                     :server_puppetserver_version => '2.5.0',
+                                     :server_puppetserver_dir => '/etc/custom/puppetserver',
+                                 })
+          end
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/web-routes.conf').
+              without_content(/^\s+"puppetlabs.trapperkeeper.services.status.status-service\/status-service": "\/status"/)
+          }
+        end
+      end
       describe 'with extra_args parameter' do
         let :params do
           default_params.merge({

--- a/templates/server/puppetserver/conf.d/web-routes.conf.erb
+++ b/templates/server/puppetserver/conf.d/web-routes.conf.erb
@@ -14,4 +14,9 @@ web-router-service: {
 
     # This controls the mount point for the puppet admin API.
     "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+<%- if scope.function_versioncmp([@server_puppetserver_version, '2.6']) >= 0 -%>
+
+    # This controls the mount point for the status API
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
+<%- end -%>
 }


### PR DESCRIPTION
See https://docs.puppet.com/puppetserver/2.6/release_notes.html#new-feature-jvm-metrics-endpoint-statusv1services