### PR TITLE
only set puppetmaster var if fact is available

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -168,19 +168,21 @@ class puppet::params {
   $auth_allowed = ['$1']
 
   # Will this host be a puppet agent ?
-  $agent                     = true
-  $remove_lock               = true
-  $client_certname           = $::clientcert
+  $agent                      = true
+  $remove_lock                = true
+  $client_certname            = $::clientcert
 
   # Custom puppetmaster
-  if defined('$trusted') and $::trusted['authenticated'] == 'local' {
-    $puppetmaster            = undef
+  # needed due to a PUP-4072
+  # more information in https://github.com/theforeman/puppet-foreman/commit/5fe3239da0c6fbac76172f61042a69ab3a7eb4e6
+  if versioncmp($::puppetversion, '3.7.5') < 0 or defined('$::puppetmaster') {
+    $puppetmaster             = $::puppetmaster
   } else {
-    $puppetmaster            = $::puppetmaster
+    $puppetmaster             = undef
   }
 
   # Hashes containing additional settings
-  $additional_settings   =      {}
+  $additional_settings        = {}
   $agent_additional_settings  = {}
   $server_additional_settings = {}
 

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.3.0 < 5.0.0"
+      "version_requirement": ">= 3.6.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
we can use defined() or getar() here to determine the presence of the
fact. defined() requires puppet3.6, metadata.json currently mentions at
least 3.3. getvar() requires stdlib 4.4, metadata.json currently
mentions at least 4.2. I implemented defined() because this is already
used two lines higher.