### PR TITLE
Deprecating and replacing server_facts parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -754,7 +754,7 @@ class puppet (
   $server_foreman_ssl_ca            = $puppet::params::server_foreman_ssl_ca,
   $server_foreman_ssl_cert          = $puppet::params::server_foreman_ssl_cert,
   $server_foreman_ssl_key           = $puppet::params::server_foreman_ssl_key,
-  $server_facts                     = $puppet::params::server_foreman_facts,
+  $server_facts                     = undef,
   $server_foreman_facts             = $puppet::params::server_foreman_facts,
   $server_puppet_basedir            = $puppet::params::server_puppet_basedir,
   $server_puppetdb_host             = $puppet::params::server_puppetdb_host,
@@ -773,8 +773,8 @@ class puppet (
   $server_use_legacy_auth_conf      = $puppet::params::server_use_legacy_auth_conf,
 ) inherits puppet::params {
 
-  if $server_facts != $server_foreman_facts {
-    warning('The $server_facts parameter to puppet is deprecated and has no effect.')
+  if $server_facts {
+    warning('The $server_facts parameter to puppet is deprecated. Use $server_foreman_facts instead.')
   }
 
   validate_bool($listen)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -444,10 +444,6 @@
 #                                     approach will be installed.
 #                                     type:string
 #
-# $server_facts::                     Should foreman receive facts from puppet
-#                                     DEPRECATION WARNING: Use server_foreman_facts.
-#                                     type:boolean
-#
 # $server_foreman_facts::             Should foreman receive facts from puppet
 #                                     type:boolean
 #
@@ -754,7 +750,6 @@ class puppet (
   $server_foreman_ssl_ca            = $puppet::params::server_foreman_ssl_ca,
   $server_foreman_ssl_cert          = $puppet::params::server_foreman_ssl_cert,
   $server_foreman_ssl_key           = $puppet::params::server_foreman_ssl_key,
-  $server_facts                     = undef,
   $server_foreman_facts             = $puppet::params::server_foreman_facts,
   $server_puppet_basedir            = $puppet::params::server_puppet_basedir,
   $server_puppetdb_host             = $puppet::params::server_puppetdb_host,
@@ -772,10 +767,6 @@ class puppet (
   $server_max_requests_per_instance = $puppet::params::server_max_requests_per_instance,
   $server_use_legacy_auth_conf      = $puppet::params::server_use_legacy_auth_conf,
 ) inherits puppet::params {
-
-  if $server_facts {
-    warning('The $server_facts parameter to puppet is deprecated. Use $server_foreman_facts instead.')
-  }
 
   validate_bool($listen)
   validate_bool($pluginsync)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -445,6 +445,10 @@
 #                                     type:string
 #
 # $server_facts::                     Should foreman receive facts from puppet
+#                                     DEPRECATION WARNING: Use server_foreman_facts.
+#                                     type:boolean
+#
+# $server_foreman_facts::             Should foreman receive facts from puppet
 #                                     type:boolean
 #
 # $server_foreman::                   Should foreman integration be installed
@@ -750,7 +754,8 @@ class puppet (
   $server_foreman_ssl_ca            = $puppet::params::server_foreman_ssl_ca,
   $server_foreman_ssl_cert          = $puppet::params::server_foreman_ssl_cert,
   $server_foreman_ssl_key           = $puppet::params::server_foreman_ssl_key,
-  $server_facts                     = $puppet::params::server_facts,
+  $server_facts                     = $puppet::params::server_foreman_facts,
+  $server_foreman_facts             = $puppet::params::server_foreman_facts,
   $server_puppet_basedir            = $puppet::params::server_puppet_basedir,
   $server_puppetdb_host             = $puppet::params::server_puppetdb_host,
   $server_puppetdb_port             = $puppet::params::server_puppetdb_port,
@@ -767,6 +772,10 @@ class puppet (
   $server_max_requests_per_instance = $puppet::params::server_max_requests_per_instance,
   $server_use_legacy_auth_conf      = $puppet::params::server_use_legacy_auth_conf,
 ) inherits puppet::params {
+
+  if $server_facts != $server_foreman_facts {
+    warning('The $server_facts parameter to puppet is deprecated and has no effect.')
+  }
 
   validate_bool($listen)
   validate_bool($pluginsync)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -342,7 +342,7 @@ class puppet::params {
   # Foreman parameters
   $lower_fqdn              = downcase($::fqdn)
   $server_foreman          = true
-  $server_facts            = true
+  $server_foreman_facts    = true
   $server_puppet_basedir   = $aio_package ? {
     true  => '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet',
     false => undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -479,7 +479,6 @@ class puppet::server(
   validate_bool($passenger)
   validate_bool($git_repo)
   validate_bool($service_fallback)
-  validate_bool($server_facts)
   validate_bool($server_foreman_facts)
   validate_bool($strict_variables)
   validate_bool($foreman)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -217,10 +217,6 @@
 #                              approach will be installed.
 #                              type:string
 #
-# $server_facts::              Should foreman receive facts from puppet
-#                              DEPRECATION WARNING: Use server_foreman_facts.
-#                              type:boolean
-#
 # $server_foreman_facts::      Should foreman receive facts from puppet
 #                              type:boolean
 #
@@ -451,7 +447,6 @@ class puppet::server(
   $foreman_ssl_ca            = $::puppet::server_foreman_ssl_ca,
   $foreman_ssl_cert          = $::puppet::server_foreman_ssl_cert,
   $foreman_ssl_key           = $::puppet::server_foreman_ssl_key,
-  $server_facts              = undef,
   $server_foreman_facts      = $::puppet::server_foreman_facts,
   $puppet_basedir            = $::puppet::server_puppet_basedir,
   $puppetdb_host             = $::puppet::server_puppetdb_host,
@@ -469,10 +464,6 @@ class puppet::server(
   $max_requests_per_instance = $::puppet::server_max_requests_per_instance,
   $use_legacy_auth_conf      = $::puppet::server_use_legacy_auth_conf,
 ) {
-
-  if $server_facts {
-    warning('The $server_facts parameter to puppet::server is deprecated. Use $server_foreman_facts instead.')
-  }
 
   validate_bool($ca)
   validate_bool($http)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -218,6 +218,10 @@
 #                              type:string
 #
 # $server_facts::              Should foreman receive facts from puppet
+#                              DEPRECATION WARNING: Use server_foreman_facts.
+#                              type:boolean
+#
+# $server_foreman_facts::      Should foreman receive facts from puppet
 #                              type:boolean
 #
 # $foreman::                   Should foreman integration be installed
@@ -447,7 +451,8 @@ class puppet::server(
   $foreman_ssl_ca            = $::puppet::server_foreman_ssl_ca,
   $foreman_ssl_cert          = $::puppet::server_foreman_ssl_cert,
   $foreman_ssl_key           = $::puppet::server_foreman_ssl_key,
-  $server_facts              = $::puppet::server_facts,
+  $server_facts              = $::puppet::server_foreman_facts,
+  $server_foreman_facts      = $::puppet::server_foreman_facts,
   $puppet_basedir            = $::puppet::server_puppet_basedir,
   $puppetdb_host             = $::puppet::server_puppetdb_host,
   $puppetdb_port             = $::puppet::server_puppetdb_port,
@@ -465,12 +470,17 @@ class puppet::server(
   $use_legacy_auth_conf      = $::puppet::server_use_legacy_auth_conf,
 ) {
 
+  if $server_facts != $server_foreman_facts {
+    warning('The $server_facts parameter to puppet::server is deprecated and has no effect.')
+  }
+
   validate_bool($ca)
   validate_bool($http)
   validate_bool($passenger)
   validate_bool($git_repo)
   validate_bool($service_fallback)
   validate_bool($server_facts)
+  validate_bool($server_foreman_facts)
   validate_bool($strict_variables)
   validate_bool($foreman)
   validate_bool($puppetdb_swf)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -451,7 +451,7 @@ class puppet::server(
   $foreman_ssl_ca            = $::puppet::server_foreman_ssl_ca,
   $foreman_ssl_cert          = $::puppet::server_foreman_ssl_cert,
   $foreman_ssl_key           = $::puppet::server_foreman_ssl_key,
-  $server_facts              = $::puppet::server_foreman_facts,
+  $server_facts              = undef,
   $server_foreman_facts      = $::puppet::server_foreman_facts,
   $puppet_basedir            = $::puppet::server_puppet_basedir,
   $puppetdb_host             = $::puppet::server_puppetdb_host,
@@ -470,8 +470,8 @@ class puppet::server(
   $use_legacy_auth_conf      = $::puppet::server_use_legacy_auth_conf,
 ) {
 
-  if $server_facts != $server_foreman_facts {
-    warning('The $server_facts parameter to puppet::server is deprecated and has no effect.')
+  if $server_facts {
+    warning('The $server_facts parameter to puppet::server is deprecated. Use $server_foreman_facts instead.')
   }
 
   validate_bool($ca)

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -204,7 +204,7 @@ class puppet::server::config inherits puppet::config {
     anchor { 'puppet::server::config_start': } ->
     class {'::foreman::puppetmaster':
       foreman_url    => $::puppet::server::foreman_url,
-      receive_facts  => $::puppet::server::server_foreman_facts,
+      receive_facts  => pick($::puppet::server::server_facts, $::puppet::server::server_foreman_facts),
       puppet_home    => $::puppet::server::puppetserver_vardir,
       puppet_basedir => $::puppet::server::puppet_basedir,
       puppet_etcdir  => $puppet::dir,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -204,7 +204,7 @@ class puppet::server::config inherits puppet::config {
     anchor { 'puppet::server::config_start': } ->
     class {'::foreman::puppetmaster':
       foreman_url    => $::puppet::server::foreman_url,
-      receive_facts  => $::puppet::server::server_facts,
+      receive_facts  => $::puppet::server::server_foreman_facts,
       puppet_home    => $::puppet::server::puppetserver_vardir,
       puppet_basedir => $::puppet::server::puppet_basedir,
       puppet_etcdir  => $puppet::dir,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -204,7 +204,7 @@ class puppet::server::config inherits puppet::config {
     anchor { 'puppet::server::config_start': } ->
     class {'::foreman::puppetmaster':
       foreman_url    => $::puppet::server::foreman_url,
-      receive_facts  => pick($::puppet::server::server_facts, $::puppet::server::server_foreman_facts),
+      receive_facts  => $::puppet::server::server_foreman_facts,
       puppet_home    => $::puppet::server::puppetserver_vardir,
       puppet_basedir => $::puppet::server::puppet_basedir,
       puppet_etcdir  => $puppet::dir,


### PR DESCRIPTION
The $server_facts variable name is reserved by puppet-servers when trusted_server_facts is enabled.
Using this variable in a manifest causes compilation to fail with "Attempt to assign to a reserved variable name: server_facts"
This commit deprecates this variable and introduces the boolean $server_foreman_facts as its replacement.
**Partially** fixes GH issue #440 
