### PR TITLE
Add Puppet 3 client compatibility under rack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     * Add support for Parallels PSBM
 * Other changes and fixes:
     * Lower JVM heap size when low memory is detected
+    * Add Puppet 3 client compatibility under rack
 
 ## 7.0.2
 * Other changes and fixes:

--- a/spec/classes/puppet_server_rack_spec.rb
+++ b/spec/classes/puppet_server_rack_spec.rb
@@ -56,7 +56,7 @@ describe 'puppet::server::rack' do
         end
 
         it 'should manage config.ru contents' do
-          verify_exact_contents(catalogue, '/etc/puppet/rack/config.ru', [
+          verify_contents(catalogue, '/etc/puppet/rack/config.ru', [
             '$0 = "master"',
             'ARGV << "--rack"',
             'ARGV << "--confdir" << "/etc/puppet"',

--- a/templates/server/config.ru.erb
+++ b/templates/server/config.ru.erb
@@ -22,6 +22,81 @@ ARGV << "--vardir"  << "<%= @vardir %>"
 ARGV << "<%= server_rack_argument %>"
 <% end -%>
 
+<% if @puppetversion.to_f >= 4.0 -%>
+# always_cache_features is a performance improvement and safe for a master to
+# apply. This is intended to allow agents to recognize new features that may be
+# delivered during catalog compilation.
+ARGV << "--always_cache_features"
+
+# Rack middleware for Puppet 3 compatibility
+# See Debian bug #832536
+class Puppet3Compat
+  attr_reader :master
+  @@puppet4_endpoints = ['puppet', 'puppet-ca']
+  @@v1_res_endpoints = ['catalog', 'file_bucket_file', 'file_content',
+                        'file_metadata', 'file_metadatas', 'report',
+                        'facts', 'node', 'resource_type', 'resource_types',
+                        'status']
+  @@v1_ca_endpoints = ['certificate', 'certificate_request',
+                       'certificate_status', 'certificate_statuses',
+                       'certificate_revocation_list']
+  @@v2_endpoints = ['environments']
+
+  def initialize(app)
+    @master = app
+  end
+
+  def call(env)
+    components = env["PATH_INFO"].to_s.split("/")
+
+    components.shift if components.first.empty?
+
+    if components.length < 2
+      return master.call(env)
+    end
+
+    environment = components.shift
+    @api = components.first
+
+    # Short-circuit Puppet 4 requests
+    if @@puppet4_endpoints.include?(environment)
+      return master.call(env)
+    end
+
+    @req = Rack::Request.new(env)
+
+    # Rewrite Puppet 3 requests
+    if @@v1_ca_endpoints.include?(@api)
+      @req.path_info = "/puppet-ca/v1/#{components.join("/")}"
+    elsif @@v1_res_endpoints.include?(@api) || @@v2_endpoints.include?(@api)
+      @req.path_info = "/puppet/v3/#{components.join("/")}"
+    end
+
+    if environment != "v2.0"
+      @req.update_param("environment", environment)
+
+      # Re-create the query string
+      env['QUERY_STRING'] = Rack::Utils.build_query(@req.params)
+    end
+
+    if @api =~ /^file_(content|bucket_file)/ && @req.get?
+      env["HTTP_ACCEPT"] = "binary"
+    elsif @api == "file_bucket_file" && (@req.post? || @req.put?)
+      env["CONTENT_TYPE"] = "application/octet-stream"
+    end
+
+    master.call(env).tap do |res|
+      if @api =~ /^file_(content|bucket_file)/ && @req.get?
+        # Always respond with text/plain to Puppet 3 clients.
+        res[1]["Content-Type"] = "text/plain"
+      end
+    end
+  end
+end
+
+use Puppet3Compat
+
+<% end -%>
 # NOTE: it's unfortunate that we have to use the "CommandLine" class
 #  here to launch the app, but it contains some initialization logic
 #  (such as triggering the parsing of the config file) that is very


### PR DESCRIPTION
Add a Rack middleware re-implementing the v1 and v2 API calls, as
per[1]. This should restore compatibility with Puppet 3 clients when
run under any rack-enabled server (including Passenger).

Closes: #832536

[1] https://github.com/puppetlabs/puppetserver/blob/puppet-server-2.6.0/src/clj/puppetlabs/services/legacy_routes/legacy_routes_core.clj

(Ported from https://anonscm.debian.org/cgit/pkg-puppet/puppet.git/commit/?id=1fb4e3e95b36b2c060320914452b48c29ffa4bde)