### PR TITLE
460 - allow enabling crl when server_ca => false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,6 +155,10 @@
 # $ca_port::                                Puppet CA port
 #                                           type:Optional[Integer[0, 65535]]
 #
+# $ca_crl_filepath::                        Path to CA CRL file, dynamically resolves based on
+#                                           $::server_ca status.
+#                                           type:Optional[String]
+#
 # $dns_alt_names::                          Use additional DNS names when generating a
 #                                           certificate.  Defaults to an empty Array.
 #                                           type:Array[String]
@@ -273,6 +277,15 @@
 #
 # $server_ca::                              Provide puppet CA
 #                                           type:Boolean
+#
+# $server_ca_crl_sync::                     Sync puppet CA crl file to compile masters, Puppet CA Must be the Puppetserver
+#                                           for the compile masters. Defaults to false.
+#                                           type:Boolean
+#
+# $server_crl_enable::                      Turn on crl checking. Defaults to true when server_ca is true. Otherwise
+#                                           Defaults to false. Note unless you are using an external CA. It is recommended
+#                                           to set this to true. See $server_ca_crl_sync to enable syncing from CA Puppet Master
+#                                           type:Optional[Boolean]
 #
 # $server_http::                            Should the puppet master listen on HTTP as well as HTTPS.
 #                                           Useful for load balancer or reverse proxy scenarios. Note that
@@ -675,6 +688,7 @@ class puppet (
   $configtimeout                          = $puppet::params::configtimeout,
   $ca_server                              = $puppet::params::ca_server,
   $ca_port                                = $puppet::params::ca_port,
+  $ca_crl_filepath                        = $puppet::params::ca_crl_filepath,
   $prerun_command                         = $puppet::params::prerun_command,
   $postrun_command                        = $puppet::params::postrun_command,
   $dns_alt_names                          = $puppet::params::dns_alt_names,
@@ -709,6 +723,8 @@ class puppet (
   $server_ip                              = $puppet::params::ip,
   $server_port                            = $puppet::params::port,
   $server_ca                              = $puppet::params::server_ca,
+  $server_ca_crl_sync                     = $puppet::params::server_ca_crl_sync,
+  $server_crl_enable                      = $puppet::params::server_crl_enable,
   $server_ca_auth_required                = $puppet::params::server_ca_auth_required,
   $server_ca_client_whitelist             = $puppet::params::server_ca_client_whitelist,
   $server_http                            = $puppet::params::server_http,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,8 @@ class puppet::params {
   $usecacheonfailure   = true
   $ca_server           = undef
   $ca_port             = undef
+  $ca_crl_filepath     = undef
+  $server_crl_enable   = undef
   $prerun_command      = undef
   $postrun_command     = undef
   $dns_alt_names       = []
@@ -227,6 +229,7 @@ class puppet::params {
   # Will this host be a puppetmaster?
   $server                     = false
   $server_ca                  = true
+  $server_ca_crl_sync         = false
   $server_reports             = 'foreman'
   $server_passenger           = true
   $server_service_fallback    = true

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -163,6 +163,17 @@ class puppet::server::config inherits puppet::config {
                   Exec['puppet_server_config-create_ssl_dir'],
                   ],
     }
+  } elsif $::puppet::server::ca_crl_sync {
+    # If not a ca AND sync the crl from the ca master
+    if defined('$::servername') {
+      file { $::puppet::server::ssl_ca_crl:
+        ensure  => file,
+        owner   => $::puppet::server::user,
+        group   => $::puppet::server::group,
+        mode    => '0644',
+        content => file($::settings::cacrl, $::settings::hostcrl, '/dev/null'),
+      }
+    }
   }
 
   if $::puppet::server::passenger and $::puppet::server::implementation == 'master' and $::puppet::server::ca {

--- a/templates/server/puppetserver/conf.d/webserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/webserver.conf.erb
@@ -10,8 +10,10 @@ webserver: {
     ssl-cert: <%= scope.lookupvar('puppet::server::ssl_cert') %>
     ssl-key: <%= scope.lookupvar('puppet::server::ssl_cert_key') %>
     ssl-ca-cert: <%= scope.lookupvar('puppet::server::ssl_ca_cert') %>
+<%- if scope.lookupvar('puppet::server::_crl_enable') -%>
+    ssl-crl-path: <%= scope.lookupvar('puppet::server::ssl_ca_crl') %>
+<%- end -%>
 <%- if scope.lookupvar('puppet::server::ca') -%>
     ssl-cert-chain: <%= scope.lookupvar('puppet::server::ssl_chain') %>
-    ssl-crl-path: <%= scope.lookupvar('puppet::server::ssl_ca_crl') %>
 <%- end -%>
 }


### PR DESCRIPTION
Change allows the CRL to be enabled when puppet_ca is disabled
additionally provided the ability to sync from the master of masters
the #{ssldir}/ca/ca_crl.pem contents to #{ssldir}/crl.pem. The one side
note is i chose to not notify the puppetserver service every time the
crl.pem file is updated. This could cause undesired downtime of the
compile masters. Reference #460 for additional information.