### PR TITLE
Fixes #19019 - Generate Puppet cert with --allow-dns-alt-names

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -159,7 +159,7 @@ class puppet::server::config inherits puppet::config {
   if $::puppet::server::ca {
     exec {'puppet_server_config-generate_ca_cert':
       creates => $::puppet::server::ssl_cert,
-      command => "${::puppet::puppetca_cmd} --generate ${::puppet::server::certname}",
+      command => "${::puppet::puppetca_cmd} --generate ${::puppet::server::certname} --allow-dns-alt-names",
       umask   => '0022',
       require => [Concat["${::puppet::server::dir}/puppet.conf"],
                   Exec['puppet_server_config-create_ssl_dir'],

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -89,7 +89,7 @@ describe 'puppet::server::config' do
 
           should contain_exec('puppet_server_config-generate_ca_cert').with({
             :creates => "#{ssldir}/certs/puppetmaster.example.com.pem",
-            :command => "#{puppetcacmd} --generate puppetmaster.example.com",
+            :command => "#{puppetcacmd} --generate puppetmaster.example.com --allow-dns-alt-names",
             :umask   => '0022',
             :require => ["Concat[#{conf_file}]", "Exec[puppet_server_config-create_ssl_dir]"],
           })


### PR DESCRIPTION
With `--allow-dns-alt-names` Puppet will use the `dns_alt_names` config option in `puppet.conf` when generating the certificate. 

To test run the installer with `--puppet-dns-alt-names my-other-hostname.example.com,another-name.example.com`, you should then be able to configure an agent to use `my-other-hostname.example.com` & `another-name.example.com` as well as the servers hostname.