### PR TITLE
allow the user to add custom auth rules in auth.conf without managing the entire template

### DIFF
--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -1,0 +1,59 @@
+# == Define: puppet::auth
+#
+# === Parameters
+#
+# [*name*]
+#   String::            Name of the auth directive
+#
+# [*path*]
+#   String::            Which URLs the ACL applies to. Required. Must be the first directive in the ACL.
+#                       Default: the value of $name
+#
+# [*environment*]
+#   String::            A valid environment or a comma-separated list of environments. Optional;
+#                       defaults to all environments if omitted.
+#
+# [*method*]
+#   String::            Which HTTP methods the ACL applies to.
+#                       Allowed values: find, search, save, destroy, or a comma-separated list of those values. Optional;
+#                       defaults to all methods if omitted.
+#
+# [*auth*]
+#   String::            Whether the ACL applies to client-verified or non-client-verified HTTPS requests.
+#                       Allowed values: yes, any, no (with on and off as synonyms). Must be a single value. Optional;
+#                       defaults to yes (verified) if omitted.
+#
+# [*allow*]
+#   String::            Which certificate names or hostnames can make requests that match the ACL.
+#                       For client-verified requests, Puppet will check allow directives against the common name (CN)
+#                       from the client's SSL certificate. For unverified requests, Puppet will use reverse DNS to figure
+#                       out the client's hostname, and compare that to the allow directives.
+#                       Optional; if you don't specify any allow or allow_ip directives, Puppet will reject all requests matching the ACL.
+#
+# [*deny*]
+#   String::            The oposite of allow
+#
+# [*allow_ip*]
+#   String::            Which IP addresses can make matching requests.
+#
+# [*deny_ip*]
+#   String::            The oposite of allow_ip
+#
+define puppet::auth (
+  $path                = $name,
+  $order               = 20,
+  $environment         = undef,
+  $method              = undef,
+  $auth                = undef,
+  $allow               = undef,
+  $deny                = undef,
+  $allow_ip            = undef,
+  $deny_ip             = undef,
+  $auth_template_extra = 'puppet/auth_extra.conf.erb',
+) {
+  concat::fragment { "${name}_auth":
+    target  => "${::puppet::dir}/auth.conf",
+    content => template($auth_template_extra),
+    order   => "${order}_${name}",
+  }
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -82,7 +82,21 @@ class puppet::config(
       }
     }
   } ~>
-  file { "${puppet_dir}/auth.conf":
+  concat { "${puppet_dir}/auth.conf":
+    owner => 'root',
+    group => $::puppet::params::root_group,
+    mode  => '0644',
+  }
+
+  concat::fragment { 'puppet.auth+10-main-start':
+    target  => "${puppet_dir}/auth.conf",
     content => template($auth_template),
+    order   => '10',
+  }
+
+  concat::fragment { 'zzz_puppet.auth+999-main-end':
+    target  => "${puppet_dir}/auth.conf",
+    content => template('puppet/auth_end.conf.erb'),
+    order   => '999',
   }
 }

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -63,11 +63,19 @@ describe 'puppet::config' do
 
         it 'should contain auth.conf' do
           if Puppet.version >= '4.0'
-            should_not contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
-            should contain_file("#{confdir}/auth.conf").with_content(%r{/puppet/v3/})
+            should_not contain_concat__fragment('puppet.auth+10-main-start').
+              with_content(%r{^path /certificate_revocation_list/ca\nmethod find$}).
+              with({}) # So we can use a trailing dot on each with_content line
+            should contain_concat__fragment('puppet.auth+10-main-start').
+              with_content(%r{/puppet/v3/}).
+              with({}) # So we can use a trailing dot on each with_content line
           else
-            should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
-            should_not contain_file("#{confdir}/auth.conf").with_content(%r{/puppet/v3/})
+            should contain_concat__fragment('puppet.auth+10-main-start').
+              with_content(%r{^path /certificate_revocation_list/ca\nmethod find$}).
+              with({}) # So we can use a trailing dot on each with_content line
+            should_not contain_concat__fragment('puppet.auth+10-main-start').
+              with_content(%r{/puppet/v3/}).
+              with({}) # So we can use a trailing dot on each with_content line
           end
         end
 
@@ -101,9 +109,13 @@ describe 'puppet::config' do
 
         it 'should contain auth.conf with auth any' do
           if Puppet.version >= '4.0'
-            should contain_file("#{confdir}/auth.conf").with_content(%r{^path /puppet-ca/v1/certificate_revocation_list/ca\nauth any$})
+            should contain_concat__fragment('puppet.auth+10-main-start').
+              with_content(%r{^path /puppet-ca/v1/certificate_revocation_list/ca\nauth any$}).
+              with({}) # So we can use a trailing dot on each with_content line
           else
-            should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nauth any$})
+            should contain_concat__fragment('puppet.auth+10-main-start').
+              with_content(%r{^path /certificate_revocation_list/ca\nauth any$}).
+              with({}) # So we can use a trailing dot on each with_content line
           end
         end
       end
@@ -114,7 +126,9 @@ describe 'puppet::config' do
         end
 
         it 'should contain auth.conf with allow' do
-          should contain_file("#{confdir}/auth.conf").with_content(%r{^allow \$1, puppetproxy$})
+          should contain_concat__fragment('puppet.auth+10-main-start').
+            with_content(%r{^allow \$1, puppetproxy$}).
+            with({}) # So we can use a trailing dot on each with_content line
         end
       end
 
@@ -167,7 +181,9 @@ describe 'puppet::config' do
         end
 
         it 'should contain auth.conf with auth any' do
-          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow node1.example.com,node2.example.com$})
+          should contain_concat__fragment('puppet.auth+10-main-start').
+            with_content(%r{^path /run\nauth any\nmethod save\nallow node1.example.com,node2.example.com$}).
+            with({}) # So we can use a trailing dot on each with_content line
         end
       end
 
@@ -177,7 +193,9 @@ describe 'puppet::config' do
         end
 
         it 'should contain auth.conf with auth any' do
-          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow master.example.com$})
+          should contain_concat__fragment('puppet.auth+10-main-start').
+            with_content(%r{^path /run\nauth any\nmethod save\nallow master.example.com$}).
+            with({}) # So we can use a trailing dot on each with_content line
         end
       end
 
@@ -187,7 +205,9 @@ describe 'puppet::config' do
         end
 
         it 'should contain auth.conf with auth any' do
-          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow #{facts[:fqdn]}$})
+          should contain_concat__fragment('puppet.auth+10-main-start').
+            with_content(%r{^path /run\nauth any\nmethod save\nallow #{facts[:fqdn]}$}).
+            with({}) # So we can use a trailing dot on each with_content line
         end
       end
 

--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -221,8 +221,3 @@ path /v2.0/environments
 method find
 allow *
 <% end -%>
-
-# deny everything else; this ACL is not strictly necessary, but
-# illustrates the default policy.
-path /
-auth any

--- a/templates/auth_end.conf.erb
+++ b/templates/auth_end.conf.erb
@@ -1,0 +1,5 @@
+
+# deny everything else; this ACL is not strictly necessary, but
+# illustrates the default policy.
+path /
+auth any

--- a/templates/auth_extra.conf.erb
+++ b/templates/auth_extra.conf.erb
@@ -1,0 +1,17 @@
+
+# <%= @name %>
+path <%= @path %>
+<% if @environment then -%>environment <%= @environment %>
+<% end -%>
+<% if @method then -%>method <%= @method %>
+<% end -%>
+<% if @auth then -%>auth <%= @auth %>
+<% end -%>
+<% if @allow then -%>allow <%= @allow %>
+<% end -%>
+<% if @deny then -%>deny <%= @deny %>
+<% end -%>
+<% if @allow_ip then -%>allow_ip <%= @allow_ip %>
+<% end -%>
+<% if @deny_ip then -%>deny_ip <%= @deny_ip %>
+<% end -%>


### PR DESCRIPTION
File "${puppet_dir}/auth.conf" was modified to concat resource.
Added a new define puppet::auth.
Update tests.

Usage: 

		  puppet::auth { 'allow all machines to upload their own facts':
		    path   => '/facts/',
		    method => 'save, find, search',
		    auth   => 'yes',
		    allow  => '*',
		  }
