### PR TITLE
Option disable ssl for reporting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -483,6 +483,9 @@
 # $server_foreman_ssl_key::                 Key for authenticating against Foreman server
 #                                           type:Optional[Stdlib::Absolutepath]
 #
+# $server_foreman_enable_ssl::              Should puppet use foreman ssl to send reports
+#                                           type:Boolean
+#
 # $server_puppet_basedir::                  Where is the puppet code base located
 #                                           type:Optional[Stdlib::Absolutepath]
 #
@@ -793,6 +796,7 @@ class puppet (
   $server_foreman_ssl_cert                = $puppet::params::server_foreman_ssl_cert,
   $server_foreman_ssl_key                 = $puppet::params::server_foreman_ssl_key,
   $server_foreman_facts                   = $puppet::params::server_foreman_facts,
+  $server_foreman_enable_ssl              = $puppet::params::server_foreman_enable_ssl,
   $server_puppet_basedir                  = $puppet::params::server_puppet_basedir,
   $server_puppetdb_host                   = $puppet::params::server_puppetdb_host,
   $server_puppetdb_port                   = $puppet::params::server_puppetdb_port,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -390,10 +390,11 @@ class puppet::params {
     true  => '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet',
     false => undef,
   }
-  $server_foreman_url      = "https://${lower_fqdn}"
-  $server_foreman_ssl_ca   = undef
-  $server_foreman_ssl_cert = undef
-  $server_foreman_ssl_key  = undef
+  $server_foreman_url        = "https://${lower_fqdn}"
+  $server_foreman_ssl_ca     = undef
+  $server_foreman_ssl_cert   = undef
+  $server_foreman_ssl_key    = undef
+  $server_foreman_enable_ssl = true
 
   # Which Parser do we want to use? https://docs.puppetlabs.com/references/latest/configuration.html#parser
   $server_parser = 'current'

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -277,11 +277,11 @@ class puppet::server::config inherits puppet::config {
   if $::puppet::server::foreman {
     # check if ssl should be enabled
     if $::foreman::server_foreman_enable_ssl {
-      $foreman_ssl_ca   => pick($::puppet::server::foreman_ssl_ca,
+      $foreman_ssl_ca   = pick($::puppet::server::foreman_ssl_ca,
                                 $::puppet::server::ssl_ca_cert)
-      $foreman_ssl_cert => pick($::puppet::server::foreman_ssl_cert,
+      $foreman_ssl_cert = pick($::puppet::server::foreman_ssl_cert,
                                 $::puppet::server::ssl_cert)
-      $foreman_ssl_key  => pick($::puppet::server::foreman_ssl_key,
+      $foreman_ssl_key  = pick($::puppet::server::foreman_ssl_key,
                                 $::puppet::server::ssl_cert_key)
     }else{
       $foreman_ssl_ca   = ''

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -275,6 +275,19 @@ class puppet::server::config inherits puppet::config {
 
   ## Foreman
   if $::puppet::server::foreman {
+    # check if ssl should be enabled
+    if $::foreman::server_foreman_enable_ssl {
+      $foreman_ssl_ca   => pick($::puppet::server::foreman_ssl_ca,
+                                $::puppet::server::ssl_ca_cert)
+      $foreman_ssl_cert => pick($::puppet::server::foreman_ssl_cert,
+                                $::puppet::server::ssl_cert)
+      $foreman_ssl_key  => pick($::puppet::server::foreman_ssl_key,
+                                $::puppet::server::ssl_cert_key)
+    }else{
+      $foreman_ssl_ca   = ''
+      $foreman_ssl_cert = ''
+      $foreman_ssl_key  = ''
+    }
     # Include foreman components for the puppetmaster
     # ENC script, reporting script etc.
     anchor { 'puppet::server::config_start': } ->
@@ -287,9 +300,9 @@ class puppet::server::config inherits puppet::config {
       enc_api        => $::puppet::server::enc_api,
       report_api     => $::puppet::server::report_api,
       timeout        => $::puppet::server::request_timeout,
-      ssl_ca         => pick($::puppet::server::foreman_ssl_ca, $::puppet::server::ssl_ca_cert),
-      ssl_cert       => pick($::puppet::server::foreman_ssl_cert, $::puppet::server::ssl_cert),
-      ssl_key        => pick($::puppet::server::foreman_ssl_key, $::puppet::server::ssl_cert_key),
+      ssl_ca         => $foreman_ssl_ca,
+      ssl_cert       => $foreman_ssl_cert,
+      ssl_key        => $foreman_ssl_key,
     } ~> anchor { 'puppet::server::config_end': }
   }
 


### PR DESCRIPTION
Its unnecessary in some environments to utilise SSL certificates when sending reports from the puppet server to the foreman server (not on the same server).   In cases where there are multiple puppet masters with different CA's, its necessary to disable ssl when sending a report.  

This patch provides an additional option called server_foreman_enable_ssl which is set to true by default which has the same behaviour as before.  When set to false, the following parameters are set to empty strings in foreman.yaml in the puppet configuration directory.

```
:ssl_ca: ""
:ssl_cert: ""
:ssl_key: ""
```