### PR TITLE
Acceptance tests with beaker-rspec

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,3 +2,13 @@
 Rakefile:
   param_docs_pattern:
     - manifests/init.pp
+Gemfile:
+  extra:
+    - gem: 'beaker-rspec'
+      options:
+        groups:
+          - 'system_tests'
+    - gem: 'beaker-puppet_install_helper'
+      options:
+        groups:
+          - 'system_tests'

--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,7 @@ gem 'json', '~> 1.0', {"platforms"=>["ruby_19"], "groups"=>["test"]}
 gem 'json_pure', '~> 1.0', {"platforms"=>["ruby_19"], "groups"=>["test"]}
 gem 'metadata-json-lint'
 gem 'kafo_module_lint'
+gem 'beaker-rspec', {"groups"=>["system_tests"]}
+gem 'beaker-puppet_install_helper', {"groups"=>["system_tests"]}
 
 # vim:ft=ruby

--- a/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/spec/acceptance/nodesets/centos-6-x64.yml
@@ -1,0 +1,14 @@
+---
+HOSTS:
+  centos-6-x64:
+    roles:
+      - master
+    platform: centos-6-x86_64
+    box: centos/6
+    hypervisor: vagrant
+    vagrant_memsize: 3072
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml
+

--- a/spec/acceptance/nodesets/centos-6-x64_docker.yml
+++ b/spec/acceptance/nodesets/centos-6-x64_docker.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-6-x64-docker:
+    platform: centos-6-x86_64
+    hypervisor : docker
+    image: centos:6
+    # docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y crontabs tar wget'
+CONFIG:
+  type: aio

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,0 +1,14 @@
+---
+HOSTS:
+  centos-7-x64:
+    roles:
+      - master
+    platform: centos-7-x86_64
+    box: centos/7
+    hypervisor: vagrant
+    vagrant_memsize: 3072
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml
+

--- a/spec/acceptance/nodesets/centos-7-x64_docker.yml
+++ b/spec/acceptance/nodesets/centos-7-x64_docker.yml
@@ -1,0 +1,15 @@
+HOSTS:
+  centos-7-x64-docker:
+    platform: centos-7-x86_64
+    hypervisor : docker
+    image: centos:7
+    # docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y -q crontabs tar wget which iproute'
+      # crontab: required for  puppet cron resources
+      # iproute: required for beaker/serverspec port tests which require the 
+      #   ss utility
+      # which: required for puppetserver rpm pre/post scripts
+CONFIG:
+  type: aio

--- a/spec/acceptance/puppetserver_latest_spec.rb
+++ b/spec/acceptance/puppetserver_latest_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install puppetserver (latest):' do
+  before(:context) do
+    if check_for_package(default, 'puppetserver')
+      on(
+        default,
+        'rpm --erase puppetserver && ' \
+        'rm -rf /etc/sysconfig/puppetserver /etc/puppetlabs/puppetserver && ' \
+        'find /etc/puppetlabs/puppet/ssl/ -type f -delete'
+      )
+    end
+
+    # puppetserver won't start with lower than 2GB memory
+    memoryfree_mb = fact('memoryfree_mb').to_i
+    raise 'At least 2048MB free memory required' if memoryfree_mb < 256
+  end
+
+  let(:pp) do
+    <<-EOS
+    class { '::puppet':
+      server                => true,
+      server_foreman        => false,
+      server_reports        => 'store',
+      server_external_nodes => '',
+      # only for install test - don't think to use this in production!
+      # https://docs.puppet.com/puppetserver/latest/tuning_guide.html
+      server_jvm_max_heap_size => '256m',
+      server_jvm_min_heap_size => '256m',
+    }
+    EOS
+  end
+
+  it_behaves_like 'a idempotent resource'
+end

--- a/spec/acceptance/puppetserver_upgrade_2_6_0_to_2_7_2_spec.rb
+++ b/spec/acceptance/puppetserver_upgrade_2_6_0_to_2_7_2_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: 2.6.0 to 2.7.2 upgrade:' do
+  before(:context) do
+    if check_for_package(default, 'puppetserver')
+      on(
+        default,
+        'rpm --erase puppetserver && ' \
+        'rm -rf /etc/sysconfig/puppetserver /etc/puppetlabs/puppetserver && ' \
+        'find /etc/puppetlabs/puppet/ssl/ -type f -delete'
+      )
+    end
+
+    # puppetserver won't start with lower than 2GB memory
+    memoryfree_mb = fact('memoryfree_mb').to_i
+    raise 'At least 2048MB free memory required' if memoryfree_mb < 256
+  end
+
+  context 'install 2.6.0' do
+    let(:pp) do
+      <<-EOS
+      class { '::puppet':
+        server                => true,
+        server_foreman        => false,
+        server_reports        => 'store',
+        server_external_nodes => '',
+        server_version        => '2.6.0',
+        # only for install test - don't think to use this in production!
+        # https://docs.puppet.com/puppetserver/latest/tuning_guide.html
+        server_jvm_max_heap_size => '256m',
+        server_jvm_min_heap_size => '256m',
+      }
+      EOS
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    describe command('puppetserver --version') do
+      its(:stdout) { is_expected.to match("puppetserver version: 2.6.0\n") }
+    end
+
+    describe service('puppetserver') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe port('8140') do
+      it { is_expected.to be_listening }
+    end
+  end
+
+  context 'upgrade to 2.7.2' do
+    let(:pp) do
+      <<-EOS
+      class { '::puppet':
+        server                => true,
+        server_foreman        => false,
+        server_reports        => 'store',
+        server_external_nodes => '',
+        server_version        => '2.7.2',
+        # only for install test - don't think to use this in production!
+        # https://docs.puppet.com/puppetserver/latest/tuning_guide.html
+        server_jvm_max_heap_size => '256m',
+        server_jvm_min_heap_size => '256m',
+      }
+      EOS
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    describe command('puppetserver --version') do
+      its(:stdout) { is_expected.to match("puppetserver version: 2.7.2\n") }
+    end
+
+    describe service('puppetserver') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe port('8140') do
+      it { is_expected.to be_listening }
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,44 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(source: proj_root, module_name: 'puppet')
+    hosts.each do |host|
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppetlabs-concat'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppet-extlib'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppetlabs-apache'), acceptable_exit_codes: [0, 1]
+
+      if fact_on(host, 'osfamily') == 'RedHat'
+        # don't delete downloaded rpm for use with BEAKER_provision=no + 
+        # BEAKER_destroy=no
+        on host, 'sed -i "s/keepcache=.*/keepcache=1/" /etc/yum.conf'
+        # refresh check if cache needs refresh on next yum command
+        on host, 'yum clean expire-cache'
+      end
+    end
+  end
+end
+
+shared_examples 'a idempotent resource' do
+  it 'applies with no errors' do
+    apply_manifest(pp, catch_failures: true)
+  end
+
+  it 'applies a second time without changes' do
+    apply_manifest(pp, catch_changes: true)
+  end
+end
+


### PR DESCRIPTION
I've written simple tests with [beaker-rspec](https://github.com/puppetlabs/beaker-rspec) to play with the module. 

Is it of any interest for you?

Run tests one by one with:
 
 ```
PUPPET_INSTALL_TYPE=agent \
  BEAKER_set=centos-7-x64_docker \
  bundle exec rspec spec/acceptance/puppetserver_upgrade_2_6_0_to_2_7_2_spec.rb

# or the other test with EL6
PUPPET_INSTALL_TYPE=agent \
  BEAKER_set=centos-6-x64_docker \
  bundle exec rspec spec/acceptance/puppetserver_latest_spec.rb
 ```

Further  `BEAKER_*` env params:

* `BEAKER_destroy=no`: don't delete docker process after finishing the test. Can afterwards be inspected with `docker exec -i $ID /bin/bash`
* `BEAKER_provision=no`: don't re-initialize - works for me with vagrant+virtualbox but not with docker
* `BEAKER_debug=yes`: verbose output of whats going on