### PR TITLE
refs #17133 - add puppet::server::config (CA) dep to foreman::service

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -19,6 +19,11 @@ class puppet::server::config inherits puppet::config {
     Class['puppet::server::config'] ~> Class['foreman_proxy::service']
   }
 
+  # And before Foreman's cert-using service needs it
+  if defined(Class['foreman::service']) and $foreman::ssl {
+    Class['puppet::server::config'] -> Class['foreman::service']
+  }
+
   ## General configuration
   $ca_server                   = $::puppet::ca_server
   $ca_port                     = $::puppet::ca_port


### PR DESCRIPTION
Other half of https://github.com/theforeman/puppet-foreman/pull/500 because of the the defined() parse order, similar to the foreman_proxy dep.