### PR TITLE
addressing use cases where $::domain fact is null

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,6 +41,9 @@ class puppet::config(
     puppet::config::main{'dns_alt_names': value => $dns_alt_names; }
   }
   if $use_srv_records {
+    unless $srv_domain {
+      fail('$::domain fact found to be undefined and $srv_domain is undefined')
+    }
     puppet::config::main{
       'use_srv_records': value => true;
       'srv_domain': value => $srv_domain;

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,17 @@ class puppet::params {
   $postrun_command     = undef
   $dns_alt_names       = []
   $use_srv_records     = false
-  $srv_domain          = $::domain
+
+  # On versions < 3.7.5 the defined function was optional as such strict variables cannot be used
+  # In some edge cases 'domain' fact may be not defined
+  if versioncmp($::puppetversion, '3.7.5') < 0 {
+    $srv_domain = $::domain
+  } elsif defined('$::domain') {
+    $srv_domain = $::domain
+  } else {
+    $srv_domain = undef
+  }
+
   # lint:ignore:puppet_url_without_modules
   $pluginsource        = 'puppet:///plugins'
   $pluginfactsource    = 'puppet:///pluginfacts'


### PR DESCRIPTION
Ref: #465 

Some times it is possible for the domain fact to be null
these changes address such an instance, sometimes...

On puppet version < 3.7.5 due to the absence of a defined function we
hope for the best and insist that strict variables is disabled.

Evaluating defined('$::domain') before assigning it to srv_domain
