### PR TITLE
desupport FreeBSD 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -84,7 +84,6 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "9",
         "10"
       ]
     },


### PR DESCRIPTION
It will be EOLed at 2016-12-31 and there are no version based differences in this module, so this will reduce the test run time a little bit.