### PR TITLE
add support for Parallels PSBM

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -357,14 +357,17 @@ class puppet::params {
       }
     }
     'Redhat' : {
+      # PSBM is a CentOS 6 based distribution
+      # it reports its $osreleasemajor as 2, not 6.
+      # thats why we're matching for '2' in both parts
       $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1') # workaround for the possibly missing operatingsystemmajrelease
       $agent_restart_command = $osreleasemajor ? {
-        /^(5|6)$/ => "/sbin/service ${service_name} reload",
+        /^(2|5|6)$/ => "/sbin/service ${service_name} reload",
         '7'       => "/usr/bin/systemctl reload-or-restart ${service_name}",
         default   => undef,
       }
       $unavailable_runmodes = $osreleasemajor ? {
-        /^(5|6)$/ => ['systemd.timer'],
+        /^(2|5|6)$/ => ['systemd.timer'],
         default   => [],
       }
     }


### PR DESCRIPTION
PSBM is a propritary CentOS 6 from Parallels. It reports osreleasemajor
as 2, not 6.