### PR TITLE
fixes #17062 - move master rack restart to puppet::server::service

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -561,18 +561,22 @@ class puppet::server(
   }
 
   if $implementation == 'master' {
-    $pm_service = !$passenger and $service_fallback
-    $ps_service = undef
+    $pm_service   = !$passenger and $service_fallback
+    $ps_service   = undef
+    $rack_service = $passenger
   } elsif $implementation == 'puppetserver' {
-    $pm_service = undef
-    $ps_service = true
+    $pm_service   = undef
+    $ps_service   = true
+    $rack_service = false
   }
 
   class { '::puppet::server::install': }~>
   class { '::puppet::server::config':  }~>
   class { '::puppet::server::service':
+    app_root     => $app_root,
     puppetmaster => $pm_service,
     puppetserver => $ps_service,
+    rack         => $rack_service,
   }->
   Class['puppet::server']
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,15 +1,11 @@
 # Set up the puppet server config
 class puppet::server::config inherits puppet::config {
   if $::puppet::server::passenger and $::puppet::server::implementation == 'master' {
-    # Anchor the passenger config inside this
-    class { '::puppet::server::passenger': } -> Class['puppet::server::config']
+    contain '::puppet::server::passenger'
   }
 
   if $::puppet::server::implementation == 'puppetserver' {
-    include ::puppet::server::puppetserver
-    anchor {'::puppet::server::puppetserver_start': } ->
-    Class['::puppet::server::puppetserver'] ~>
-    anchor {'::puppet::server::puppetserver_end': }
+    contain '::puppet::server::puppetserver'
   }
 
   # Mirror the relationship, as defined() is parse-order dependent

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -31,6 +31,17 @@ class puppet::server::install {
     }
   }
 
+  # Prevent the master service running and preventing Apache from binding to the port
+  if $::puppet::server::passenger and $::osfamily == 'Debian' {
+    file { '/etc/default/puppetmaster':
+      content => "START=no\n",
+    }
+
+    if $::puppet::manage_packages == true or $::puppet::manage_packages == 'server' {
+      File['/etc/default/puppetmaster'] -> Package[$server_package]
+    }
+  }
+
   if $::puppet::server::git_repo {
     file { $puppet::vardir:
       ensure => directory,

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -25,26 +25,7 @@ class puppet::server::passenger (
 ) {
   include ::apache
   include ::apache::mod::passenger
-
-  class { '::puppet::server::rack':
-    app_root       => $app_root,
-    confdir        => $confdir,
-    rack_arguments => $rack_arguments,
-    user           => $user,
-    vardir         => $vardir,
-  }
-
-  case $::operatingsystem {
-    'Debian', 'Ubuntu': {
-      file { '/etc/default/puppetmaster':
-        content => "START=no\n",
-        before  => Class['puppet::server::install'],
-      }
-    }
-    default: {
-      # nothing to do
-    }
-  }
+  contain '::puppet::server::rack'
 
   $directory = {
     'path'              => "${app_root}/public/",

--- a/manifests/server/rack.pp
+++ b/manifests/server/rack.pp
@@ -11,23 +11,12 @@
 # include puppet::server::rack
 #
 class puppet::server::rack(
-  $app_root       = $::puppet::server::app_root,
-  $confdir        = $::puppet::server::dir,
-  $rack_arguments = $::puppet::server::rack_arguments,
-  $user           = $::puppet::server::user,
-  $vardir         = $::puppet::vardir,
+  $app_root       = $::puppet::server::passenger::app_root,
+  $confdir        = $::puppet::server::passenger::confdir,
+  $rack_arguments = $::puppet::server::passenger::rack_arguments,
+  $user           = $::puppet::server::passenger::user,
+  $vardir         = $::puppet::server::passenger::vardir,
 ) {
-  exec {'puppet_server_rack-restart':
-    command     => "touch ${app_root}/tmp/restart.txt",
-    cwd         => $app_root,
-    path        => '/bin:/usr/bin',
-    refreshonly => true,
-    require     => [
-      Class['puppet::server::install'],
-      File["${app_root}/tmp"]
-    ],
-  }
-
   file {
     [$app_root, "${app_root}/public", "${app_root}/tmp"]:
       ensure => directory,
@@ -35,11 +24,9 @@ class puppet::server::rack(
       mode   => '0755',
   }
 
-  file {
-    "${app_root}/config.ru":
-      owner   => $user,
-      content => template('puppet/server/config.ru.erb'),
-      notify  => Exec['puppet_server_rack-restart'],
+  file { "${app_root}/config.ru":
+    owner   => $user,
+    content => template('puppet/server/config.ru.erb'),
   }
 
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -4,15 +4,22 @@
 #
 # === Parameters:
 #
+# $app_root::      Rack application top-level directory
+#
 # $puppetmaster::  Whether to start/stop the (Ruby) puppetmaster service
 #                  type:boolean
 #
 # $puppetserver::  Whether to start/stop the (JVM) puppetserver service
 #                  type:boolean
 #
+# $rack::          Whether to manage restarts for the Rack-based puppetmaster service
+#                  type:boolean
+#
 class puppet::server::service(
+  $app_root     = undef,
   $puppetmaster = undef,
   $puppetserver = undef,
+  $rack         = undef,
 ) {
   if $puppetmaster and $puppetserver {
     fail('Both puppetmaster and puppetserver cannot be enabled simultaneously')
@@ -46,4 +53,11 @@ class puppet::server::service(
     }
   }
 
+  if $rack {
+    exec {'restart_puppetmaster':
+      command     => "/bin/touch ${app_root}/tmp/restart.txt",
+      refreshonly => true,
+      cwd         => $app_root,
+    }
+  }
 }

--- a/spec/classes/puppet_server_rack_spec.rb
+++ b/spec/classes/puppet_server_rack_spec.rb
@@ -25,16 +25,6 @@ describe 'puppet::server::rack' do
       describe 'defaults' do
         let(:params) { default_params }
 
-        it 'should define Exec[puppet_server_rack-restart]' do
-          should contain_exec('puppet_server_rack-restart').with({
-            :command      => 'touch /etc/puppet/rack/tmp/restart.txt',
-            :path         => '/bin:/usr/bin',
-            :refreshonly  => true,
-            :cwd          => '/etc/puppet/rack',
-            :require      => ['Class[Puppet::Server::Install]', 'File[/etc/puppet/rack/tmp]'],
-          })
-        end
-
         it 'should create server_app_root' do
           should contain_file('/etc/puppet/rack').with({
             :ensure => 'directory',
@@ -62,7 +52,6 @@ describe 'puppet::server::rack' do
         it 'should create config.ru' do
           should contain_file('/etc/puppet/rack/config.ru').with({
             :owner  => 'puppet',
-            :notify => 'Exec[puppet_server_rack-restart]',
           })
         end
 

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -21,6 +21,7 @@ describe 'puppet::server::service' do
       describe 'default_parameters' do
         it { should_not contain_service(master_service) }
         it { should_not contain_service('puppetserver') }
+        it { should_not contain_exec('restart_puppetmaster') }
       end
 
       describe 'when puppetmaster => true' do
@@ -59,6 +60,17 @@ describe 'puppet::server::service' do
           should contain_service('puppetserver').with({
             :ensure => 'stopped',
             :enable => 'false',
+          })
+        end
+      end
+
+      describe 'when rack => true' do
+        let(:params) { {:rack => true, :puppetserver => :undef, :puppetmaster => :undef, :app_root => '/etc/puppet/rack'} }
+        it do
+          should contain_exec('restart_puppetmaster').with({
+            :command      => '/bin/touch /etc/puppet/rack/tmp/restart.txt',
+            :refreshonly  => true,
+            :cwd          => '/etc/puppet/rack',
           })
         end
       end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -33,12 +33,20 @@ describe 'puppet::server' do
             should contain_class('puppet::server::config')
             should contain_class('puppet::server::service').
               with_puppetmaster(false).
-              with_puppetserver(nil)
+              with_puppetserver(nil).
+              with_rack(true)
           end
           it { should_not contain_notify('ip_not_supported') }
           # No server_package for FreeBSD
           if not facts[:osfamily] == 'FreeBSD'
             it { should contain_package(server_package) }
+          end
+          if facts[:osfamily] == 'Debian'
+            it do
+              should contain_file('/etc/default/puppetmaster').
+                with_content("START=no\n").
+                that_comes_before("Package[#{server_package}]")
+            end
           end
         end
       end
@@ -100,7 +108,8 @@ describe 'puppet::server' do
         it do
           should contain_class('puppet::server::service').
             with_puppetmaster(true).
-            with_puppetserver(nil)
+            with_puppetserver(nil).
+            with_rack(false)
         end
 
         describe "and server_service_fallback => false" do
@@ -112,7 +121,8 @@ describe 'puppet::server' do
           it do
             should contain_class('puppet::server::service').
               with_puppetmaster(false).
-              with_puppetserver(nil)
+              with_puppetserver(nil).
+              with_rack(false)
           end
         end
       end
@@ -129,7 +139,8 @@ describe 'puppet::server' do
           it do
             should contain_class('puppet::server::service').
               with_puppetmaster(nil).
-              with_puppetserver(true)
+              with_puppetserver(true).
+              with_rack(false)
           end
           it { should contain_class('puppet::server::puppetserver') }
           it { should contain_package('puppetserver') }


### PR DESCRIPTION
Includes minor changes to containment of server configuration classes
to ensure notifies of changes from puppet::server::passenger and ::rack
all reach puppet::server::service.