### PR TITLE
correct typo in changelog (5.0-stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.0.1
 * Other changes and fixes:
-    * Change default Puppet Server version to 2.5.0
+    * Add support for Puppet Server 2.6.x and set it as default version
 
 ## 5.0.0
 * New or changed parameters:


### PR DESCRIPTION
Unfortunately I did push the last four commits into 5.0-stable unintentionally. :cry:

In 63b587, the default puppetserver version is set to 2.6.0 now, but I'm unsure if that's bringing more harm or more good, any comments on that?