### PR TITLE
fixes #17634 - set vardir, rundir and logdir explicit in puppet.conf

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -6,6 +6,21 @@ class puppet::server::config inherits puppet::config {
 
   if $::puppet::server::implementation == 'puppetserver' {
     contain 'puppet::server::puppetserver' # lint:ignore:relative_classname_inclusion (PUP-1597)
+    unless empty($::puppet::server::puppetserver_vardir) {
+      puppet::config::master {
+        'vardir': value => $::puppet::server::puppetserver_vardir;
+      }
+    }
+    unless empty($::puppet::server::puppetserver_rundir) {
+      puppet::config::master {
+        'rundir': value => $::puppet::server::puppetserver_rundir;
+      }
+    }
+    unless empty($::puppet::server::puppetserver_logdir) {
+      puppet::config::master {
+        'logdir': value => $::puppet::server::puppetserver_logdir;
+      }
+    }
   }
 
   # Mirror the relationship, as defined() is parse-order dependent
@@ -69,6 +84,7 @@ class puppet::server::config inherits puppet::config {
     'parser':             value => $::puppet::server::parser;
     'strict_variables':   value => $::puppet::server::strict_variables;
   }
+
   if $::puppet::server::ssl_dir_manage {
     puppet::config::master {
       'ssldir':           value => $::puppet::server::ssl_dir;

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -14,6 +14,8 @@ describe 'puppet::server::config' do
         rundir              = '/var/run/puppet'
         vardir              = '/var/lib/puppet'
         puppetserver_vardir = '/var/lib/puppet'
+        puppetserver_logdir = '/var/log/puppet'
+        puppetserver_rundir = '/var/run/puppet'
         ssldir              = '/var/lib/puppet/ssl'
         sharedir            = '/usr/share/puppet'
         etcdir              = '/etc/puppet'
@@ -28,6 +30,8 @@ describe 'puppet::server::config' do
         rundir              = '/var/run/puppetlabs'
         vardir              = '/opt/puppetlabs/puppet/cache'
         puppetserver_vardir = '/opt/puppetlabs/server/data/puppetserver'
+        puppetserver_logdir = '/var/log/puppetlabs/puppetserver'
+        puppetserver_rundir = '/var/run/puppetlabs/puppetserver'
         ssldir              = '/etc/puppetlabs/puppet/ssl'
         sharedir            = '/opt/puppetlabs/puppet'
         etcdir              = '/etc/puppetlabs/puppet'
@@ -44,6 +48,8 @@ describe 'puppet::server::config' do
         rundir              = '/var/run/puppet'
         vardir              = '/var/puppet'
         puppetserver_vardir = '/var/puppet/server/data/puppetserver'
+        puppetserver_logdir = '/var/log/puppetserver'
+        puppetserver_rundir = '/var/run/puppetserver'
         ssldir              = '/var/puppet/ssl'
         sharedir            = '/usr/local/share/puppet'
         etcdir              = '/usr/local/etc/puppet'
@@ -602,6 +608,21 @@ describe 'puppet::server::config' do
           it 'should not generate CA certificates' do
             should_not contain_exec('puppet_server_config-generate_ca_cert')
           end
+        end
+      end
+
+      describe 'with server_implementation => "puppetserver"', :if => (Puppet.version >= '4.0.0') do
+        let :pre_condition do
+          "class {'puppet':
+            server => true,
+            server_implementation => 'puppetserver'
+          }"
+        end
+
+        it 'should configure puppet.conf' do
+          should contain_puppet__config__master("vardir").with_value(puppetserver_vardir)
+          should contain_puppet__config__master("logdir").with_value(puppetserver_logdir)
+          should contain_puppet__config__master("rundir").with_value(puppetserver_rundir)
         end
       end
     end


### PR DESCRIPTION
set the vardir, logdir and rundir in puppet.conf, so values are equal to puppetserver/conf.d/puppetserver.conf
see: https://docs.puppet.com/puppetserver/2.7/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server

PS:
I have a really hard time testing this with foreman-installer. Help is much appreciated. 