### PR TITLE
Fix contain() compatibility with Puppet 3.6 (PUP-1597)

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,11 +1,11 @@
 # Set up the puppet server config
 class puppet::server::config inherits puppet::config {
   if $::puppet::server::passenger and $::puppet::server::implementation == 'master' {
-    contain '::puppet::server::passenger'
+    contain 'puppet::server::passenger' # lint:ignore:relative_classname_inclusion (PUP-1597)
   }
 
   if $::puppet::server::implementation == 'puppetserver' {
-    contain '::puppet::server::puppetserver'
+    contain 'puppet::server::puppetserver' # lint:ignore:relative_classname_inclusion (PUP-1597)
   }
 
   # Mirror the relationship, as defined() is parse-order dependent

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -25,7 +25,7 @@ class puppet::server::passenger (
 ) {
   include ::apache
   include ::apache::mod::passenger
-  contain '::puppet::server::rack'
+  contain 'puppet::server::rack' # lint:ignore:relative_classname_inclusion (PUP-1597)
 
   $directory = {
     'path'              => "${app_root}/public/",


### PR DESCRIPTION
Fixes errors building the catalog on Puppet 3.6 (e.g. from EPEL7):

    # [ERROR 2016-11-19 09:28:04 verbose] undefined method `ref' for nil:NilClass on node foreman-el7.example.com
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/resource/catalog.rb:534:in `block in to_catalog'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/resource/catalog.rb:522:in `each'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/resource/catalog.rb:522:in `to_catalog'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/resource/catalog.rb:410:in `to_resource'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/parser/compiler.rb:23:in `compile'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/indirector/catalog/compiler.rb:95:in `block (2 levels) in compile'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/util/profiler/none.rb:6:in `profile'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/util/profiler.rb:43:in `profile'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/indirector/catalog/compiler.rb:93:in `block in compile'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/util.rb:161:in `block in benchmark'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/benchmark.rb:296:in `realtime'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/util.rb:160:in `benchmark'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/indirector/catalog/compiler.rb:92:in `compile'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/indirector/catalog/compiler.rb:52:in `find'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/indirector/indirection.rb:201:in `find'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/application/apply.rb:214:in `block in main'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/context.rb:64:in `override'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet.rb:234:in `override'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/application/apply.rb:190:in `main'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/application/apply.rb:151:in `run_command'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/application.rb:371:in `block (2 levels) in run'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/application.rb:477:in `plugin_hook'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/application.rb:371:in `block in run'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/util.rb:479:in `exit_on_fail'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/application.rb:371:in `run'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/util/command_line.rb:137:in `run'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/share/ruby/vendor_ruby/puppet/util/command_line.rb:91:in `execute'
	# [ERROR 2016-11-19 09:28:04 verbose] /usr/bin/puppet:8:in `&lt;main&gt;'
