### PR TITLE
dedicated setting for allow-header-cert-info

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -643,7 +643,7 @@
 #
 # $server_allow_header_cert_info::          Enable client authentication over HTTP Headers
 #                                           Defaults to false, and can also be activated with the $server_http setting
-#                                           type:boolean
+#                                           type:Boolean
 # === Usage:
 #
 # * Simple usage:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -641,6 +641,9 @@
 #                                           Defaults to false
 #                                           type:Boolean
 #
+# $server_allow_header_cert_info::          Enable client authentication over HTTP Headers
+#                                           Defaults to false, and can also be activated with the $server_http setting
+#                                           type:boolean
 # === Usage:
 #
 # * Simple usage:
@@ -822,6 +825,7 @@ class puppet (
   $server_use_legacy_auth_conf            = $puppet::params::server_use_legacy_auth_conf,
   $server_check_for_updates               = $puppet::params::server_check_for_updates,
   $server_environment_class_cache_enabled = $puppet::params::server_environment_class_cache_enabled,
+  $server_allow_header_cert_info          = $puppet::params::server_allow_header_cert_info,
 ) inherits puppet::params {
 
   validate_bool($listen)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -448,6 +448,7 @@ class puppet::params {
   $server_ssl_chain_filepath              = "${server_ssl_dir}/ca/ca_crt.pem"
   $server_check_for_updates               = true
   $server_environment_class_cache_enabled = false
+  $server_allow_header_cert_info          = false
 
   # Puppetserver >= 2.2 Which auth.conf shall we use?
   $server_use_legacy_auth_conf     = false

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -388,6 +388,9 @@
 #                              Defaults to false (the puppetserver will use its own conf.d/auth.conf)
 #                              type:boolean
 #
+# $allow_header_cert_info::    Allow client authentication over HTTP Headers
+#                              Defaults to false, and can also be activated with the $http setting
+#                              type:boolean
 
 
 class puppet::server(
@@ -492,6 +495,7 @@ class puppet::server(
   $use_legacy_auth_conf            = $::puppet::server_use_legacy_auth_conf,
   $check_for_updates               = $::puppet::server_check_for_updates,
   $environment_class_cache_enabled = $::puppet::server_environment_class_cache_enabled,
+  $allow_header_cert_info          = $::puppet::server_allow_header_cert_info,
 ) {
 
   validate_bool($ca)
@@ -568,6 +572,7 @@ class puppet::server(
     validate_bool($use_legacy_auth_conf)
     validate_re($puppetserver_version, '^[\d]\.[\d]+\.[\d]+$')
     validate_bool($environment_class_cache_enabled)
+    validate_bool($allow_header_cert_info)
   } else {
     if $ip != $puppet::params::ip {
       notify {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -390,7 +390,7 @@
 #
 # $allow_header_cert_info::    Allow client authentication over HTTP Headers
 #                              Defaults to false, and can also be activated with the $http setting
-#                              type:boolean
+#                              type:Boolean
 
 
 class puppet::server(

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -624,6 +624,23 @@ describe 'puppet::server::puppetserver' do
         }
       end
 
+      describe 'with server_allow_header_cert_info parameter set to true for the puppet class' do
+        let(:params) do
+          default_params.merge({
+            :server_puppetserver_dir => '/etc/custom/puppetserver',
+           })
+        end
+
+        let :pre_condition do
+          "class {'puppet': server_allow_header_cert_info => true, server_implementation => 'puppetserver'}"
+        end
+
+        it { should contain_file('/etc/custom/puppetserver/conf.d/auth.conf').
+            with_content(/allow-header-cert-info: true/).
+            with({})
+        }
+      end
+
       describe 'with server_http_allow parameter set for the puppet class' do
         let(:params) do
           default_params.merge({

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -1,6 +1,6 @@
 authorization: {
     version: 1
-    allow-header-cert-info: <%= scope.lookupvar('puppet::server::http') %>
+    allow-header-cert-info: <%= scope.lookupvar('puppet::server::http') || scope.lookupvar('puppet::server::allow_header_cert_info') %>
     rules: [
         {
             # Allow nodes to retrieve their own catalog


### PR DESCRIPTION
add a dedicated setting to enable allow-header-cert-info without http being active

- i just want to enable allow-header-cert-info, but not the http server, so there should be a setting with only activates the header support.