### PR TITLE
fixes #15550 - start Puppet agent after server is running

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -814,4 +814,10 @@ class puppet (
     include ::puppet::server
     Class['puppet::server'] -> Class['puppet']
   }
+
+  # Ensure the server is running before the agent needs it, and that
+  # certificates are generated in the server config (if enabled)
+  if $server == true and $agent == true {
+    Class['puppet::server'] -> Class['puppet::agent::service']
+  }
 }

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -52,7 +52,10 @@ describe 'puppet' do
       end
 
       describe 'with no custom parameters' do
+        it { is_expected.to compile.with_all_deps unless os_facts[:osfamily] == 'windows' }
+        it { should contain_class('puppet::agent') }
         it { should contain_class('puppet::config') }
+        it { should_not contain_class('puppet::server') }
         if Puppet.version < '4.0'
           it { should contain_file(puppet_directory).with_ensure('directory') }
           it { should contain_concat(puppet_concat) }
@@ -62,6 +65,16 @@ describe 'puppet' do
           it { should contain_concat(puppet_concat) }
           it { should contain_package(puppet_package).with_ensure('present') }
         end
+      end
+
+      describe 'with server => true', :unless => (os_facts[:osfamily] == 'windows') do
+        let :params do {
+          :server => true,
+        } end
+
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_class('puppet::server') }
+        it { should contain_class('puppet::agent::service').that_requires('Class[puppet::server]') }
       end
 
       describe 'with empty ca_server' do


### PR DESCRIPTION
Ensures no race condition will occur between the generate CA step of the
server configuration and the agent starting up, generating its own
private key.

---

The agent started by `puppet::agent::service` generates its private key _after_ forking (if entropy is low, it might even take a while), and so this might otherwise happen at the same time as `puppet::server::config` calling `puppet cert generate`. If the agent is slower to write to disk, its key overwrites the one used by the generate command to create the new certificate.