### PR TITLE
Add autosign_source, which may be used instead of autosign_content

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,10 @@
 #                                           template('another_module/autosign.sh.erb')
 #                                           type:Optional[String]
 #
+# $autosign_source::                        If set, use this as the source for the autosign file,
+#                                           instead of autosign_content.
+#                                           type:Optional[String]
+#
 # $usecacheonfailure::                      Switch to enable use of cached catalog on
 #                                           failure of run.
 #                                           type:Boolean
@@ -689,6 +693,7 @@ class puppet (
   $autosign_entries                       = $puppet::params::autosign_entries,
   $autosign_mode                          = $puppet::params::autosign_mode,
   $autosign_content                       = $puppet::params::autosign_content,
+  $autosign_source                        = $puppet::params::autosign_source,
   $runinterval                            = $puppet::params::runinterval,
   $usecacheonfailure                      = $puppet::params::usecacheonfailure,
   $runmode                                = $puppet::params::runmode,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -173,6 +173,7 @@ class puppet::params {
   $autosign_entries = []
   $autosign_mode    = '0664'
   $autosign_content = undef
+  $autosign_source  = undef
 
   $puppet_cmd = "${bindir}/puppet"
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -26,6 +26,10 @@
 #                              template('another_module/autosign.sh.erb')
 #                              type:Optional[String]
 #
+# $autosign_source::           If set, use this as the source for the autosign file,
+#                              instead of autosign_content.
+#                              type:Optional[String]
+#
 # $hiera_config::              The hiera configuration file.
 #                              type:string
 #
@@ -398,6 +402,7 @@ class puppet::server(
   $autosign_entries                = $::puppet::autosign_entries,
   $autosign_mode                   = $::puppet::autosign_mode,
   $autosign_content                = $::puppet::autosign_content,
+  $autosign_source                 = $::puppet::autosign_source,
   $hiera_config                    = $::puppet::hiera_config,
   $admin_api_whitelist             = $::puppet::server_admin_api_whitelist,
   $user                            = $::puppet::server_user,
@@ -541,6 +546,10 @@ class puppet::server(
 
   if $autosign_content {
     validate_string($autosign_content)
+  }
+
+  if $autosign_source {
+    validate_string($autosign_source)
   }
 
   validate_array($rack_arguments)

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -184,9 +184,9 @@ class puppet::server::config inherits puppet::config {
 
   # autosign file
   if $::puppet::server_ca and ! is_bool($puppet::server::autosign){
-    if $::puppet::server::autosign_content {
+    if $::puppet::server::autosign_content or $::puppet::server::autosign_source {
       if !empty($::puppet::server::autosign_entries) {
-        fail('Cannot set both autosign_content and autosign_entries')
+        fail('Cannot set both autosign_content/autosign_source and autosign_entries')
       }
       $autosign_content = $::puppet::server::autosign_content
     } elsif !empty($::puppet::server::autosign_entries) {
@@ -200,6 +200,7 @@ class puppet::server::config inherits puppet::config {
       group   => $::puppet::server::group,
       mode    => $::puppet::server::autosign_mode,
       content => $autosign_content,
+      source  => $::puppet::server::autosign_source,
     }
   }
 

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -266,11 +266,11 @@ describe 'puppet::server::config' do
       end
 
 
-      describe "when autosign_source => set to foo.bar and and autosign_entries set to ['foo.bar']=> true" do
+      describe "when autosign_source => set to puppet:///foo/bar and and autosign_entries set to ['foo.bar']=> true" do
         let :pre_condition do
           "class {'puppet':
               server           => true,
-              autosign_source  => 'foo.bar',
+              autosign_source  => 'puppet:///foo/bar',
               autosign_entries => ['foo.bar'],
            }"
         end
@@ -279,7 +279,7 @@ describe 'puppet::server::config' do
       end
 
 
-      describe "when autosign => #{confdir}/custom_autosign.sh, autosign_mode => 664 and autosign_content set to 'foo.bar'" do
+      describe "when autosign => #{confdir}/custom_autosign.sh, autosign_mode => 775 and autosign_content set to 'foo.bar'" do
         let :pre_condition do
           "class {'puppet':
               server           => true,
@@ -296,6 +296,26 @@ describe 'puppet::server::config' do
         it 'should contain custom_autosign.sh with content set' do
            should contain_file("#{confdir}/custom_autosign.sh")
            should contain_file("#{confdir}/custom_autosign.sh").with_content(/foo.bar/)
+        end
+      end
+
+      describe "when autosign => #{confdir}/custom_autosign.sh, autosign_mode => 775 and autosign_source set to 'puppet:///foo/bar'" do
+        let :pre_condition do
+          "class {'puppet':
+              server           => true,
+              autosign         => '#{confdir}/custom_autosign.sh',
+              autosign_mode    => '775',
+              autosign_source  => 'puppet:///foo/bar',
+           }"
+        end
+
+        it 'should contain puppet.conf [main] with autosign = /somedir/custom_autosign { mode = 775 }' do
+          should contain_puppet__config__master('autosign').with({'value' => "#{confdir}/custom_autosign.sh { mode = 775 }"})
+        end
+
+        it 'should contain custom_autosign.sh with content set' do
+           should contain_file("#{confdir}/custom_autosign.sh")
+           should contain_file("#{confdir}/custom_autosign.sh").with_source('puppet:///foo/bar')
         end
       end
 

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -262,7 +262,20 @@ describe 'puppet::server::config' do
            }"
         end
 
-        it { should raise_error(Puppet::Error, /Cannot set both autosign_content and autosign_entries/) }
+        it { should raise_error(Puppet::Error, /Cannot set both autosign_content\/autosign_source and autosign_entries/) }
+      end
+
+
+      describe "when autosign_source => set to foo.bar and and autosign_entries set to ['foo.bar']=> true" do
+        let :pre_condition do
+          "class {'puppet':
+              server           => true,
+              autosign_source  => 'foo.bar',
+              autosign_entries => ['foo.bar'],
+           }"
+        end
+
+        it { should raise_error(Puppet::Error, /Cannot set both autosign_content\/autosign_source and autosign_entries/) }
       end
 
 


### PR DESCRIPTION
autosign_content is nice, but very ugly if you only use hiera to pass parameters to classes.

This adds autosign_source, which can be used instead of autosign_content and does the obvious.