### PR TITLE
Move existing Puppet 4 data types to class parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,7 @@ class puppet::config(
   if $ca_server and !empty($ca_server) {
     puppet::config::main{'ca_server': value => $ca_server; }
   }
-  if $ca_port and !empty($ca_port) {
+  if $ca_port {
     puppet::config::main{'ca_port': value => $ca_port; }
   }
   if $dns_alt_names and !empty($dns_alt_names) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,57 +8,42 @@
 #                                           install. The version should be the exact
 #                                           match for your distro.
 #                                           You can also use certain values like 'latest'.
-#                                           type:String
 #
 # $user::                                   Override the name of the puppet user.
-#                                           type:String
 #
 # $group::                                  Override the name of the puppet group.
-#                                           type:String
 #
 # $dir::                                    Override the puppet directory.
-#                                           type:Stdlib::Absolutepath
 #
 # $codedir::                                Override the puppet code directory.
-#                                           type:Stdlib::Absolutepath
 #
 # $vardir::                                 Override the puppet var directory.
-#                                           type:Stdlib::Absolutepath
 #
 # $logdir::                                 Override the log directory.
-#                                           type:Stdlib::Absolutepath
 #
 # $rundir::                                 Override the PID directory.
-#                                           type:Stdlib::Absolutepath
 #
 # $ssldir::                                 Override where SSL certificates are kept.
-#                                           type:Stdlib::Absolutepath
 #
 # $sharedir::                               Override the system data directory.
-#                                           type:Stdlib::Absolutepath
 #
 # $manage_packages::                        Should this module install packages or not.
 #                                           Can also install only server packages with value
 #                                           of 'server' or only agent packages with 'agent'.
-#                                           type:Variant[Boolean, Enum['server', 'agent']]
 #
 # $package_provider::                       The provider used to install the agent.
 #                                           Defaults to chocolatey on Windows
 #                                           Defaults to undef elsewhere
-#                                           type:Optional[String]
 #
 # $package_source::                         The location of the file to be used by the
 #                                           agent's package resource.
 #                                           Defaults to undef. If 'windows' or 'msi' are
 #                                           used as the provider then this setting is
 #                                           required.
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $port::                                   Override the port of the master we connect to.
-#                                           type:Integer[0, 65535]
 #
 # $listen::                                 Should the puppet agent listen for connections.
-#                                           type:Boolean
 #
 # $listen_to::                              An array of servers allowed to initiate a puppet run.
 #                                           If $listen = true one of three things will happen:
@@ -69,25 +54,20 @@
 #                                           allowed.
 #                                           3) if $puppetmaster is not defined or empty,
 #                                           $fqdn will be used.
-#                                           type:Array[String]
 #
 # $pluginsync::                             Enable pluginsync.
-#                                           type:Boolean
 #
 # $splay::                                  Switch to enable a random amount of time
 #                                           to sleep before each run.
-#                                           type:Boolean
 #
 # $splaylimit::                             The maximum time to delay before runs.
 #                                           Defaults to being the same as the run interval.
 #                                           This setting can be a time interval in seconds
 #                                           (30 or 30s), minutes (30m), hours (6h), days (2d),
 #                                           or years (5y).
-#                                           type:Pattern[/^\d+[smhdy]?$/]
 #
 # $runinterval::                            Set up the interval (in seconds) to run
 #                                           the puppet agent.
-#                                           type:Integer[0]
 #
 # $autosign::                               If set to a boolean, autosign is enabled or disabled
 #                                           for all incoming requests. Otherwise this has to be
@@ -95,15 +75,12 @@
 #                                           an autosign script. If this is set to a script, make
 #                                           sure that script considers the content of autosign.conf
 #                                           as otherwise Foreman functionality might be broken.
-#                                           type:Variant[Boolean, Stdlib::Absolutepath]
 #
 # $autosign_entries::                       A list of certnames or domain name globs
 #                                           whose certificate requests will automatically be signed.
 #                                           Defaults to an empty Array.
-#                                           type:Array[String]
 #
 # $autosign_mode::                          mode of the autosign file/script
-#                                           type:Pattern[/^[0-9]{4}$/]
 #
 # $autosign_content::                       If set, write the autosign file content
 #                                           using the value of this parameter.
@@ -111,14 +88,11 @@
 #                                           For example, could be a string, or
 #                                           file('another_module/autosign.sh') or
 #                                           template('another_module/autosign.sh.erb')
-#                                           type:Optional[String]
 #
 # $usecacheonfailure::                      Switch to enable use of cached catalog on
 #                                           failure of run.
-#                                           type:Boolean
 #
 # $runmode::                                Select the mode to setup the puppet agent.
-#                                           type:Enum['cron', 'service', 'systemd.timer', 'none']
 #
 # $unavailable_runmodes::                   Runmodes that are not available for the
 #                                           current system. This module will not try
@@ -126,186 +100,136 @@
 #                                           on Linux, ['cron', 'systemd.timer'] on
 #                                           Windows and ['systemd.timer'] on other
 #                                           systems.
-#                                           type:Array[Enum['cron', 'service', 'systemd.timer', 'none']]
 #
 # $cron_cmd::                               Specify command to launch when runmode is
 #                                           set 'cron'.
-#                                           type:Optional[String]
 #
 # $systemd_cmd::                            Specify command to launch when runmode is
 #                                           set 'systemd.timer'.
-#                                           type:Optional[String]
 #
 # $show_diff::                              Show and report changed files with diff output
-#                                           type:Boolean
 #
 # $module_repository::                      Use a different puppet module repository
-#                                           type:Optional[Stdlib::HTTPUrl]
 #
 # $configtimeout::                          How long the client should wait for the
 #                                           configuration to be retrieved before
 #                                           considering it a failure.
-#                                           type:Optional[Integer[0]]
 #
 # $ca_server::                              Use a different ca server. Should be either
 #                                           a string with the location of the ca_server
 #                                           or 'false'.
-#                                           type:Optional[Variant[String, Boolean]]
 #
 # $ca_port::                                Puppet CA port
-#                                           type:Optional[Integer[0, 65535]]
 #
 # $ca_crl_filepath::                        Path to CA CRL file, dynamically resolves based on
 #                                           $::server_ca status.
-#                                           type:Optional[String]
 #
 # $dns_alt_names::                          Use additional DNS names when generating a
 #                                           certificate.  Defaults to an empty Array.
-#                                           type:Array[String]
 #
 # $classfile::                              The file in which puppet agent stores a list
 #                                           of the classes associated with the retrieved
 #                                           configuration.
-#                                           type:String
 #
 # $hiera_config::                           The hiera configuration file.
-#                                           type:String
 #
 # $syslogfacility::                         Facility name to use when logging to syslog
-#                                           type:Optional[String]
 #
 # $auth_template::                          Use a custom template for the auth
 #                                           configuration.
-#                                           type:String
 #
 # $main_template::                          Use a custom template for the main puppet
 #                                           configuration.
-#                                           type:String
 #
 # $use_srv_records::                        Whether DNS SRV records will be used to resolve
 #                                           the Puppet master
-#                                           type:Boolean
 #
 # $srv_domain::                             Search domain for SRV records
-#                                           type:String
 #
 # $pluginsource::                           URL to retrieve Puppet plugins from during pluginsync
-#                                           type:String
 #
 # $pluginfactsource::                       URL to retrieve Puppet facts from during pluginsync
-#                                           type:String
 #
 # $additional_settings::                    A hash of additional main settings.
-#                                           type:Hash[String, Data]
 #
 # == puppet::agent parameters
 #
 # $agent::                                  Should a puppet agent be installed
-#                                           type:Boolean
 #
 # $agent_noop::                             Run the agent in noop mode.
-#                                           type:Boolean
 #
 # $agent_template::                         Use a custom template for the agent puppet
 #                                           configuration.
-#                                           type:String
 #
 # $client_package::                         Install a custom package to provide
 #                                           the puppet client
-#                                           type:Array[String]
 #
 # $puppetmaster::                           Hostname of your puppetmaster (server
 #                                           directive in puppet.conf)
-#                                           type:Optional[String]
 #
 # $prerun_command::                         A command which gets excuted before each Puppet run
-#                                           type:Optional[String]
 #
 # $postrun_command::                        A command which gets excuted after each Puppet run
-#                                           type:Optional[String]
 #
 # $systemd_unit_name::                      The name of the puppet systemd units.
-#                                           type:String
 #
 # $service_name::                           The name of the puppet agent service.
-#                                           type:String
 #
 # $agent_restart_command::                  The command which gets excuted on puppet service restart
-#                                           type:Optional[String]
 #
 # $environment::                            Default environment of the Puppet agent
-#                                           type:String
 #
 # $agent_additional_settings::              A hash of additional agent settings.
 #                                           Example: {stringify_facts => true}
-#                                           type:Hash[String, Data]
 #
 # $remove_lock::                            Remove the agent lock when running.
-#                                           type:Boolean
 #
 # $client_certname::                        The node's certificate name, and the unique
 #                                           identifier it uses when requesting catalogs.
-#                                           type:String
 #
 # $dir_owner::                              Owner of the base puppet directory, used when
 #                                           puppet::server is false.
-#                                           type:String
 #
 # $dir_group::                              Group of the base puppet directory, used when
 #                                           puppet::server is false.
-#                                           type:Optional[String]
 #
 # == puppet::server parameters
 #
 # $server::                                 Should a puppet master be installed as well as the client
-#                                           type:Boolean
 #
 # $server_user::                            Name of the puppetmaster user.
-#                                           type:String
 #
 # $server_group::                           Name of the puppetmaster group.
-#                                           type:String
 #
 # $server_dir::                             Puppet configuration directory
-#                                           type:String
 #
 # $server_ip::                              Bind ip address of the puppetmaster
-#                                           type:String
 #
 # $server_port::                            Puppet master port
-#                                           type:Integer
 #
 # $server_ca::                              Provide puppet CA
-#                                           type:Boolean
 #
 # $server_ca_crl_sync::                     Sync puppet CA crl file to compile masters, Puppet CA Must be the Puppetserver
 #                                           for the compile masters. Defaults to false.
-#                                           type:Boolean
 #
 # $server_crl_enable::                      Turn on crl checking. Defaults to true when server_ca is true. Otherwise
 #                                           Defaults to false. Note unless you are using an external CA. It is recommended
 #                                           to set this to true. See $server_ca_crl_sync to enable syncing from CA Puppet Master
-#                                           type:Optional[Boolean]
 #
 # $server_http::                            Should the puppet master listen on HTTP as well as HTTPS.
 #                                           Useful for load balancer or reverse proxy scenarios. Note that
 #                                           the HTTP puppet master denies access from all clients by default,
 #                                           allowed clients must be specified with $server_http_allow.
-#                                           type:Boolean
 #
 # $server_http_port::                       Puppet master HTTP port; defaults to 8139.
-#                                           type:Integer
 #
 # $server_http_allow::                      Array of allowed clients for the HTTP puppet master. Passed
 #                                           to Apache's 'Allow' directive.
-#                                           type:Array[String]
 #
 # $server_reports::                         List of report types to include on the puppetmaster
-#                                           type:String
 #
 # $server_implementation::                  Puppet master implementation, either "master" (traditional
 #                                           Ruby) or "puppetserver" (JVM-based)
-#                                           type:Enum['master', 'puppetserver']
 #
 # $server_passenger::                       If set to true, we will configure apache with
 #                                           passenger. If set to false, we will enable the
@@ -313,123 +237,89 @@
 #                                           service_fallback is set to false. See 'Advanced
 #                                           server parameters' for more information.
 #                                           Only applicable when server_implementation is "master".
-#                                           type:Boolean
 #
 # $server_external_nodes::                  External nodes classifier executable
-#                                           type:Stdlib::Absolutepath
 #
 # $server_template::                        Which template should be used for master
 #                                           configuration
-#                                           type:String
 #
 # $server_main_template::                   Which template should be used for master
 #                                           related configuration in the [main] section
-#                                           type:String
 #
 # $server_git_repo::                        Use git repository as a source of modules
-#                                           type:Boolean
 #
 # $server_dynamic_environments::            Use $environment in the modulepath
 #                                           Deprecated when $server_directory_environments is true,
 #                                           set $server_environments to [] instead.
-#                                           type:Boolean
 #
 # $server_directory_environments::          Enable directory environments, defaulting to true
 #                                           with Puppet 3.6.0 or higher
-#                                           type:Boolean
 #
 # $server_environments::                    Environments to setup (creates directories).
 #                                           Applies only when $server_dynamic_environments
 #                                           is false
-#                                           type:Array[String]
 #
 # $server_environments_owner::              The owner of the environments directory
-#                                           type:String
 #
 # $server_environments_group::              The group owning the environments directory
-#                                           type:Optional[String]
 #
 # $server_environments_mode::               Environments directory mode.
-#                                           type:Pattern[/^[0-9]{4}$/]
 #
 # $server_envs_dir::                        Directory that holds puppet environments
-#                                           type:Stdlib::Absolutepath
 #
 # $server_envs_target::                     Indicates that $envs_dir should be
 #                                           a symbolic link to this target
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $server_common_modules_path::             Common modules paths (only when
 #                                           $server_git_repo_path and $server_dynamic_environments
 #                                           are false)
-#                                           type:Array[Stdlib::Absolutepath]
 #
 # $server_git_repo_path::                   Git repository path
-#                                           type:Stdlib::Absolutepath
 #
 # $server_git_repo_mode::                   Git repository mode
-#                                           type:Pattern[/^[0-9]{4}$/]
 #
 # $server_git_repo_group::                  Git repository group
-#                                           type:String
 #
 # $server_git_repo_user::                   Git repository user
-#                                           type:String
 #
 # $server_git_branch_map::                  Git branch to puppet env mapping for the
 #                                           default post receive hook
-#                                           type:Hash[String, String]
 #
 # $server_post_hook_content::               Which template to use for git post hook
-#                                           type:String
 #
 # $server_post_hook_name::                  Name of a git hook
-#                                           type:String
 #
 # $server_storeconfigs_backend::            Do you use storeconfigs? (note: not required)
 #                                           false if you don't, "active_record" for 2.X
 #                                           style db, "puppetdb" for puppetdb
-#                                           type:Variant[Undef, Boolean, Enum['active_record', 'puppetdb']]
 #
 # $server_app_root::                        Directory where the application lives
-#                                           type:Stdlib::Absolutepath
 #
 # $server_ssl_dir::                         SSL directory
-#                                           type:Stdlib::Absolutepath
 #
 # $server_package::                         Custom package name for puppet master
-#                                           type:Optional[Variant[String, Array[String]]]
 #
 # $server_version::                         Custom package version for puppet master
-#                                           type:Optional[String]
 #
 # $server_certname::                        The name to use when handling certificates.
-#                                           type:String
 #
 # $server_strict_variables::                if set to true, it will throw parse errors
 #                                           when accessing undeclared variables.
-#                                           type:Boolean
 #
 # $server_additional_settings::             A hash of additional settings.
 #                                           Example: {trusted_node_data => true, ordering => 'manifest'}
-#                                           type:Hash[String, Data]
 #
 # $server_rack_arguments::                  Arguments passed to rack app ARGV in addition to --confdir and
 #                                           --vardir.  The default is an empty array.
-#                                           type:Array[String]
 #
 # $server_puppetdb_host::                   PuppetDB host
-#                                           type:Optional[String]
 #
 # $server_puppetdb_port::                   PuppetDB port
-#                                           type:Integer[0, 65535]
 #
 # $server_puppetdb_swf::                    PuppetDB soft_write_failure
-#                                           type:Boolean
 #
 # $server_parser::                          Sets the parser to use. Valid options are 'current' or 'future'.
 #                                           Defaults to 'current'.
-#                                           type:Enum['current', 'future']
 #
 # === Advanced server parameters:
 #
@@ -437,213 +327,161 @@
 #                                           on configuration changes. Defaults
 #                                           to 'httpd' based on the default
 #                                           apache module included with foreman-installer.
-#                                           type:String
 #
 # $server_service_fallback::                If passenger is not used, do we want to fallback
 #                                           to using the puppetmaster service? Set to false
 #                                           if you disabled passenger and you do NOT want to
 #                                           use the puppetmaster service. Defaults to true.
-#                                           type:Boolean
 #
 # $server_passenger_min_instances::         The PassengerMinInstances parameter. Sets the
 #                                           minimum number of application processes to run.
 #                                           Defaults to the number of processors on your
 #                                           system.
-#                                           type:Integer[0]
 #
 # $server_passenger_pre_start::             Pre-start the first passenger worker instance
 #                                           process during httpd start.
-#                                           type:Boolean
 #
 # $server_passenger_ruby::                  The PassengerRuby parameter. Sets the Ruby
 #                                           interpreter for serving the puppetmaster
 #                                           rack application.
-#                                           type:Optional[String]
 #
 # $server_config_version::                  How to determine the configuration version. When
 #                                           using git_repo, by default a git describe
 #                                           approach will be installed.
-#                                           type:Optional[String]
 #
 # $server_foreman_facts::                   Should foreman receive facts from puppet
-#                                           type:Boolean
 #
 # $server_foreman::                         Should foreman integration be installed
-#                                           type:Boolean
 #
 # $server_foreman_url::                     Foreman URL
-#                                           type:Stdlib::HTTPUrl
 #
 # $server_foreman_ssl_ca::                  SSL CA of the Foreman server
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $server_foreman_ssl_cert::                Client certificate for authenticating against Foreman server
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $server_foreman_ssl_key::                 Key for authenticating against Foreman server
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $server_puppet_basedir::                  Where is the puppet code base located
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $server_enc_api::                         What version of enc script to deploy. Valid
 #                                           values are 'v2' for latest, and 'v1'
 #                                           for Foreman =< 1.2
-#                                           type:Enum['v2', 'v1']
 #
 # $server_report_api::                      What version of report processor to deploy.
 #                                           Valid values are 'v2' for latest, and 'v1'
 #                                           for Foreman =< 1.2
-#                                           type:Enum['v2', 'v1']
 #
 # $server_request_timeout::                 Timeout in node.rb script for fetching
 #                                           catalog from Foreman (in seconds).
-#                                           type:Integer[0]
 #
 # $server_environment_timeout::             Timeout for cached compiled catalogs (10s, 5m, ...)
-#                                           type:Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]]
 #
 # $server_ca_proxy::                        The actual server that handles puppet CA.
 #                                           Setting this to anything non-empty causes
 #                                           the apache vhost to set up a proxy for all
 #                                           certificates pointing to the value.
-#                                           type:Optional[String]
 #
 # $server_jvm_java_bin::                    Set the default java to use.
-#                                           type:String
 #
 # $server_jvm_config::                      Specify the puppetserver jvm configuration file.
-#                                           type:String
 #
 # $server_jvm_min_heap_size::               Specify the minimum jvm heap space.
-#                                           type:String
 #
 # $server_jvm_max_heap_size::               Specify the maximum jvm heap space.
-#                                           type:String
 #
 # $server_jvm_extra_args::                  Additional java options to pass through.
 #                                           This can be used for Java versions prior to
 #                                           Java 8 to specify the max perm space to use:
 #                                           For example: '-XX:MaxPermSpace=128m'.
-#                                           type:String
 #
 # $server_jruby_gem_home::                  Where jruby gems are located for puppetserver
-#                                           type:String
 #
 # $allow_any_crl_auth::                     Allow any authentication for the CRL. This
 #                                           is needed on the puppet CA to accept clients
 #                                           from a the puppet CA proxy.
-#                                           type:Boolean
 #
 # $auth_allowed::                           An array of authenticated nodes allowed to
 #                                           access all catalog and node endpoints.
 #                                           default to ['$1']
-#                                           type:Array[String]
 #
 # $server_default_manifest::                Toggle if default_manifest setting should
 #                                           be added to the [main] section
-#                                           type:Boolean
 #
 # $server_default_manifest_path::           A string setting the path to the default_manifest
-#                                           type:Stdlib::Absolutepath
 #
 # $server_default_manifest_content::        A string to set the content of the default_manifest
 #                                           If set to '' it will not manage the file
-#                                           type:String
 #
 # $server_ssl_dir_manage::                  Toggle if ssl_dir should be added to the [master]
 #                                           configuration section. This is necessary to
 #                                           disable in case CA is delegated to a separate instance
-#                                           type:Boolean
 #
 # $server_ssl_key_manage::                  Toggle if "private_keys/${::puppet::server::certname}.pem"
 #                                           should be created with default user and group. This is used in
 #                                           the default Forman setup to reuse the key for TLS communication.
-#                                           type:Boolean
 #
 # $server_puppetserver_vardir::             The path of the puppetserver var dir
-#                                           type:Stdlib::Absolutepath
 #
 # $server_puppetserver_rundir::             The path of the puppetserver run dir
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $server_puppetserver_logdir::             The path of the puppetserver log dir
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $server_puppetserver_dir::                The path of the puppetserver config dir
-#                                           type:Stdlib::Absolutepath
 #
 # $server_puppetserver_version::            The version of puppetserver 2 installed (or being installed)
 #                                           Unfortunately, different versions of puppetserver need configuring differently,
 #                                           and there's no easy way of determining which version is being installed.
 #                                           Defaults to '2.3.1' but can be overriden if you're installing an older version.
-#                                           type:Pattern[/^[0-9\.]+$/]
 #
 # $server_max_active_instances::            Max number of active jruby instances. Defaults to
 #                                           processor count
-#                                           type:Integer[1]
 #
 # $server_max_requests_per_instance::       Max number of requests a jruby instances will handle. Defaults to 0 (disabled)
-#                                           type:Integer[0]
 #
 # $server_idle_timeout::                    How long the server will wait for a response on an existing connection
-#                                           type:Integer[0]
 #
 # $server_connect_timeout::                 How long the server will wait for a response to a connection attempt
-#                                           type:Integer[0]
 #
 # $server_ssl_protocols::                   Array of SSL protocols to use.
 #                                           Defaults to [ 'TLSv1.2' ]
-#                                           type:Array[String]
 #
 # $server_ssl_chain_filepath::              Path to certificate chain for puppetserver
 #                                           Only used when $ca is true
 #                                           Defaults to "${ssl_dir}/ca/ca_crt.pem"
-#                                           type:Optional[Stdlib::Absolutepath]
 #
 # $server_cipher_suites::                   List of SSL ciphers to use in negotiation
 #                                           Defaults to [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA',
 #                                           'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA', ]
-#                                           type:Array[String]
 #
 # $server_ruby_load_paths::                 List of ruby paths
 #                                           Defaults based on $::puppetversion
-#                                           type:Array[Stdlib::Absolutepath]
 #
 # $server_ca_client_whitelist::             The whitelist of client certificates that
 #                                           can query the certificate-status endpoint
 #                                           Defaults to [ '127.0.0.1', '::1', $::ipaddress ]
-#                                           type:Array[String]
 #
 # $server_admin_api_whitelist::             The whitelist of clients that
 #                                           can query the puppet-admin-api endpoint
 #                                           Defaults to [ '127.0.0.1', '::1', $::ipaddress ]
-#                                           type:Array[String]
 #
 # $server_enable_ruby_profiler::            Should the puppetserver ruby profiler be enabled?
 #                                           Defaults to false
-#                                           type:Boolean
 #
 # $server_ca_auth_required::                Whether client certificates are needed to access the puppet-admin api
 #                                           Defaults to true
-#                                           type:Boolean
 #
 # $server_use_legacy_auth_conf::            Should the puppetserver use the legacy puppet auth.conf?
 #                                           Defaults to false (the puppetserver will use its own conf.d/auth.conf)
-#                                           type:Boolean
 #
 # $server_check_for_updates::               Should the puppetserver phone home to check for available updates?
 #                                           Defaults to true
-#                                           type:Boolean
 #
 # $server_environment_class_cache_enabled:: Enable environment class cache in conjunction with the use of the
 #                                           environment_classes API.
 #                                           Defaults to false
-#                                           type:Boolean
 #
 # $server_allow_header_cert_info::          Enable client authentication over HTTP Headers
 #                                           Defaults to false, is also activated by the $server_http setting
-#                                           type:Boolean
 # === Usage:
 #
 # * Simple usage:
@@ -664,168 +502,168 @@
 #   }
 #
 class puppet (
-  $version                                = $puppet::params::version,
-  $user                                   = $puppet::params::user,
-  $group                                  = $puppet::params::group,
-  $dir                                    = $puppet::params::dir,
-  $codedir                                = $puppet::params::codedir,
-  $vardir                                 = $puppet::params::vardir,
-  $logdir                                 = $puppet::params::logdir,
-  $rundir                                 = $puppet::params::rundir,
-  $ssldir                                 = $puppet::params::ssldir,
-  $sharedir                               = $puppet::params::sharedir,
-  $manage_packages                        = $puppet::params::manage_packages,
-  $dir_owner                              = $puppet::params::dir_owner,
-  $dir_group                              = $puppet::params::dir_group,
-  $package_provider                       = $puppet::params::package_provider,
-  $package_source                         = $puppet::params::package_source,
-  $port                                   = $puppet::params::port,
-  $listen                                 = $puppet::params::listen,
-  $listen_to                              = $puppet::params::listen_to,
-  $pluginsync                             = $puppet::params::pluginsync,
-  $splay                                  = $puppet::params::splay,
-  $splaylimit                             = $puppet::params::splaylimit,
-  $autosign                               = $puppet::params::autosign,
-  $autosign_entries                       = $puppet::params::autosign_entries,
-  $autosign_mode                          = $puppet::params::autosign_mode,
-  $autosign_content                       = $puppet::params::autosign_content,
-  $runinterval                            = $puppet::params::runinterval,
-  $usecacheonfailure                      = $puppet::params::usecacheonfailure,
-  $runmode                                = $puppet::params::runmode,
-  $unavailable_runmodes                   = $puppet::params::unavailable_runmodes,
-  $cron_cmd                               = $puppet::params::cron_cmd,
-  $systemd_cmd                            = $puppet::params::systemd_cmd,
-  $agent_noop                             = $puppet::params::agent_noop,
-  $show_diff                              = $puppet::params::show_diff,
-  $module_repository                      = $puppet::params::module_repository,
-  $configtimeout                          = $puppet::params::configtimeout,
-  $ca_server                              = $puppet::params::ca_server,
-  $ca_port                                = $puppet::params::ca_port,
-  $ca_crl_filepath                        = $puppet::params::ca_crl_filepath,
-  $prerun_command                         = $puppet::params::prerun_command,
-  $postrun_command                        = $puppet::params::postrun_command,
-  $dns_alt_names                          = $puppet::params::dns_alt_names,
-  $use_srv_records                        = $puppet::params::use_srv_records,
-  $srv_domain                             = $puppet::params::srv_domain,
-  $pluginsource                           = $puppet::params::pluginsource,
-  $pluginfactsource                       = $puppet::params::pluginfactsource,
-  $additional_settings                    = $puppet::params::additional_settings,
-  $agent_additional_settings              = $puppet::params::agent_additional_settings,
-  $agent_restart_command                  = $puppet::params::agent_restart_command,
-  $classfile                              = $puppet::params::classfile,
-  $hiera_config                           = $puppet::params::hiera_config,
-  $main_template                          = $puppet::params::main_template,
-  $agent_template                         = $puppet::params::agent_template,
-  $auth_template                          = $puppet::params::auth_template,
-  $allow_any_crl_auth                     = $puppet::params::allow_any_crl_auth,
-  $auth_allowed                           = $puppet::params::auth_allowed,
-  $client_package                         = $puppet::params::client_package,
-  $agent                                  = $puppet::params::agent,
-  $remove_lock                            = $puppet::params::remove_lock,
-  $client_certname                        = $puppet::params::client_certname,
-  $puppetmaster                           = $puppet::params::puppetmaster,
-  $systemd_unit_name                      = $puppet::params::systemd_unit_name,
-  $service_name                           = $puppet::params::service_name,
-  $syslogfacility                         = $puppet::params::syslogfacility,
-  $environment                            = $puppet::params::environment,
-  $server                                 = $puppet::params::server,
-  $server_admin_api_whitelist             = $puppet::params::server_admin_api_whitelist,
-  $server_user                            = $puppet::params::user,
-  $server_group                           = $puppet::params::group,
-  $server_dir                             = $puppet::params::dir,
-  $server_ip                              = $puppet::params::ip,
-  $server_port                            = $puppet::params::port,
-  $server_ca                              = $puppet::params::server_ca,
-  $server_ca_crl_sync                     = $puppet::params::server_ca_crl_sync,
-  $server_crl_enable                      = $puppet::params::server_crl_enable,
-  $server_ca_auth_required                = $puppet::params::server_ca_auth_required,
-  $server_ca_client_whitelist             = $puppet::params::server_ca_client_whitelist,
-  $server_http                            = $puppet::params::server_http,
-  $server_http_port                       = $puppet::params::server_http_port,
-  $server_http_allow                      = $puppet::params::server_http_allow,
-  $server_reports                         = $puppet::params::server_reports,
-  $server_implementation                  = $puppet::params::server_implementation,
-  $server_passenger                       = $puppet::params::server_passenger,
-  $server_puppetserver_dir                = $puppet::params::server_puppetserver_dir,
-  $server_puppetserver_vardir             = $puppet::params::server_puppetserver_vardir,
-  $server_puppetserver_rundir             = $puppet::params::server_puppetserver_rundir,
-  $server_puppetserver_logdir             = $puppet::params::server_puppetserver_logdir,
-  $server_puppetserver_version            = $puppet::params::server_puppetserver_version,
-  $server_service_fallback                = $puppet::params::server_service_fallback,
-  $server_passenger_min_instances         = $puppet::params::server_passenger_min_instances,
-  $server_passenger_pre_start             = $puppet::params::server_passenger_pre_start,
-  $server_passenger_ruby                  = $puppet::params::server_passenger_ruby,
-  $server_httpd_service                   = $puppet::params::server_httpd_service,
-  $server_external_nodes                  = $puppet::params::server_external_nodes,
-  $server_template                        = $puppet::params::server_template,
-  $server_main_template                   = $puppet::params::server_main_template,
-  $server_cipher_suites                   = $puppet::params::server_cipher_suites,
-  $server_config_version                  = $puppet::params::server_config_version,
-  $server_connect_timeout                 = $puppet::params::server_connect_timeout,
-  $server_git_repo                        = $puppet::params::server_git_repo,
-  $server_dynamic_environments            = $puppet::params::server_dynamic_environments,
-  $server_directory_environments          = $puppet::params::server_directory_environments,
-  $server_default_manifest                = $puppet::params::server_default_manifest,
-  $server_default_manifest_path           = $puppet::params::server_default_manifest_path,
-  $server_default_manifest_content        = $puppet::params::server_default_manifest_content,
-  $server_enable_ruby_profiler            = $puppet::params::server_enable_ruby_profiler,
-  $server_environments                    = $puppet::params::server_environments,
-  $server_environments_owner              = $puppet::params::server_environments_owner,
-  $server_environments_group              = $puppet::params::server_environments_group,
-  $server_environments_mode               = $puppet::params::server_environments_mode,
-  $server_envs_dir                        = $puppet::params::server_envs_dir,
-  $server_envs_target                     = $puppet::params::server_envs_target,
-  $server_common_modules_path             = $puppet::params::server_common_modules_path,
-  $server_git_repo_mode                   = $puppet::params::server_git_repo_mode,
-  $server_git_repo_path                   = $puppet::params::server_git_repo_path,
-  $server_git_repo_group                  = $puppet::params::server_git_repo_group,
-  $server_git_repo_user                   = $puppet::params::server_git_repo_user,
-  $server_git_branch_map                  = $puppet::params::server_git_branch_map,
-  $server_idle_timeout                    = $puppet::params::server_idle_timeout,
-  $server_post_hook_content               = $puppet::params::server_post_hook_content,
-  $server_post_hook_name                  = $puppet::params::server_post_hook_name,
-  $server_storeconfigs_backend            = $puppet::params::server_storeconfigs_backend,
-  $server_app_root                        = $puppet::params::server_app_root,
-  $server_ruby_load_paths                 = $puppet::params::server_ruby_load_paths,
-  $server_ssl_dir                         = $puppet::params::server_ssl_dir,
-  $server_ssl_dir_manage                  = $puppet::params::server_ssl_dir_manage,
-  $server_ssl_key_manage                  = $puppet::params::server_ssl_key_manage,
-  $server_ssl_protocols                   = $puppet::params::server_ssl_protocols,
-  $server_ssl_chain_filepath              = $puppet::params::server_ssl_chain_filepath,
-  $server_package                         = $puppet::params::server_package,
-  $server_version                         = $puppet::params::server_version,
-  $server_certname                        = $puppet::params::server_certname,
-  $server_enc_api                         = $puppet::params::server_enc_api,
-  $server_report_api                      = $puppet::params::server_report_api,
-  $server_request_timeout                 = $puppet::params::server_request_timeout,
-  $server_ca_proxy                        = $puppet::params::server_ca_proxy,
-  $server_strict_variables                = $puppet::params::server_strict_variables,
-  $server_additional_settings             = $puppet::params::server_additional_settings,
-  $server_rack_arguments                  = $puppet::params::server_rack_arguments,
-  $server_foreman                         = $puppet::params::server_foreman,
-  $server_foreman_url                     = $puppet::params::server_foreman_url,
-  $server_foreman_ssl_ca                  = $puppet::params::server_foreman_ssl_ca,
-  $server_foreman_ssl_cert                = $puppet::params::server_foreman_ssl_cert,
-  $server_foreman_ssl_key                 = $puppet::params::server_foreman_ssl_key,
-  $server_foreman_facts                   = $puppet::params::server_foreman_facts,
-  $server_puppet_basedir                  = $puppet::params::server_puppet_basedir,
-  $server_puppetdb_host                   = $puppet::params::server_puppetdb_host,
-  $server_puppetdb_port                   = $puppet::params::server_puppetdb_port,
-  $server_puppetdb_swf                    = $puppet::params::server_puppetdb_swf,
-  $server_parser                          = $puppet::params::server_parser,
-  $server_environment_timeout             = $puppet::params::server_environment_timeout,
-  $server_jvm_java_bin                    = $puppet::params::server_jvm_java_bin,
-  $server_jvm_config                      = $puppet::params::server_jvm_config,
-  $server_jvm_min_heap_size               = $puppet::params::server_jvm_min_heap_size,
-  $server_jvm_max_heap_size               = $puppet::params::server_jvm_max_heap_size,
-  $server_jvm_extra_args                  = $puppet::params::server_jvm_extra_args,
-  $server_jruby_gem_home                  = $puppet::params::server_jruby_gem_home,
-  $server_max_active_instances            = $puppet::params::server_max_active_instances,
-  $server_max_requests_per_instance       = $puppet::params::server_max_requests_per_instance,
-  $server_use_legacy_auth_conf            = $puppet::params::server_use_legacy_auth_conf,
-  $server_check_for_updates               = $puppet::params::server_check_for_updates,
-  $server_environment_class_cache_enabled = $puppet::params::server_environment_class_cache_enabled,
-  $server_allow_header_cert_info          = $puppet::params::server_allow_header_cert_info,
+  String $version = $puppet::params::version,
+  String $user = $puppet::params::user,
+  String $group = $puppet::params::group,
+  Stdlib::Absolutepath $dir = $puppet::params::dir,
+  Stdlib::Absolutepath $codedir = $puppet::params::codedir,
+  Stdlib::Absolutepath $vardir = $puppet::params::vardir,
+  Stdlib::Absolutepath $logdir = $puppet::params::logdir,
+  Stdlib::Absolutepath $rundir = $puppet::params::rundir,
+  Stdlib::Absolutepath $ssldir = $puppet::params::ssldir,
+  Stdlib::Absolutepath $sharedir = $puppet::params::sharedir,
+  Variant[Boolean, Enum['server', 'agent']] $manage_packages = $puppet::params::manage_packages,
+  Optional[String] $dir_owner = $puppet::params::dir_owner,
+  Optional[String] $dir_group = $puppet::params::dir_group,
+  Optional[String] $package_provider = $puppet::params::package_provider,
+  Optional[Stdlib::Absolutepath] $package_source = $puppet::params::package_source,
+  Integer[0, 65535] $port = $puppet::params::port,
+  Boolean $listen = $puppet::params::listen,
+  Array[String] $listen_to = $puppet::params::listen_to,
+  Boolean $pluginsync = $puppet::params::pluginsync,
+  Boolean $splay = $puppet::params::splay,
+  Pattern[/^\d+[smhdy]?$/] $splaylimit = $puppet::params::splaylimit,
+  Variant[Boolean, Stdlib::Absolutepath] $autosign = $puppet::params::autosign,
+  Array[String] $autosign_entries = $puppet::params::autosign_entries,
+  Pattern[/^[0-9]{3,4}$/] $autosign_mode = $puppet::params::autosign_mode,
+  Optional[String] $autosign_content = $puppet::params::autosign_content,
+  Integer[0] $runinterval = $puppet::params::runinterval,
+  Boolean $usecacheonfailure = $puppet::params::usecacheonfailure,
+  Enum['cron', 'service', 'systemd.timer', 'none'] $runmode = $puppet::params::runmode,
+  Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,
+  Optional[String] $cron_cmd = $puppet::params::cron_cmd,
+  Optional[String] $systemd_cmd = $puppet::params::systemd_cmd,
+  Boolean $agent_noop = $puppet::params::agent_noop,
+  Boolean $show_diff = $puppet::params::show_diff,
+  Optional[Stdlib::HTTPUrl] $module_repository = $puppet::params::module_repository,
+  Optional[Integer[0]] $configtimeout = $puppet::params::configtimeout,
+  Optional[Variant[String, Boolean]] $ca_server = $puppet::params::ca_server,
+  Optional[Integer[0, 65535]] $ca_port = $puppet::params::ca_port,
+  Optional[String] $ca_crl_filepath = $puppet::params::ca_crl_filepath,
+  Optional[String] $prerun_command = $puppet::params::prerun_command,
+  Optional[String] $postrun_command = $puppet::params::postrun_command,
+  Array[String] $dns_alt_names = $puppet::params::dns_alt_names,
+  Boolean $use_srv_records = $puppet::params::use_srv_records,
+  Optional[String] $srv_domain = $puppet::params::srv_domain,
+  String $pluginsource = $puppet::params::pluginsource,
+  String $pluginfactsource = $puppet::params::pluginfactsource,
+  Hash[String, Data] $additional_settings = $puppet::params::additional_settings,
+  Hash[String, Data] $agent_additional_settings = $puppet::params::agent_additional_settings,
+  Optional[String] $agent_restart_command = $puppet::params::agent_restart_command,
+  String $classfile = $puppet::params::classfile,
+  String $hiera_config = $puppet::params::hiera_config,
+  String $main_template = $puppet::params::main_template,
+  String $agent_template = $puppet::params::agent_template,
+  String $auth_template = $puppet::params::auth_template,
+  Boolean $allow_any_crl_auth = $puppet::params::allow_any_crl_auth,
+  Array[String] $auth_allowed = $puppet::params::auth_allowed,
+  Array[String] $client_package = $puppet::params::client_package,
+  Boolean $agent = $puppet::params::agent,
+  Boolean $remove_lock = $puppet::params::remove_lock,
+  String $client_certname = $puppet::params::client_certname,
+  Optional[String] $puppetmaster = $puppet::params::puppetmaster,
+  String $systemd_unit_name = $puppet::params::systemd_unit_name,
+  String $service_name = $puppet::params::service_name,
+  Optional[String] $syslogfacility = $puppet::params::syslogfacility,
+  String $environment = $puppet::params::environment,
+  Boolean $server = $puppet::params::server,
+  Array[String] $server_admin_api_whitelist = $puppet::params::server_admin_api_whitelist,
+  String $server_user = $puppet::params::user,
+  String $server_group = $puppet::params::group,
+  String $server_dir = $puppet::params::dir,
+  String $server_ip = $puppet::params::ip,
+  Integer $server_port = $puppet::params::port,
+  Boolean $server_ca = $puppet::params::server_ca,
+  Boolean $server_ca_crl_sync = $puppet::params::server_ca_crl_sync,
+  Optional[Boolean] $server_crl_enable = $puppet::params::server_crl_enable,
+  Boolean $server_ca_auth_required = $puppet::params::server_ca_auth_required,
+  Array[String] $server_ca_client_whitelist = $puppet::params::server_ca_client_whitelist,
+  Boolean $server_http = $puppet::params::server_http,
+  Integer $server_http_port = $puppet::params::server_http_port,
+  Array[String] $server_http_allow = $puppet::params::server_http_allow,
+  String $server_reports = $puppet::params::server_reports,
+  Enum['master', 'puppetserver'] $server_implementation = $puppet::params::server_implementation,
+  Boolean $server_passenger = $puppet::params::server_passenger,
+  Optional[Stdlib::Absolutepath] $server_puppetserver_dir = $puppet::params::server_puppetserver_dir,
+  Optional[Stdlib::Absolutepath] $server_puppetserver_vardir = $puppet::params::server_puppetserver_vardir,
+  Optional[Stdlib::Absolutepath] $server_puppetserver_rundir = $puppet::params::server_puppetserver_rundir,
+  Optional[Stdlib::Absolutepath] $server_puppetserver_logdir = $puppet::params::server_puppetserver_logdir,
+  Pattern[/^[0-9\.]+$/] $server_puppetserver_version = $puppet::params::server_puppetserver_version,
+  Boolean $server_service_fallback = $puppet::params::server_service_fallback,
+  Integer[0] $server_passenger_min_instances = $puppet::params::server_passenger_min_instances,
+  Boolean $server_passenger_pre_start = $puppet::params::server_passenger_pre_start,
+  Optional[String] $server_passenger_ruby = $puppet::params::server_passenger_ruby,
+  String $server_httpd_service = $puppet::params::server_httpd_service,
+  Variant[Undef, String[0], Stdlib::Absolutepath] $server_external_nodes = $puppet::params::server_external_nodes,
+  String $server_template = $puppet::params::server_template,
+  String $server_main_template = $puppet::params::server_main_template,
+  Array[String] $server_cipher_suites = $puppet::params::server_cipher_suites,
+  Optional[String] $server_config_version = $puppet::params::server_config_version,
+  Integer[0] $server_connect_timeout = $puppet::params::server_connect_timeout,
+  Boolean $server_git_repo = $puppet::params::server_git_repo,
+  Boolean $server_dynamic_environments = $puppet::params::server_dynamic_environments,
+  Boolean $server_directory_environments = $puppet::params::server_directory_environments,
+  Boolean $server_default_manifest = $puppet::params::server_default_manifest,
+  Stdlib::Absolutepath $server_default_manifest_path = $puppet::params::server_default_manifest_path,
+  String $server_default_manifest_content = $puppet::params::server_default_manifest_content,
+  Boolean $server_enable_ruby_profiler = $puppet::params::server_enable_ruby_profiler,
+  Array[String] $server_environments = $puppet::params::server_environments,
+  String $server_environments_owner = $puppet::params::server_environments_owner,
+  Optional[String] $server_environments_group = $puppet::params::server_environments_group,
+  Pattern[/^[0-9]{3,4}$/] $server_environments_mode = $puppet::params::server_environments_mode,
+  Stdlib::Absolutepath $server_envs_dir = $puppet::params::server_envs_dir,
+  Optional[Stdlib::Absolutepath] $server_envs_target = $puppet::params::server_envs_target,
+  Variant[Undef, String[0], Array[Stdlib::Absolutepath]] $server_common_modules_path = $puppet::params::server_common_modules_path,
+  Pattern[/^[0-9]{3,4}$/] $server_git_repo_mode = $puppet::params::server_git_repo_mode,
+  Stdlib::Absolutepath $server_git_repo_path = $puppet::params::server_git_repo_path,
+  String $server_git_repo_group = $puppet::params::server_git_repo_group,
+  String $server_git_repo_user = $puppet::params::server_git_repo_user,
+  Hash[String, String] $server_git_branch_map = $puppet::params::server_git_branch_map,
+  Integer[0] $server_idle_timeout = $puppet::params::server_idle_timeout,
+  String $server_post_hook_content = $puppet::params::server_post_hook_content,
+  String $server_post_hook_name = $puppet::params::server_post_hook_name,
+  Variant[Undef, Boolean, Enum['active_record', 'puppetdb']] $server_storeconfigs_backend = $puppet::params::server_storeconfigs_backend,
+  Stdlib::Absolutepath $server_app_root = $puppet::params::server_app_root,
+  Array[Stdlib::Absolutepath] $server_ruby_load_paths = $puppet::params::server_ruby_load_paths,
+  Stdlib::Absolutepath $server_ssl_dir = $puppet::params::server_ssl_dir,
+  Boolean $server_ssl_dir_manage = $puppet::params::server_ssl_dir_manage,
+  Boolean $server_ssl_key_manage = $puppet::params::server_ssl_key_manage,
+  Array[String] $server_ssl_protocols = $puppet::params::server_ssl_protocols,
+  Optional[Stdlib::Absolutepath] $server_ssl_chain_filepath = $puppet::params::server_ssl_chain_filepath,
+  Optional[Variant[String, Array[String]]] $server_package = $puppet::params::server_package,
+  Optional[String] $server_version = $puppet::params::server_version,
+  String $server_certname = $puppet::params::server_certname,
+  Enum['v2', 'v1'] $server_enc_api = $puppet::params::server_enc_api,
+  Enum['v2', 'v1'] $server_report_api = $puppet::params::server_report_api,
+  Integer[0] $server_request_timeout = $puppet::params::server_request_timeout,
+  Optional[String] $server_ca_proxy = $puppet::params::server_ca_proxy,
+  Boolean $server_strict_variables = $puppet::params::server_strict_variables,
+  Hash[String, Data] $server_additional_settings = $puppet::params::server_additional_settings,
+  Array[String] $server_rack_arguments = $puppet::params::server_rack_arguments,
+  Boolean $server_foreman = $puppet::params::server_foreman,
+  Stdlib::HTTPUrl $server_foreman_url = $puppet::params::server_foreman_url,
+  Optional[Stdlib::Absolutepath] $server_foreman_ssl_ca = $puppet::params::server_foreman_ssl_ca,
+  Optional[Stdlib::Absolutepath] $server_foreman_ssl_cert = $puppet::params::server_foreman_ssl_cert,
+  Optional[Stdlib::Absolutepath] $server_foreman_ssl_key = $puppet::params::server_foreman_ssl_key,
+  Boolean $server_foreman_facts = $puppet::params::server_foreman_facts,
+  Optional[Stdlib::Absolutepath] $server_puppet_basedir = $puppet::params::server_puppet_basedir,
+  Optional[String] $server_puppetdb_host = $puppet::params::server_puppetdb_host,
+  Integer[0, 65535] $server_puppetdb_port = $puppet::params::server_puppetdb_port,
+  Boolean $server_puppetdb_swf = $puppet::params::server_puppetdb_swf,
+  Enum['current', 'future'] $server_parser = $puppet::params::server_parser,
+  Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]] $server_environment_timeout = $puppet::params::server_environment_timeout,
+  String $server_jvm_java_bin = $puppet::params::server_jvm_java_bin,
+  String $server_jvm_config = $puppet::params::server_jvm_config,
+  String $server_jvm_min_heap_size = $puppet::params::server_jvm_min_heap_size,
+  String $server_jvm_max_heap_size = $puppet::params::server_jvm_max_heap_size,
+  String $server_jvm_extra_args = $puppet::params::server_jvm_extra_args,
+  String $server_jruby_gem_home = $puppet::params::server_jruby_gem_home,
+  Integer[1] $server_max_active_instances = $puppet::params::server_max_active_instances,
+  Integer[0] $server_max_requests_per_instance = $puppet::params::server_max_requests_per_instance,
+  Boolean $server_use_legacy_auth_conf = $puppet::params::server_use_legacy_auth_conf,
+  Boolean $server_check_for_updates = $puppet::params::server_check_for_updates,
+  Boolean $server_environment_class_cache_enabled = $puppet::params::server_environment_class_cache_enabled,
+  Boolean $server_allow_header_cert_info = $puppet::params::server_allow_header_cert_info,
 ) inherits puppet::params {
 
   validate_bool($listen)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -588,7 +588,7 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_puppetserver_vardir = $puppet::params::server_puppetserver_vardir,
   Optional[Stdlib::Absolutepath] $server_puppetserver_rundir = $puppet::params::server_puppetserver_rundir,
   Optional[Stdlib::Absolutepath] $server_puppetserver_logdir = $puppet::params::server_puppetserver_logdir,
-  Pattern[/^[0-9\.]+$/] $server_puppetserver_version = $puppet::params::server_puppetserver_version,
+  Pattern[/^[\d]\.[\d]+\.[\d]+$/] $server_puppetserver_version = $puppet::params::server_puppetserver_version,
   Boolean $server_service_fallback = $puppet::params::server_service_fallback,
   Integer[0] $server_passenger_min_instances = $puppet::params::server_passenger_min_instances,
   Boolean $server_passenger_pre_start = $puppet::params::server_passenger_pre_start,
@@ -654,10 +654,10 @@ class puppet (
   Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]] $server_environment_timeout = $puppet::params::server_environment_timeout,
   String $server_jvm_java_bin = $puppet::params::server_jvm_java_bin,
   String $server_jvm_config = $puppet::params::server_jvm_config,
-  String $server_jvm_min_heap_size = $puppet::params::server_jvm_min_heap_size,
-  String $server_jvm_max_heap_size = $puppet::params::server_jvm_max_heap_size,
+  Pattern[/^[0-9]+[kKmMgG]$/] $server_jvm_min_heap_size = $puppet::params::server_jvm_min_heap_size,
+  Pattern[/^[0-9]+[kKmMgG]$/] $server_jvm_max_heap_size = $puppet::params::server_jvm_max_heap_size,
   String $server_jvm_extra_args = $puppet::params::server_jvm_extra_args,
-  String $server_jruby_gem_home = $puppet::params::server_jruby_gem_home,
+  Optional[Stdlib::Absolutepath] $server_jruby_gem_home = $puppet::params::server_jruby_gem_home,
   Integer[1] $server_max_active_instances = $puppet::params::server_max_active_instances,
   Integer[0] $server_max_requests_per_instance = $puppet::params::server_max_requests_per_instance,
   Boolean $server_use_legacy_auth_conf = $puppet::params::server_use_legacy_auth_conf,
@@ -665,41 +665,6 @@ class puppet (
   Boolean $server_environment_class_cache_enabled = $puppet::params::server_environment_class_cache_enabled,
   Boolean $server_allow_header_cert_info = $puppet::params::server_allow_header_cert_info,
 ) inherits puppet::params {
-
-  validate_bool($listen)
-  validate_bool($pluginsync)
-  validate_bool($splay)
-  validate_bool($usecacheonfailure)
-  validate_bool($agent_noop)
-  validate_bool($agent)
-  validate_bool($remove_lock)
-  validate_bool($server)
-  validate_bool($allow_any_crl_auth)
-
-  validate_hash($additional_settings)
-  validate_hash($agent_additional_settings)
-
-  if $ca_server {
-    validate_string($ca_server)
-  }
-
-  validate_string($systemd_unit_name)
-
-  validate_string($service_name)
-
-  validate_array($listen_to)
-  validate_array($dns_alt_names)
-  validate_array($auth_allowed)
-
-  validate_absolute_path($dir)
-  validate_absolute_path($vardir)
-  validate_absolute_path($logdir)
-  validate_absolute_path($rundir)
-
-  if $manage_packages != true and $manage_packages != false {
-    validate_re($manage_packages, '^(server|agent)$')
-  }
-
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class puppet::params {
   $pluginsync          = true
   $splay               = false
   $splaylimit          = '1800'
-  $runinterval         = '1800'
+  $runinterval         = 1800
   $runmode             = 'service'
 
   # Not defined here as the commands depend on module parameter "dir"

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,7 +14,6 @@
 # $autosign_entries::          A list of certnames or domain name globs
 #                              whose certificate requests will automatically be signed.
 #                              Defaults to an empty Array.
-#                              type: array
 #
 # $autosign_mode::             mode of the autosign file/script
 #
@@ -24,59 +23,43 @@
 #                              For example, could be a string, or
 #                              file('another_module/autosign.sh') or
 #                              template('another_module/autosign.sh.erb')
-#                              type:Optional[String]
 #
 # $hiera_config::              The hiera configuration file.
-#                              type:string
 #
 # $user::                      Name of the puppetmaster user.
-#                              type:string
 #
 # $group::                     Name of the puppetmaster group.
-#                              type:string
 #
 # $dir::                       Puppet configuration directory
-#                              type:string
 #
 # $ip::                        Bind ip address of the puppetmaster
-#                              type:string
 #
 # $port::                      Puppet master port
-#                              type:integer
 #
 # $ca::                        Provide puppet CA
-#                              type:boolean
 #
 # $ca_crl_filepath::           Path to ca_crl file
-#                              type:string
 #
 # $ca_crl_sync::               Sync the puppet ca crl to compile masters. Requires compile masters to
 #                              be agents of the CA master (MOM) defaults to false
-#                              type:boolean
 #
 # $crl_enable::                Enable CRL processing, defaults to true when $ca is true else defaults
 #                              to false
-#                              type:boolean
 #
 # $http::                      Should the puppet master listen on HTTP as well as HTTPS.
 #                              Useful for load balancer or reverse proxy scenarios. Note that
 #                              the HTTP puppet master denies access from all clients by default,
 #                              allowed clients must be specified with $http_allow.
-#                              type:boolean
 #
 # $http_port::                 Puppet master HTTP port; defaults to 8139.
-#                              type:integer
 #
 # $http_allow::                Array of allowed clients for the HTTP puppet master. Passed
 #                              to Apache's 'Allow' directive.
-#                              type:array
 #
 # $reports::                   List of report types to include on the puppetmaster
-#                              type:string
 #
 # $implementation::            Puppet master implementation, either "master" (traditional
 #                              Ruby) or "puppetserver" (JVM-based)
-#                              type:string
 #
 # $passenger::                 If set to true, we will configure apache with
 #                              passenger. If set to false, we will enable the
@@ -84,115 +67,83 @@
 #                              service_fallback is set to false. See 'Advanced
 #                              server parameters' for more information.
 #                              Only applicable when server_implementation is "master".
-#                              type:boolean
 #
 # $external_nodes::            External nodes classifier executable
-#                              type:string
 #
 # $git_repo::                  Use git repository as a source of modules
-#                              type:boolean
 #
 # $dynamic_environments::      Use $environment in the modulepath
 #                              Deprecated when $directory_environments is true,
 #                              set $environments to [] instead.
-#                              type:boolean
 #
 # $directory_environments::    Enable directory environments, defaulting to true
 #                              with Puppet 3.6.0 or higher
-#                              type:boolean
 #
 # $environments::              Environments to setup (creates directories).
 #                              Applies only when $dynamic_environments
 #                              is false
-#                              type:array
 #
 # $environments_owner::        The owner of the environments directory
-#                              type:string
 #
 # $environments_group::        The group owning the environments directory
-#                              type:string
 #
 # $environments_mode::         Environments directory mode.
-#                              type:string
 #
 # $envs_dir::                  Directory that holds puppet environments
-#                              type:string
 #
 # $envs_target::               Indicates that $envs_dir should be
 #                              a symbolic link to this target
-#                              type:string
 #
 # $common_modules_path::       Common modules paths (only when
 #                              $git_repo_path and $dynamic_environments
 #                              are false)
-#                              type:array
 #
 # $git_repo_path::             Git repository path
-#                              type:string
 #
 # $git_repo_mode::             Git repository mode
-#                              type:string
 #
 # $git_repo_group::            Git repository group
-#                              type:string
 #
 # $git_repo_user::             Git repository user
-#                              type:string
 #
 # $git_branch_map::            Git branch to puppet env mapping for the
 #                              default post receive hook
-#                              type:hash
 #
 # $post_hook_content::         Which template to use for git post hook
-#                              type:string
 #
 # $post_hook_name::            Name of a git hook
-#                              type:string
 #
 # $storeconfigs_backend::      Do you use storeconfigs? (note: not required)
 #                              false if you don't, "active_record" for 2.X
 #                              style db, "puppetdb" for puppetdb
-#                              type:string
 #
 # $app_root::                  Directory where the application lives
-#                              type:string
 #
 # $ssl_dir::                   SSL directory
-#                              type:string
 #
 # $package::                   Custom package name for puppet master
-#                              type:string
 #
 # $version::                   Custom package version for puppet master
-#                              type:string
 #
 # $certname::                  The name to use when handling certificates.
-#                              type:string
 #
 # $strict_variables::          if set to true, it will throw parse errors
 #                              when accessing undeclared variables.
-#                              type:boolean
 #
 # $additional_settings::       A hash of additional settings.
 #                              Example: {trusted_node_data => true, ordering => 'manifest'}
-#                              type:hash
 #
 # $rack_arguments::            Arguments passed to rack app ARGV in addition to --confdir and
 #                              --vardir.  The default is an empty array.
-#                              type:array
 #
 # $puppetdb_host::             PuppetDB host
-#                              type:string
 #
 # $puppetdb_port::             PuppetDB port
-#                              type:integer
 #
 # $puppetdb_swf::              PuppetDB soft_write_failure
-#                              type:boolean
 #
 # $parser::                    Sets the parser to use. Valid options are 'current' or 'future'.
 #                              Defaults to 'current'.
-#                              type:string
 #
 # === Advanced server parameters:
 #
@@ -200,302 +151,253 @@
 #                              on configuration changes. Defaults
 #                              to 'httpd' based on the default
 #                              apache module included with foreman-installer.
-#                              type:string
 #
 # $service_fallback::          If passenger is not used, do we want to fallback
 #                              to using the puppetmaster service? Set to false
 #                              if you disabled passenger and you do NOT want to
 #                              use the puppetmaster service. Defaults to true.
-#                              type:boolean
 #
 # $passenger_min_instances::   The PassengerMinInstances parameter. Sets the
 #                              minimum number of application processes to run.
 #                              Defaults to the number of processors on your
 #                              system.
-#                              type:integer
 #
 # $passenger_pre_start::       Pre-start the first passenger worker instance
 #                              process during httpd start.
-#                              type:boolean
 #
 # $passenger_ruby::            The PassengerRuby parameter. Sets the Ruby
 #                              interpreter for serving the puppetmaster rack
 #                              application.
-#                              type:string
 #
 # $config_version::            How to determine the configuration version. When
 #                              using git_repo, by default a git describe
 #                              approach will be installed.
-#                              type:string
 #
 # $server_foreman_facts::      Should foreman receive facts from puppet
-#                              type:boolean
 #
 # $foreman::                   Should foreman integration be installed
-#                              type:boolean
 #
 # $foreman_url::               Foreman URL
-#                              type:string
 #
 # $foreman_ssl_ca::            SSL CA of the Foreman server
-#                              type:string
 #
 # $foreman_ssl_cert::          Client certificate for authenticating against Foreman server
-#                              type:string
 #
 # $foreman_ssl_key::           Key for authenticating against Foreman server
-#                              type:string
 #
 # $puppet_basedir::            Where is the puppet code base located
-#                              type:string
 #
 # $enc_api::                   What version of enc script to deploy. Valid
 #                              values are 'v2' for latest, and 'v1'
 #                              for Foreman =< 1.2
-#                              type:string
 #
 # $report_api::                What version of report processor to deploy.
 #                              Valid values are 'v2' for latest, and 'v1'
 #                              for Foreman =< 1.2
-#                              type:string
 #
 # $request_timeout::           Timeout in node.rb script for fetching
 #                              catalog from Foreman (in seconds).
-#                              type:integer
 #
 # $environment_timeout::       Timeout for cached compiled catalogs (10s, 5m, ...)
-#                              type:string
 #
 # $ca_proxy::                  The actual server that handles puppet CA.
 #                              Setting this to anything non-empty causes
 #                              the apache vhost to set up a proxy for all
 #                              certificates pointing to the value.
-#                              type:string
 #
 # $jvm_java_bin::              Set the default java to use.
-#                              type:string
 #
 # $jvm_config::                Specify the puppetserver jvm configuration file.
-#                              type:string
 #
 # $jvm_min_heap_size::         Specify the minimum jvm heap space.
-#                              type:string
 #
 # $jvm_max_heap_size::         Specify the maximum jvm heap space.
-#                              type:string
 #
 # $jvm_extra_args::            Additional java options to pass through.
 #                              This can be used for Java versions prior to
 #                              Java 8 to specify the max perm space to use:
 #                              For example: '-XX:MaxPermSpace=128m'.
-#                              type:string
 #
 # $jruby_gem_home::            Where jruby gems are located for puppetserver
-#                              type:string
 #
 # $allow_any_crl_auth::        Allow any authentication for the CRL. This
 #                              is needed on the puppet CA to accept clients
 #                              from a the puppet CA proxy.
-#                              type:boolean
 #
 # $auth_allowed::              An array of authenticated nodes allowed to
 #                              access all catalog and node endpoints.
 #                              default to ['$1']
-#                              type:array
 #
 # $default_manifest::          Toggle if default_manifest setting should
 #                              be added to the [main] section
-#                              type:boolean
 #
 # $default_manifest_path::     A string setting the path to the default_manifest
-#                              type:string
 #
 # $default_manifest_content::  A string to set the content of the default_manifest
 #                              If set to '' it will not manage the file
-#                              type:string
 #
 # $ssl_dir_manage::            Toggle if ssl_dir should be added to the [master]
 #                              configuration section. This is necessary to
 #                              disable in case CA is delegated to a separate instance
-#                              type:boolean
 #
 # $ssl_key_manage::            Toggle if "private_keys/${::puppet::server::certname}.pem"
 #                              should be created with default user and group. This is used in
 #                              the default Forman setup to reuse the key for TLS communication.
-#                              type:Boolean
 #
 # $puppetserver_vardir::       The path of the puppetserver var dir
-#                              type:string
 #
 # $puppetserver_dir::          The path of the puppetserver config dir
-#                              type:string
 #
 # $puppetserver_version::      The version of puppetserver 2 installed (or being installed)
 #                              Unfortunately, different versions of puppetserver need configuring differently,
 #                              and there's no easy way of determining which version is being installed.
 #                              Defaults to '2.3.1' but can be overriden if you're installing an older version.
-#                              type:string
 #
 # $max_active_instances::      Max number of active jruby instances. Defaults to
 #                              processor count
-#                              type:integer
 #
 # $max_requests_per_instance:: Max number of requests per jruby instance. Defaults to 0 (disabled)
-#                              type:integer
 #
 # $idle_timeout::              How long the server will wait for a response on an existing connection
-#                              type:integer
 #
 # $connect_timeout::           How long the server will wait for a response to a connection attempt
-#                              type:integer
 #
 # $ssl_protocols::             Array of SSL protocols to use.
 #                              Defaults to [ 'TLSv1.2' ]
-#                              type:array
 #
 # $ssl_chain_filepath::        Path to certificate chain for puppetserver
 #                              Defaults to "${ssl_dir}/ca/ca_crt.pem"
-#                              type:Stdlib::Absolutepath
 #
 # $cipher_suites::             List of SSL ciphers to use in negotiation
 #                              Defaults to [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA',
 #                              'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA', ]
-#                              type:array
 #
 # $ruby_load_paths::           List of ruby paths
 #                              Defaults based on $::puppetversion
-#                              type:array
 #
 # $ca_client_whitelist::       The whitelist of client certificates that
 #                              can query the certificate-status endpoint
 #                              Defaults to [ '127.0.0.1', '::1', $::ipaddress ]
-#                              type:array
 #
 # $admin_api_whitelist::       The whitelist of clients that
 #                              can query the puppet-admin-api endpoint
 #                              Defaults to [ '127.0.0.1', '::1', $::ipaddress ]
-#                              type:array
 #
 # $enable_ruby_profiler::      Should the puppetserver ruby profiler be enabled?
 #                              Defaults to false
-#                              type:boolean
 #
 # $ca_auth_required::          Whether client certificates are needed to access the puppet-admin api
 #                              Defaults to true
-#                              type:boolean
 #
 # $use_legacy_auth_conf::      Should the puppetserver use the legacy puppet auth.conf?
 #                              Defaults to false (the puppetserver will use its own conf.d/auth.conf)
-#                              type:boolean
 #
 # $allow_header_cert_info::    Allow client authentication over HTTP Headers
 #                              Defaults to false, is also activated by the $http setting
-#                              type:Boolean
-
-
+#
 class puppet::server(
-  $autosign                        = $::puppet::autosign,
-  $autosign_entries                = $::puppet::autosign_entries,
-  $autosign_mode                   = $::puppet::autosign_mode,
-  $autosign_content                = $::puppet::autosign_content,
-  $hiera_config                    = $::puppet::hiera_config,
-  $admin_api_whitelist             = $::puppet::server_admin_api_whitelist,
-  $user                            = $::puppet::server_user,
-  $group                           = $::puppet::server_group,
-  $dir                             = $::puppet::server_dir,
-  $codedir                         = $::puppet::codedir,
-  $port                            = $::puppet::server_port,
-  $ip                              = $::puppet::server_ip,
-  $ca                              = $::puppet::server_ca,
-  $ca_crl_filepath                 = $::puppet::ca_crl_filepath,
-  $ca_crl_sync                     = $::puppet::server_ca_crl_sync,
-  $crl_enable                      = $::puppet::server_crl_enable,
-  $ca_auth_required                = $::puppet::server_ca_auth_required,
-  $ca_client_whitelist             = $::puppet::server_ca_client_whitelist,
-  $http                            = $::puppet::server_http,
-  $http_port                       = $::puppet::server_http_port,
-  $http_allow                      = $::puppet::server_http_allow,
-  $reports                         = $::puppet::server_reports,
-  $implementation                  = $::puppet::server_implementation,
-  $passenger                       = $::puppet::server_passenger,
-  $puppetserver_vardir             = $::puppet::server_puppetserver_vardir,
-  $puppetserver_rundir             = $::puppet::server_puppetserver_rundir,
-  $puppetserver_logdir             = $::puppet::server_puppetserver_logdir,
-  $puppetserver_dir                = $::puppet::server_puppetserver_dir,
-  $puppetserver_version            = $::puppet::server_puppetserver_version,
-  $service_fallback                = $::puppet::server_service_fallback,
-  $passenger_min_instances         = $::puppet::server_passenger_min_instances,
-  $passenger_pre_start             = $::puppet::server_passenger_pre_start,
-  $passenger_ruby                  = $::puppet::server_passenger_ruby,
-  $httpd_service                   = $::puppet::server_httpd_service,
-  $external_nodes                  = $::puppet::server_external_nodes,
-  $cipher_suites                   = $::puppet::server_cipher_suites,
-  $config_version                  = $::puppet::server_config_version,
-  $connect_timeout                 = $::puppet::server_connect_timeout,
-  $git_repo                        = $::puppet::server_git_repo,
-  $dynamic_environments            = $::puppet::server_dynamic_environments,
-  $directory_environments          = $::puppet::server_directory_environments,
-  $default_manifest                = $::puppet::server_default_manifest,
-  $default_manifest_path           = $::puppet::server_default_manifest_path,
-  $default_manifest_content        = $::puppet::server_default_manifest_content,
-  $enable_ruby_profiler            = $::puppet::server_enable_ruby_profiler,
-  $environments                    = $::puppet::server_environments,
-  $environments_owner              = $::puppet::server_environments_owner,
-  $environments_group              = $::puppet::server_environments_group,
-  $environments_mode               = $::puppet::server_environments_mode,
-  $envs_dir                        = $::puppet::server_envs_dir,
-  $envs_target                     = $::puppet::server_envs_target,
-  $common_modules_path             = $::puppet::server_common_modules_path,
-  $git_repo_mode                   = $::puppet::server_git_repo_mode,
-  $git_repo_path                   = $::puppet::server_git_repo_path,
-  $git_repo_group                  = $::puppet::server_git_repo_group,
-  $git_repo_user                   = $::puppet::server_git_repo_user,
-  $git_branch_map                  = $::puppet::server_git_branch_map,
-  $idle_timeout                    = $::puppet::server_idle_timeout,
-  $post_hook_content               = $::puppet::server_post_hook_content,
-  $post_hook_name                  = $::puppet::server_post_hook_name,
-  $storeconfigs_backend            = $::puppet::server_storeconfigs_backend,
-  $app_root                        = $::puppet::server_app_root,
-  $ruby_load_paths                 = $::puppet::server_ruby_load_paths,
-  $ssl_dir                         = $::puppet::server_ssl_dir,
-  $ssl_dir_manage                  = $::puppet::server_ssl_dir_manage,
-  $ssl_key_manage                  = $::puppet::server_ssl_key_manage,
-  $ssl_protocols                   = $::puppet::server_ssl_protocols,
-  $ssl_chain_filepath              = $::puppet::server_ssl_chain_filepath,
-  $package                         = $::puppet::server_package,
-  $version                         = $::puppet::server_version,
-  $certname                        = $::puppet::server_certname,
-  $enc_api                         = $::puppet::server_enc_api,
-  $report_api                      = $::puppet::server_report_api,
-  $request_timeout                 = $::puppet::server_request_timeout,
-  $ca_proxy                        = $::puppet::server_ca_proxy,
-  $strict_variables                = $::puppet::server_strict_variables,
-  $additional_settings             = $::puppet::server_additional_settings,
-  $rack_arguments                  = $::puppet::server_rack_arguments,
-  $foreman                         = $::puppet::server_foreman,
-  $foreman_url                     = $::puppet::server_foreman_url,
-  $foreman_ssl_ca                  = $::puppet::server_foreman_ssl_ca,
-  $foreman_ssl_cert                = $::puppet::server_foreman_ssl_cert,
-  $foreman_ssl_key                 = $::puppet::server_foreman_ssl_key,
-  $server_foreman_facts            = $::puppet::server_foreman_facts,
-  $puppet_basedir                  = $::puppet::server_puppet_basedir,
-  $puppetdb_host                   = $::puppet::server_puppetdb_host,
-  $puppetdb_port                   = $::puppet::server_puppetdb_port,
-  $puppetdb_swf                    = $::puppet::server_puppetdb_swf,
-  $parser                          = $::puppet::server_parser,
-  $environment_timeout             = $::puppet::server_environment_timeout,
-  $jvm_java_bin                    = $::puppet::server_jvm_java_bin,
-  $jvm_config                      = $::puppet::server_jvm_config,
-  $jvm_min_heap_size               = $::puppet::server_jvm_min_heap_size,
-  $jvm_max_heap_size               = $::puppet::server_jvm_max_heap_size,
-  $jvm_extra_args                  = $::puppet::server_jvm_extra_args,
-  $jruby_gem_home                  = $::puppet::server_jruby_gem_home,
-  $max_active_instances            = $::puppet::server_max_active_instances,
-  $max_requests_per_instance       = $::puppet::server_max_requests_per_instance,
-  $use_legacy_auth_conf            = $::puppet::server_use_legacy_auth_conf,
-  $check_for_updates               = $::puppet::server_check_for_updates,
-  $environment_class_cache_enabled = $::puppet::server_environment_class_cache_enabled,
-  $allow_header_cert_info          = $::puppet::server_allow_header_cert_info,
+  Variant[Boolean, Stdlib::Absolutepath] $autosign = $::puppet::autosign,
+  Array[String] $autosign_entries = $::puppet::autosign_entries,
+  Pattern[/^[0-9]{3,4}$/] $autosign_mode = $::puppet::autosign_mode,
+  Optional[String] $autosign_content = $::puppet::autosign_content,
+  String $hiera_config = $::puppet::hiera_config,
+  Array[String] $admin_api_whitelist = $::puppet::server_admin_api_whitelist,
+  String $user = $::puppet::server_user,
+  String $group = $::puppet::server_group,
+  String $dir = $::puppet::server_dir,
+  Stdlib::Absolutepath $codedir = $::puppet::codedir,
+  Integer $port = $::puppet::server_port,
+  String $ip = $::puppet::server_ip,
+  Boolean $ca = $::puppet::server_ca,
+  Optional[String] $ca_crl_filepath = $::puppet::ca_crl_filepath,
+  Boolean $ca_crl_sync = $::puppet::server_ca_crl_sync,
+  Optional[Boolean] $crl_enable = $::puppet::server_crl_enable,
+  Boolean $ca_auth_required = $::puppet::server_ca_auth_required,
+  Array[String] $ca_client_whitelist = $::puppet::server_ca_client_whitelist,
+  Boolean $http = $::puppet::server_http,
+  Integer $http_port = $::puppet::server_http_port,
+  Array[String] $http_allow = $::puppet::server_http_allow,
+  String $reports = $::puppet::server_reports,
+  Enum['master', 'puppetserver'] $implementation = $::puppet::server_implementation,
+  Boolean $passenger = $::puppet::server_passenger,
+  Stdlib::Absolutepath $puppetserver_vardir = $::puppet::server_puppetserver_vardir,
+  Optional[Stdlib::Absolutepath] $puppetserver_rundir = $::puppet::server_puppetserver_rundir,
+  Optional[Stdlib::Absolutepath] $puppetserver_logdir = $::puppet::server_puppetserver_logdir,
+  Stdlib::Absolutepath $puppetserver_dir = $::puppet::server_puppetserver_dir,
+  Pattern[/^[0-9\.]+$/] $puppetserver_version = $::puppet::server_puppetserver_version,
+  Boolean $service_fallback = $::puppet::server_service_fallback,
+  Integer[0] $passenger_min_instances = $::puppet::server_passenger_min_instances,
+  Boolean $passenger_pre_start = $::puppet::server_passenger_pre_start,
+  Optional[String] $passenger_ruby = $::puppet::server_passenger_ruby,
+  String $httpd_service = $::puppet::server_httpd_service,
+  Variant[Undef, String[0], Stdlib::Absolutepath] $external_nodes = $::puppet::server_external_nodes,
+  Array[String] $cipher_suites = $::puppet::server_cipher_suites,
+  Optional[String] $config_version = $::puppet::server_config_version,
+  Integer[0] $connect_timeout = $::puppet::server_connect_timeout,
+  Boolean $git_repo = $::puppet::server_git_repo,
+  Boolean $dynamic_environments = $::puppet::server_dynamic_environments,
+  Boolean $directory_environments = $::puppet::server_directory_environments,
+  Boolean $default_manifest = $::puppet::server_default_manifest,
+  Stdlib::Absolutepath $default_manifest_path = $::puppet::server_default_manifest_path,
+  String $default_manifest_content = $::puppet::server_default_manifest_content,
+  Boolean $enable_ruby_profiler = $::puppet::server_enable_ruby_profiler,
+  Array[String] $environments = $::puppet::server_environments,
+  String $environments_owner = $::puppet::server_environments_owner,
+  Optional[String] $environments_group = $::puppet::server_environments_group,
+  Pattern[/^[0-9]{3,4}$/] $environments_mode = $::puppet::server_environments_mode,
+  Stdlib::Absolutepath $envs_dir = $::puppet::server_envs_dir,
+  Optional[Stdlib::Absolutepath] $envs_target = $::puppet::server_envs_target,
+  Variant[Undef, String[0], Array[Stdlib::Absolutepath]] $common_modules_path = $::puppet::server_common_modules_path,
+  Pattern[/^[0-9]{3,4}$/] $git_repo_mode = $::puppet::server_git_repo_mode,
+  Stdlib::Absolutepath $git_repo_path = $::puppet::server_git_repo_path,
+  String $git_repo_group = $::puppet::server_git_repo_group,
+  String $git_repo_user = $::puppet::server_git_repo_user,
+  Hash[String, String] $git_branch_map = $::puppet::server_git_branch_map,
+  Integer[0] $idle_timeout = $::puppet::server_idle_timeout,
+  String $post_hook_content = $::puppet::server_post_hook_content,
+  String $post_hook_name = $::puppet::server_post_hook_name,
+  Variant[Undef, Boolean, Enum['active_record', 'puppetdb']] $storeconfigs_backend = $::puppet::server_storeconfigs_backend,
+  Stdlib::Absolutepath $app_root = $::puppet::server_app_root,
+  Array[Stdlib::Absolutepath] $ruby_load_paths = $::puppet::server_ruby_load_paths,
+  Stdlib::Absolutepath $ssl_dir = $::puppet::server_ssl_dir,
+  Boolean $ssl_dir_manage = $::puppet::server_ssl_dir_manage,
+  Boolean $ssl_key_manage = $::puppet::server_ssl_key_manage,
+  Array[String] $ssl_protocols = $::puppet::server_ssl_protocols,
+  Optional[Stdlib::Absolutepath] $ssl_chain_filepath = $::puppet::server_ssl_chain_filepath,
+  Optional[Variant[String, Array[String]]] $package = $::puppet::server_package,
+  Optional[String] $version = $::puppet::server_version,
+  String $certname = $::puppet::server_certname,
+  Enum['v2', 'v1'] $enc_api = $::puppet::server_enc_api,
+  Enum['v2', 'v1'] $report_api = $::puppet::server_report_api,
+  Integer[0] $request_timeout = $::puppet::server_request_timeout,
+  Optional[String] $ca_proxy = $::puppet::server_ca_proxy,
+  Boolean $strict_variables = $::puppet::server_strict_variables,
+  Hash[String, Data] $additional_settings = $::puppet::server_additional_settings,
+  Array[String] $rack_arguments = $::puppet::server_rack_arguments,
+  Boolean $foreman = $::puppet::server_foreman,
+  Stdlib::HTTPUrl $foreman_url = $::puppet::server_foreman_url,
+  Optional[Stdlib::Absolutepath] $foreman_ssl_ca = $::puppet::server_foreman_ssl_ca,
+  Optional[Stdlib::Absolutepath] $foreman_ssl_cert = $::puppet::server_foreman_ssl_cert,
+  Optional[Stdlib::Absolutepath] $foreman_ssl_key = $::puppet::server_foreman_ssl_key,
+  Boolean $server_foreman_facts = $::puppet::server_foreman_facts,
+  Optional[Stdlib::Absolutepath] $puppet_basedir = $::puppet::server_puppet_basedir,
+  Optional[String] $puppetdb_host = $::puppet::server_puppetdb_host,
+  Integer[0, 65535] $puppetdb_port = $::puppet::server_puppetdb_port,
+  Boolean $puppetdb_swf = $::puppet::server_puppetdb_swf,
+  Enum['current', 'future'] $parser = $::puppet::server_parser,
+  Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]] $environment_timeout = $::puppet::server_environment_timeout,
+  String $jvm_java_bin = $::puppet::server_jvm_java_bin,
+  String $jvm_config = $::puppet::server_jvm_config,
+  String $jvm_min_heap_size = $::puppet::server_jvm_min_heap_size,
+  String $jvm_max_heap_size = $::puppet::server_jvm_max_heap_size,
+  String $jvm_extra_args = $::puppet::server_jvm_extra_args,
+  String $jruby_gem_home = $::puppet::server_jruby_gem_home,
+  Integer[1] $max_active_instances = $::puppet::server_max_active_instances,
+  Integer[0] $max_requests_per_instance = $::puppet::server_max_requests_per_instance,
+  Boolean $use_legacy_auth_conf = $::puppet::server_use_legacy_auth_conf,
+  Boolean $check_for_updates = $::puppet::server_check_for_updates,
+  Boolean $environment_class_cache_enabled = $::puppet::server_environment_class_cache_enabled,
+  Boolean $allow_header_cert_info = $::puppet::server_allow_header_cert_info,
 ) {
 
   validate_bool($ca)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -324,7 +324,7 @@ class puppet::server(
   Optional[Stdlib::Absolutepath] $puppetserver_rundir = $::puppet::server_puppetserver_rundir,
   Optional[Stdlib::Absolutepath] $puppetserver_logdir = $::puppet::server_puppetserver_logdir,
   Stdlib::Absolutepath $puppetserver_dir = $::puppet::server_puppetserver_dir,
-  Pattern[/^[0-9\.]+$/] $puppetserver_version = $::puppet::server_puppetserver_version,
+  Pattern[/^[\d]\.[\d]+\.[\d]+$/] $puppetserver_version = $::puppet::server_puppetserver_version,
   Boolean $service_fallback = $::puppet::server_service_fallback,
   Integer[0] $passenger_min_instances = $::puppet::server_passenger_min_instances,
   Boolean $passenger_pre_start = $::puppet::server_passenger_pre_start,
@@ -388,10 +388,10 @@ class puppet::server(
   Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]] $environment_timeout = $::puppet::server_environment_timeout,
   String $jvm_java_bin = $::puppet::server_jvm_java_bin,
   String $jvm_config = $::puppet::server_jvm_config,
-  String $jvm_min_heap_size = $::puppet::server_jvm_min_heap_size,
-  String $jvm_max_heap_size = $::puppet::server_jvm_max_heap_size,
+  Pattern[/^[0-9]+[kKmMgG]$/] $jvm_min_heap_size = $::puppet::server_jvm_min_heap_size,
+  Pattern[/^[0-9]+[kKmMgG]$/] $jvm_max_heap_size = $::puppet::server_jvm_max_heap_size,
   String $jvm_extra_args = $::puppet::server_jvm_extra_args,
-  String $jruby_gem_home = $::puppet::server_jruby_gem_home,
+  Optional[Stdlib::Absolutepath] $jruby_gem_home = $::puppet::server_jruby_gem_home,
   Integer[1] $max_active_instances = $::puppet::server_max_active_instances,
   Integer[0] $max_requests_per_instance = $::puppet::server_max_requests_per_instance,
   Boolean $use_legacy_auth_conf = $::puppet::server_use_legacy_auth_conf,
@@ -399,89 +399,11 @@ class puppet::server(
   Boolean $environment_class_cache_enabled = $::puppet::server_environment_class_cache_enabled,
   Boolean $allow_header_cert_info = $::puppet::server_allow_header_cert_info,
 ) {
-
-  validate_bool($ca)
-  validate_bool($http)
-  validate_bool($passenger)
-  validate_bool($git_repo)
-  validate_bool($service_fallback)
-  validate_bool($server_foreman_facts)
-  validate_bool($strict_variables)
-  validate_bool($foreman)
-  validate_bool($puppetdb_swf)
-  validate_bool($default_manifest)
-  validate_bool($ssl_dir_manage)
-  validate_bool($ssl_key_manage)
-  validate_bool($passenger_pre_start)
-  validate_integer($passenger_min_instances)
-
-  validate_hash($additional_settings)
-
-  if $default_manifest {
-    validate_absolute_path($default_manifest_path)
-    validate_string($default_manifest_content)
-  }
-
-  validate_string($hiera_config)
-  validate_string($external_nodes)
-  if $ca_proxy {
-    validate_string($ca_proxy)
-  }
-  if $puppetdb_host {
-    validate_string($puppetdb_host)
-  }
-
-  if $http {
-    validate_array($http_allow)
-  }
-
-  if ! is_bool($autosign) {
-    validate_absolute_path($autosign)
-    validate_string($autosign_mode)
-    validate_array($autosign_entries)
-  }
-
-  if $autosign_content {
-    validate_string($autosign_content)
-  }
-
-  validate_array($rack_arguments)
-
-  validate_re($implementation, '^(master|puppetserver)$')
-  validate_re($parser, '^(current|future)$')
-
-  if $environment_timeout {
-    validate_re($environment_timeout, '^(unlimited|0|[0-9]+[smh]{1})$')
-  }
-
-  if $implementation == 'puppetserver' {
-    validate_re($jvm_min_heap_size, '^[0-9]+[kKmMgG]$')
-    validate_re($jvm_max_heap_size, '^[0-9]+[kKmMgG]$')
-    validate_absolute_path($puppetserver_dir)
-    validate_absolute_path($puppetserver_vardir)
-    validate_absolute_path($jruby_gem_home)
-    validate_integer($max_active_instances)
-    validate_integer($max_requests_per_instance)
-    validate_integer($idle_timeout)
-    validate_integer($connect_timeout)
-    validate_array($ssl_protocols)
-    validate_array($cipher_suites)
-    validate_array($ruby_load_paths)
-    validate_array($ca_client_whitelist)
-    validate_array($admin_api_whitelist)
-    validate_bool($enable_ruby_profiler)
-    validate_bool($ca_auth_required)
-    validate_bool($use_legacy_auth_conf)
-    validate_re($puppetserver_version, '^[\d]\.[\d]+\.[\d]+$')
-    validate_bool($environment_class_cache_enabled)
-    validate_bool($allow_header_cert_info)
-  } else {
-    if $ip != $puppet::params::ip {
-      notify {
-        'ip_not_supported':
-          message  => "Bind IP address is unsupported for the ${implementation} implementation.",
-          loglevel => 'warning',
-      }
+  if $implementation == 'master' and $ip != $puppet::params::ip {
+    notify {
+      'ip_not_supported':
+        message  => "Bind IP address is unsupported for the ${implementation} implementation.",
+        loglevel => 'warning',
     }
   }
 

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -7,19 +7,16 @@
 # $app_root::      Rack application top-level directory
 #
 # $puppetmaster::  Whether to start/stop the (Ruby) puppetmaster service
-#                  type:boolean
 #
 # $puppetserver::  Whether to start/stop the (JVM) puppetserver service
-#                  type:boolean
 #
 # $rack::          Whether to manage restarts for the Rack-based puppetmaster service
-#                  type:boolean
 #
 class puppet::server::service(
-  $app_root     = undef,
-  $puppetmaster = undef,
-  $puppetserver = undef,
-  $rack         = undef,
+  Optional[Stdlib::Absolutepath] $app_root = undef,
+  Optional[Boolean] $puppetmaster = undef,
+  Optional[Boolean] $puppetserver = undef,
+  Optional[Boolean] $rack = undef,
 ) {
   if $puppetmaster and $puppetserver {
     fail('Both puppetmaster and puppetserver cannot be enabled simultaneously')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "theforeman-puppet",
-  "version": "7.1.2",
+  "version": "8.0.0",
   "author": "theforeman",
   "summary": "Puppet agent and server configuration",
   "license": "GPL-3.0+",
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.2.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 5.0.0"
     },
     {
       "name": "puppet/extlib",
@@ -35,7 +35,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.6.0 < 5.0.0"
+      "version_requirement": ">= 4.6.1 < 5.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -117,14 +117,6 @@ describe 'puppet::agent::service' do
           end
         end
       end
-
-      describe 'when runmode => foo' do
-        let :pre_condition do
-          "class {'puppet': agent => true, runmode => 'foo'}"
-        end
-
-        it { should raise_error(Puppet::Error, /Runmode of foo not supported by puppet::agent::config!/) }
-      end
     end
   end
 end

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -87,9 +87,9 @@ describe 'puppet' do
         }
       end
 
-      describe 'with empty ca_port' do
+      describe 'with undef ca_port' do
         let :params do {
-          :ca_port => '',
+          :ca_port => :undef,
         } end
 
         it {
@@ -99,7 +99,7 @@ describe 'puppet' do
 
       describe 'with ca_port' do
         let :params do {
-          :ca_port => '8140',
+          :ca_port => 8140,
         } end
 
         it {
@@ -116,28 +116,6 @@ describe 'puppet' do
           should contain_puppet__config__main('ca_port').with({'value' => 8140})
         }
       end
-
-      # Test validate_array parameters
-      [
-        :dns_alt_names,
-      ].each do |p|
-        context "when #{p} => 'foo'" do
-          let(:params) {{ p => 'foo' }}
-          it { should raise_error(Puppet::Error, /is not an Array/) }
-        end
-      end
-
-      describe 'when directories are not absolute paths' do
-        [
-          'dir', 'logdir', 'rundir'
-        ].each do |d|
-          context "when #{d} => './somedir'" do
-            let(:params) {{ d => './somedir'}}
-            it { should raise_error(Puppet::Error, /is not an absolute path/) }
-          end
-        end
-      end
-
     end
   end
 end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -177,27 +177,6 @@ describe 'puppet::server' do
           it { should contain_package(server_package) }
         end
       end
-
-      describe 'when an invalid jvm size value is given' do
-        context "when server_jvm_min_heap_size => 'x4m'" do
-          let :pre_condition do
-            "class { 'puppet': server => true,
-                               server_implementation => 'puppetserver',
-                               server_jvm_min_heap_size => 'x4m',
-                               server_jvm_max_heap_size => '2G' }"
-          end
-          it { should raise_error(Puppet::Error, /does not match "\^\[0-9\]\+\[kKmMgG\]\$"/) }
-        end
-        context "when server_jvm_max_heap_size => 'x4m'" do
-          let :pre_condition do
-            "class { 'puppet': server => true,
-                               server_implementation => 'puppetserver',
-                               server_jvm_min_heap_size => '2G',
-                               server_jvm_max_heap_size => 'x4m' }"
-          end
-          it { should raise_error(Puppet::Error, /does not match "\^\[0-9\]\+\[kKmMgG\]\$"/) }
-        end
-      end
     end
   end
 end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -141,13 +141,6 @@ describe 'puppet::server' do
         it { should contain_package('puppetserver') }
       end
 
-      describe 'with unknown server_implementation' do
-        let :pre_condition do
-          "class {'puppet': server => true, server_implementation => 'golang'}"
-        end
-        it { should raise_error(Puppet::Error, /"golang" does not match/) }
-      end
-
       describe "when manage_packages => false" do
         let :pre_condition do
           "class { 'puppet': server => true, manage_packages => false,
@@ -203,16 +196,6 @@ describe 'puppet::server' do
                                server_jvm_max_heap_size => 'x4m' }"
           end
           it { should raise_error(Puppet::Error, /does not match "\^\[0-9\]\+\[kKmMgG\]\$"/) }
-        end
-      end
-
-      describe 'when an invalid hiera_config is given' do
-        context "when hiera_config => ['foo']" do
-          let :pre_condition do
-            "class { 'puppet': server => true,
-                               hiera_config => ['foo'] }"
-          end
-          it { should raise_error(Puppet::Error, /is not a string/) }
         end
       end
     end


### PR DESCRIPTION
1. Moves existing Puppet 4 data types from the class/parameter docs into the class parameters themselves.
1. Converts some older Kafo-only data types into the Puppet 4 style and moves them into the class parameters.
1. Removes the validate_* family of functions, updates a few instances where they had better validation than the data types.

Replaces #485 by adding data types to every parameter.