### PR TITLE
Add optional ssl_chain_filepath option for puppet::server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -591,6 +591,11 @@
 #                                           Defaults to [ 'TLSv1.2' ]
 #                                           type:Array[String]
 #
+# $server_ssl_chain_filepath::              Path to certificate chain for puppetserver
+#                                           Only used when $ca is true
+#                                           Defaults to "${ssl_dir}/ca/ca_crt.pem"
+#                                           type:Optional[Stdlib::Absolutepath]
+#
 # $server_cipher_suites::                   List of SSL ciphers to use in negotiation
 #                                           Defaults to [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA',
 #                                           'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA', ]
@@ -777,6 +782,7 @@ class puppet (
   $server_ssl_dir                         = $puppet::params::server_ssl_dir,
   $server_ssl_dir_manage                  = $puppet::params::server_ssl_dir_manage,
   $server_ssl_protocols                   = $puppet::params::server_ssl_protocols,
+  $server_ssl_chain_filepath              = $puppet::params::server_ssl_chain_filepath,
   $server_package                         = $puppet::params::server_package,
   $server_version                         = $puppet::params::server_version,
   $server_certname                        = $puppet::params::server_certname,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -427,6 +427,7 @@ class puppet::params {
   $server_ca_client_whitelist             = [ 'localhost', $lower_fqdn ]
   $server_cipher_suites                   = [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA', 'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA' ]
   $server_ssl_protocols                   = [ 'TLSv1.2' ]
+  $server_ssl_chain_filepath              = "${server_ssl_dir}/ca/ca_crt.pem"
   $server_check_for_updates               = true
   $server_environment_class_cache_enabled = false
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -348,6 +348,10 @@
 #                              Defaults to [ 'TLSv1.2' ]
 #                              type:array
 #
+# $ssl_chain_filepath::        Path to certificate chain for puppetserver
+#                              Defaults to "${ssl_dir}/ca/ca_crt.pem"
+#                              type:Stdlib::Absolutepath
+#
 # $cipher_suites::             List of SSL ciphers to use in negotiation
 #                              Defaults to [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA',
 #                              'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA', ]
@@ -448,6 +452,7 @@ class puppet::server(
   $ssl_dir                         = $::puppet::server_ssl_dir,
   $ssl_dir_manage                  = $::puppet::server_ssl_dir_manage,
   $ssl_protocols                   = $::puppet::server_ssl_protocols,
+  $ssl_chain_filepath              = $::puppet::server_ssl_chain_filepath,
   $package                         = $::puppet::server_package,
   $version                         = $::puppet::server_version,
   $certname                        = $::puppet::server_certname,
@@ -569,7 +574,7 @@ class puppet::server(
   if $ca {
     $ssl_ca_cert = "${ssl_dir}/ca/ca_crt.pem"
     $ssl_ca_crl  = "${ssl_dir}/ca/ca_crl.pem"
-    $ssl_chain   = "${ssl_dir}/ca/ca_crt.pem"
+    $ssl_chain   = $ssl_chain_filepath
     $_crl_enable = pick($crl_enable, true)
   } else {
     $ssl_ca_cert = "${ssl_dir}/certs/ca.pem"

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -763,6 +763,23 @@ describe 'puppet::server::config' do
           end
         end
       end
+
+      describe 'with ssl_chain_filepath overwritten' do
+	let :pre_condition do
+          "class {'puppet':
+              server                      => true,
+              server_implementation       => 'puppetserver',
+              server_ca                   => true,
+              server_puppetserver_dir     => '/etc/custom/puppetserver',
+              server_jruby_gem_home       => '/opt/puppetlabs/server/data/puppetserver/jruby-gems',
+              server_ssl_chain_filepath   => '/etc/example/certchain.pem',
+           }"
+        end
+        it 'should use the server_ssl_chain_filepath file' do
+           should contain_file('/etc/custom/puppetserver/conf.d/webserver.conf').
+             with_content(/ssl-cert-chain: \/etc\/example\/certchain.pem/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Motivation for the change is to let the user specificity the value of `ssl-cert-chain` in the `webserver.conf` file for puppetserver.
Previously the module hard coded the value of `ssl-cert-chain` to be `${ssl_dir}/ca/ca_crt.pem`.