### PR TITLE
Add toggle to disable ssl key handling

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -556,6 +556,11 @@
 #                                           disable in case CA is delegated to a separate instance
 #                                           type:Boolean
 #
+# $server_ssl_key_manage::                  Toggle if "private_keys/${::puppet::server::certname}.pem"
+#                                           should be created with default user and group. This is used in
+#                                           the default Forman setup to reuse the key for TLS communication.
+#                                           type:Boolean
+#
 # $server_puppetserver_vardir::             The path of the puppetserver var dir
 #                                           type:Stdlib::Absolutepath
 #
@@ -776,6 +781,7 @@ class puppet (
   $server_ruby_load_paths                 = $puppet::params::server_ruby_load_paths,
   $server_ssl_dir                         = $puppet::params::server_ssl_dir,
   $server_ssl_dir_manage                  = $puppet::params::server_ssl_dir_manage,
+  $server_ssl_key_manage                  = $puppet::params::server_ssl_key_manage,
   $server_ssl_protocols                   = $puppet::params::server_ssl_protocols,
   $server_package                         = $puppet::params::server_package,
   $server_version                         = $puppet::params::server_version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -414,6 +414,7 @@ class puppet::params {
   $server_jvm_extra_args    = '-XX:MaxPermSize=256m'
 
   $server_ssl_dir_manage                  = true
+  $server_ssl_key_manage                  = true
   $server_default_manifest                = false
   $server_default_manifest_path           = '/etc/puppet/manifests/default_manifest.pp'
   $server_default_manifest_content        = '' # lint:ignore:empty_string_assignment

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,7 +53,7 @@
 # $ca_crl_sync::               Sync the puppet ca crl to compile masters. Requires compile masters to
 #                              be agents of the CA master (MOM) defaults to false
 #                              type:boolean
-# 
+#
 # $crl_enable::                Enable CRL processing, defaults to true when $ca is true else defaults
 #                              to false
 #                              type:boolean
@@ -319,6 +319,11 @@
 #                              disable in case CA is delegated to a separate instance
 #                              type:boolean
 #
+# $ssl_key_manage::            Toggle if "private_keys/${::puppet::server::certname}.pem"
+#                              should be created with default user and group. This is used in
+#                              the default Forman setup to reuse the key for TLS communication.
+#                              type:Boolean
+#
 # $puppetserver_vardir::       The path of the puppetserver var dir
 #                              type:string
 #
@@ -447,6 +452,7 @@ class puppet::server(
   $ruby_load_paths                 = $::puppet::server_ruby_load_paths,
   $ssl_dir                         = $::puppet::server_ssl_dir,
   $ssl_dir_manage                  = $::puppet::server_ssl_dir_manage,
+  $ssl_key_manage                  = $::puppet::server_ssl_key_manage,
   $ssl_protocols                   = $::puppet::server_ssl_protocols,
   $package                         = $::puppet::server_package,
   $version                         = $::puppet::server_version,
@@ -494,6 +500,7 @@ class puppet::server(
   validate_bool($puppetdb_swf)
   validate_bool($default_manifest)
   validate_bool($ssl_dir_manage)
+  validate_bool($ssl_key_manage)
   validate_bool($passenger_pre_start)
   validate_integer($passenger_min_instances)
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -139,10 +139,12 @@ class puppet::server::config inherits puppet::config {
     require => Exec['puppet_server_config-create_ssl_dir'],
   }
 
-  file { "${::puppet::server::ssl_dir}/private_keys/${::puppet::server::certname}.pem":
-    owner => $::puppet::server::user,
-    group => $::puppet::server::group,
-    mode  => '0640',
+  if $puppet::server::ssl_key_manage {
+    file { "${::puppet::server::ssl_dir}/private_keys/${::puppet::server::certname}.pem":
+      owner => $::puppet::server::user,
+      group => $::puppet::server::group,
+      mode  => '0640',
+    }
   }
 
   # If the ssl dir is not the default dir, it needs to be created before running

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -630,6 +630,21 @@ describe 'puppet::server::config' do
         end
       end
 
+      describe 'with ssl key management disabled for server' do
+        let :pre_condition do
+          "class {'puppet':
+            server                => true,
+            server_certname       => 'servercert',
+            server_ssl_key_manage => false,
+            server_ssl_dir        => '/etc/custom/puppetlabs/puppet/ssl'
+          }"
+        end
+
+        it 'should not contain a default ssl key definition' do
+          should_not contain_file('/etc/custom/puppetlabs/puppet/ssl/private_keys/servercert.pem')
+        end
+      end
+
       describe 'with nondefault CA settings' do
         context 'with server_ca => false' do
           let :pre_condition do


### PR DESCRIPTION
fixes #479 
To enable external certifacte and key handling add a new boolean to disable the standard private_key