### PR TITLE
External SSL Termination with Apache for Puppetserver

### DIFF
--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -74,8 +74,14 @@ class puppet::server::puppetserver (
   $server_admin_api_whitelist  = $::puppet::server::admin_api_whitelist,
   $server_puppetserver_version = $::puppet::server::puppetserver_version,
   $server_use_legacy_auth_conf = $::puppet::server::use_legacy_auth_conf,
+  $ca_server                   = $::puppet::ca_server,
+  $ca_port                     = $::puppet::ca_port
 ) {
   include ::puppet::server
+  
+  if $ca_server != '' and $ca_port != '' {
+    include ::puppet::server::reverseproxy
+  }
 
   $puppetserver_package = pick($::puppet::server::package, 'puppetserver')
 

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -79,7 +79,7 @@ class puppet::server::puppetserver (
   $ca_port                     = $::puppet::ca_port
 ) {
   include ::puppet::server
-  
+
   if $http and $ca_server != '' and $ca_port != '' {
     include ::puppet::server::reverseproxy
   }

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -74,12 +74,13 @@ class puppet::server::puppetserver (
   $server_admin_api_whitelist  = $::puppet::server::admin_api_whitelist,
   $server_puppetserver_version = $::puppet::server::puppetserver_version,
   $server_use_legacy_auth_conf = $::puppet::server::use_legacy_auth_conf,
+  $http                        = $::puppet::server::http,
   $ca_server                   = $::puppet::ca_server,
   $ca_port                     = $::puppet::ca_port
 ) {
   include ::puppet::server
   
-  if $ca_server != '' and $ca_port != '' {
+  if $http and $ca_server != '' and $ca_port != '' {
     include ::puppet::server::reverseproxy
   }
 

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -52,14 +52,14 @@ class puppet::server::reverseproxy (
     ],
     proxy_pass_match     => [
       {
-        'path'           => '^/.*/certificate.*/',
-        'url'            => "https://${ca_server}:${ca_port}",
-        'reverse_urls'   => "https://${ca_server}:${ca_port}",
+         'path'          => '^/.*/certificate.*/',
+          'url'          => "https://${ca_server}:${ca_port}",
+          'reverse_urls' => "https://${ca_server}:${ca_port}",
       },
       {
-        'path'           => '/',
-        'url'            => "http://localhost:${http_port}",
-        'reverse_urls'   => "http://localhost:${http_port}",
+          'path'         => '/',
+          'url'          => "http://localhost:${http_port}",
+          'reverse_urls' => "http://localhost:${http_port}",
       },
     ],
     require              => File["$confdir/public"],

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -15,8 +15,7 @@ class puppet::server::reverseproxy (
   $http_port             = $::puppet::server::http_port,
   $confdir               = $::puppet::server::dir,
   $ca_port               = $::puppet::ca_port,
-  $ca_server             = $::puppet::ca_server,
-  $vardir                = $::puppet::vardir
+  $ca_server             = $::puppet::ca_server
 ) {
   include ::apache
 

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -20,7 +20,7 @@ class puppet::server::reverseproxy (
 ) {
   include ::apache
   
-  file { "$confdir/public":
+  file { "${confdir}/public":
     ensure => directory,
   }
  
@@ -30,7 +30,7 @@ class puppet::server::reverseproxy (
     servername           => "$fqdn",
     vhost_name           => '*',
     priority             => false,
-    docroot              => "$confdir/public",
+    docroot              => "${confdir}/public",
     port                 => $port,
     ssl                  => true,
     ssl_cert             => $ssl_cert,
@@ -63,6 +63,6 @@ class puppet::server::reverseproxy (
         'reverse_urls'   => "http://localhost:${http_port}",
       },
     ],
-    require              => File["$confdir/public"],
+    require              => File["${confdir}/public"],
   }
 }

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -1,0 +1,67 @@
+# == Class: puppet::server::reverseproxy
+#
+# Set up apache to proxy certificate requests to the 
+# designated ca server.
+#
+class puppet::server::reverseproxy (
+  $port                    = $::puppet::server::port,
+  $ssl_ca_cert             = $::puppet::server::ssl_ca_cert,
+  $ssl_ca_crl              = $::puppet::server::ssl_ca_crl,
+  $ssl_cert                = $::puppet::server::ssl_cert,
+  $ssl_cert_key            = $::puppet::server::ssl_cert_key,
+  $ssl_chain               = $::puppet::server::ssl_chain,
+  $ssl_dir                 = $::puppet::server::ssl_dir,
+  $http                    = $::puppet::server::http,
+  $http_port               = $::puppet::server::http_port,
+  $confdir                 = $::puppet::server::dir,
+  $ca_port                 = $::puppet::ca_port,
+  $ca_server               = $::puppet::ca_server,
+) {
+  include ::apache
+
+  file { "$confdir/public":
+    ensure => directory,
+  }
+  
+  ::apache::listen {'8140':}
+  
+  ::apache::vhost { 'puppetserver-reverse-proxy':
+    servername             => "$fqdn",
+    vhost_name             => '*',
+    priority               => false,
+    docroot                => "$confdir/public",
+    port                   => $port,
+    ssl                    => true,
+    ssl_cert               => $ssl_cert,
+    ssl_key                => $ssl_cert_key,
+    ssl_ca                 => $ssl_ca_cert,
+    ssl_crl                => $ssl_ca_crl,
+    ssl_chain              => $ssl_chain,
+    ssl_protocol           => 'ALL -SSLv2 -SSLv3',
+    ssl_cipher             => 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA',
+    ssl_honorcipherorder   => 'on',
+    ssl_verify_client      => 'optional',
+    ssl_options            => '+StdEnvVars +ExportCertData',
+    ssl_verify_depth       => '1',
+    ssl_proxyengine        => true,
+    proxy_preserve_host    => true,
+    request_headers        => [
+      'set X-SSL-Subject %{SSL_CLIENT_S_DN}e',
+      'set X-Client-DN %{SSL_CLIENT_S_DN}e',
+      'set X-Client-Verify %{SSL_CLIENT_VERIFY}e',
+    ],
+    proxy_pass_match       => [
+      {
+        'path'             => '^/.*/certificate.*/',
+        'url'              => "https://${ca_server}:${ca_port}",
+        'reverse_urls'     => "https://${ca_server}:${ca_port}",
+      },
+      {
+        'path'             => '/',
+        'url'              => "http://localhost:${http_port}",
+        'reverse_urls'     => "http://localhost:${http_port}",
+      },
+    ],
+    require                => File["$confdir/public"],
+  }
+}

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -1,6 +1,6 @@
 # == Class: puppet::server::reverseproxy
 #
-# Set up apache to proxy certificate requests to the 
+# Set up apache to proxy certificate requests to the
 # designated ca server.
 #
 class puppet::server::reverseproxy (
@@ -16,15 +16,15 @@ class puppet::server::reverseproxy (
   $confdir                 = $::puppet::server::dir,
   $ca_port                 = $::puppet::ca_port,
   $ca_server               = $::puppet::ca_server,
+  $vardir                  = $::puppet::vardir
 ) {
   include ::apache
-
   file { "$confdir/public":
     ensure => directory,
   }
-  
+ 
   ::apache::listen {'8140':}
-  
+ 
   ::apache::vhost { 'puppetserver-reverse-proxy':
     servername             => "$fqdn",
     vhost_name             => '*',

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -23,9 +23,9 @@ class puppet::server::reverseproxy (
   file { "${confdir}/public":
     ensure => directory,
   }
- 
+
   ::apache::listen {'8140':}
- 
+
   ::apache::vhost { 'puppetserver-reverse-proxy':
     servername           => "$fqdn",
     vhost_name           => '*',

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -19,7 +19,7 @@ class puppet::server::reverseproxy (
   $vardir                = $::puppet::vardir
 ) {
   include ::apache
-  
+
   file { "${confdir}/public":
     ensure => directory,
   }

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -19,6 +19,7 @@ class puppet::server::reverseproxy (
   $vardir                = $::puppet::vardir
 ) {
   include ::apache
+  
   file { "$confdir/public":
     ensure => directory,
   }
@@ -52,14 +53,14 @@ class puppet::server::reverseproxy (
     ],
     proxy_pass_match     => [
       {
-          'path'         => '^/.*/certificate.*/',
-          'url'          => "https://${ca_server}:${ca_port}",
-          'reverse_urls' => "https://${ca_server}:${ca_port}",
+        'path'           => '^/.*/certificate.*/',
+        'url'            => "https://${ca_server}:${ca_port}",
+        'reverse_urls'   => "https://${ca_server}:${ca_port}",
       },
       {
-          'path'         => '/',
-          'url'          => "http://localhost:${http_port}",
-          'reverse_urls' => "http://localhost:${http_port}",
+        'path'           => '/',
+        'url'            => "http://localhost:${http_port}",
+        'reverse_urls'   => "http://localhost:${http_port}",
       },
     ],
     require              => File["$confdir/public"],

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -52,7 +52,7 @@ class puppet::server::reverseproxy (
     ],
     proxy_pass_match     => [
       {
-         'path'          => '^/.*/certificate.*/',
+          'path'         => '^/.*/certificate.*/',
           'url'          => "https://${ca_server}:${ca_port}",
           'reverse_urls' => "https://${ca_server}:${ca_port}",
       },

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -4,19 +4,19 @@
 # designated ca server.
 #
 class puppet::server::reverseproxy (
-  $port                    = $::puppet::server::port,
-  $ssl_ca_cert             = $::puppet::server::ssl_ca_cert,
-  $ssl_ca_crl              = $::puppet::server::ssl_ca_crl,
-  $ssl_cert                = $::puppet::server::ssl_cert,
-  $ssl_cert_key            = $::puppet::server::ssl_cert_key,
-  $ssl_chain               = $::puppet::server::ssl_chain,
-  $ssl_dir                 = $::puppet::server::ssl_dir,
-  $http                    = $::puppet::server::http,
-  $http_port               = $::puppet::server::http_port,
-  $confdir                 = $::puppet::server::dir,
-  $ca_port                 = $::puppet::ca_port,
-  $ca_server               = $::puppet::ca_server,
-  $vardir                  = $::puppet::vardir
+  $port                  = $::puppet::server::port,
+  $ssl_ca_cert           = $::puppet::server::ssl_ca_cert,
+  $ssl_ca_crl            = $::puppet::server::ssl_ca_crl,
+  $ssl_cert              = $::puppet::server::ssl_cert,
+  $ssl_cert_key          = $::puppet::server::ssl_cert_key,
+  $ssl_chain             = $::puppet::server::ssl_chain,
+  $ssl_dir               = $::puppet::server::ssl_dir,
+  $http                  = $::puppet::server::http,
+  $http_port             = $::puppet::server::http_port,
+  $confdir               = $::puppet::server::dir,
+  $ca_port               = $::puppet::ca_port,
+  $ca_server             = $::puppet::ca_server,
+  $vardir                = $::puppet::vardir
 ) {
   include ::apache
   file { "$confdir/public":
@@ -26,42 +26,42 @@ class puppet::server::reverseproxy (
   ::apache::listen {'8140':}
  
   ::apache::vhost { 'puppetserver-reverse-proxy':
-    servername             => "$fqdn",
-    vhost_name             => '*',
-    priority               => false,
-    docroot                => "$confdir/public",
-    port                   => $port,
-    ssl                    => true,
-    ssl_cert               => $ssl_cert,
-    ssl_key                => $ssl_cert_key,
-    ssl_ca                 => $ssl_ca_cert,
-    ssl_crl                => $ssl_ca_crl,
-    ssl_chain              => $ssl_chain,
-    ssl_protocol           => 'ALL -SSLv2 -SSLv3',
-    ssl_cipher             => 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA',
-    ssl_honorcipherorder   => 'on',
-    ssl_verify_client      => 'optional',
-    ssl_options            => '+StdEnvVars +ExportCertData',
-    ssl_verify_depth       => '1',
-    ssl_proxyengine        => true,
-    proxy_preserve_host    => true,
-    request_headers        => [
+    servername           => "$fqdn",
+    vhost_name           => '*',
+    priority             => false,
+    docroot              => "$confdir/public",
+    port                 => $port,
+    ssl                  => true,
+    ssl_cert             => $ssl_cert,
+    ssl_key              => $ssl_cert_key,
+    ssl_ca               => $ssl_ca_cert,
+    ssl_crl              => $ssl_ca_crl,
+    ssl_chain            => $ssl_chain,
+    ssl_protocol         => 'ALL -SSLv2 -SSLv3',
+    ssl_cipher           => 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA',
+    ssl_honorcipherorder => 'on',
+    ssl_verify_client    => 'optional',
+    ssl_options          => '+StdEnvVars +ExportCertData',
+    ssl_verify_depth     => '1',
+    ssl_proxyengine      => true,
+    proxy_preserve_host  => true,
+    request_headers      => [
       'set X-SSL-Subject %{SSL_CLIENT_S_DN}e',
       'set X-Client-DN %{SSL_CLIENT_S_DN}e',
       'set X-Client-Verify %{SSL_CLIENT_VERIFY}e',
     ],
-    proxy_pass_match       => [
+    proxy_pass_match     => [
       {
-        'path'             => '^/.*/certificate.*/',
-        'url'              => "https://${ca_server}:${ca_port}",
-        'reverse_urls'     => "https://${ca_server}:${ca_port}",
+        'path'           => '^/.*/certificate.*/',
+        'url'            => "https://${ca_server}:${ca_port}",
+        'reverse_urls'   => "https://${ca_server}:${ca_port}",
       },
       {
-        'path'             => '/',
-        'url'              => "http://localhost:${http_port}",
-        'reverse_urls'     => "http://localhost:${http_port}",
+        'path'           => '/',
+        'url'            => "http://localhost:${http_port}",
+        'reverse_urls'   => "http://localhost:${http_port}",
       },
     ],
-    require                => File["$confdir/public"],
+    require              => File["$confdir/public"],
   }
 }

--- a/manifests/server/reverseproxy.pp
+++ b/manifests/server/reverseproxy.pp
@@ -26,7 +26,7 @@ class puppet::server::reverseproxy (
   ::apache::listen {'8140':}
 
   ::apache::vhost { 'puppetserver-reverse-proxy':
-    servername           => "$fqdn",
+    servername           => "${::fqdn}",
     vhost_name           => '*',
     priority             => false,
     docroot              => "${confdir}/public",

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -1,5 +1,6 @@
 authorization: {
     version: 1
+    allow-header-cert-info: <%= scope.lookupvar('puppet::server::http') %>
     rules: [
         {
             # Allow nodes to retrieve their own catalog

--- a/templates/server/puppetserver/conf.d/webserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/webserver.conf.erb
@@ -2,7 +2,7 @@ webserver: {
     access-log-config = <%= scope.lookupvar('puppet::server::puppetserver_dir') %>/request-logging.xml
     client-auth       = want
 <%- if scope.lookupvar('puppet::server::http') -%>
-    host              = 127.0.0.1
+    host              = <%= scope.lookupvar('puppet::server::ip') %>
     port              = <%= scope.lookupvar('puppet::server::http_port') %>
 <%- else -%>
     ssl-host          = <%= scope.lookupvar('puppet::server::ip') %>

--- a/templates/server/puppetserver/conf.d/webserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/webserver.conf.erb
@@ -1,6 +1,10 @@
 webserver: {
     access-log-config = <%= scope.lookupvar('puppet::server::puppetserver_dir') %>/request-logging.xml
     client-auth       = want
+<%- if scope.lookupvar('puppet::server::http') -%>
+    host              = 127.0.0.1
+    port              = <%= scope.lookupvar('puppet::server::http_port') %>
+<%- else -%>
     ssl-host          = <%= scope.lookupvar('puppet::server::ip') %>
     ssl-port          = <%= scope.lookupvar('puppet::server::port') %>
     ssl-cert          = <%= scope.lookupvar('puppet::server::ssl_cert') %>
@@ -9,5 +13,6 @@ webserver: {
 <%- if scope.lookupvar('puppet::server::ca') -%>
     ssl-cert-chain    = <%= scope.lookupvar('puppet::server::ssl_chain') %>
     ssl-crl-path      = <%= scope.lookupvar('puppet::server::ssl_ca_crl') %>
+<%- end -%>
 <%- end -%>
 }


### PR DESCRIPTION
This functionality exists for puppet master configurations in the puppet-puppet module but is not available for puppetserver. Puppet Labs' documentation on configuring compile masters with external SSL termination is here: https://docs.puppet.com/puppetserver/latest/external_ssl_termination.html

This code is tested and working on OracleLinux 6.8. 
I'd appreciate any feedback/suggestions on making this more Foreman-friendly.

Sample code to configure a compile master:

```
  class { '::puppet':
    agent                       => true,
    server                      => true,
    server_ca                   => false,
    ca_server                   => "<fqdn of master of masters>",
    ca_port                     => '8140',
    server_implementation       => 'puppetserver',
    server_foreman              => false,
    server_http                 => true,
    server_http_port            => '8139',
  }
```
