### PR TITLE
Allow disabling crl when server_ca => true

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -570,7 +570,7 @@ class puppet::server(
     $ssl_ca_cert = "${ssl_dir}/ca/ca_crt.pem"
     $ssl_ca_crl  = "${ssl_dir}/ca/ca_crl.pem"
     $ssl_chain   = "${ssl_dir}/ca/ca_crt.pem"
-    $_crl_enable = true
+    $_crl_enable = pick($crl_enable, true)
   } else {
     $ssl_ca_cert = "${ssl_dir}/certs/ca.pem"
     $ssl_ca_crl  = pick($ca_crl_filepath, "${ssl_dir}/crl.pem")


### PR DESCRIPTION
This allows the CRL checking to be disabled when server_ca is enabled.
Useful for users who have an external CA configured.