### PR TITLE
Add web_server_idle_timeout to puppetserver jetty configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -481,6 +481,11 @@
 #
 # $server_allow_header_cert_info::          Enable client authentication over HTTP Headers
 #                                           Defaults to false, is also activated by the $server_http setting
+#
+# $server_web_idle_timeout::                Time in ms that Jetty allows a socket to be idle, after processing has
+#                                           completed.
+#                                           Defaults to 30000, using the Jetty default of 30s
+#
 # === Usage:
 #
 # * Simple usage:
@@ -664,6 +669,7 @@ class puppet (
   Boolean $server_check_for_updates = $puppet::params::server_check_for_updates,
   Boolean $server_environment_class_cache_enabled = $puppet::params::server_environment_class_cache_enabled,
   Boolean $server_allow_header_cert_info = $puppet::params::server_allow_header_cert_info,
+  Integer[0] $server_web_idle_timeout = $puppet::params::server_web_idle_timeout,
 ) inherits puppet::params {
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -439,6 +439,7 @@ class puppet::params {
   $server_default_manifest_content        = '' # lint:ignore:empty_string_assignment
   $server_max_requests_per_instance       = 0
   $server_idle_timeout                    = 1200000
+  $server_web_idle_timeout                = 30000
   $server_connect_timeout                 = 120000
   $server_enable_ruby_profiler            = false
   $server_ca_auth_required                = true

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -265,6 +265,9 @@
 #
 # $connect_timeout::           How long the server will wait for a response to a connection attempt
 #
+# $web_idle_timeout::          Time in ms that Jetty allows a socket to be idle, after processing has completed.
+#                              Defaults to the Jetty default of 30s
+#
 # $ssl_protocols::             Array of SSL protocols to use.
 #                              Defaults to [ 'TLSv1.2' ]
 #
@@ -338,6 +341,7 @@ class puppet::server(
   Array[String] $cipher_suites = $::puppet::server_cipher_suites,
   Optional[String] $config_version = $::puppet::server_config_version,
   Integer[0] $connect_timeout = $::puppet::server_connect_timeout,
+  Integer[0] $web_idle_timeout = $puppet::server_web_idle_timeout,
   Boolean $git_repo = $::puppet::server_git_repo,
   Boolean $dynamic_environments = $::puppet::server_dynamic_environments,
   Boolean $directory_environments = $::puppet::server_directory_environments,

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -76,6 +76,7 @@ class puppet::server::puppetserver (
   $server_dir                             = $::puppet::server::dir,
   $codedir                                = $::puppet::server::codedir,
   $server_idle_timeout                    = $::puppet::server::idle_timeout,
+  $server_web_idle_timeout                = $::puppet::server::web_idle_timeout,
   $server_connect_timeout                 = $::puppet::server::connect_timeout,
   $server_enable_ruby_profiler            = $::puppet::server::enable_ruby_profiler,
   $server_ca_auth_required                = $::puppet::server::ca_auth_required,

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -49,6 +49,7 @@ describe 'puppet::server::puppetserver' do
         :server_dir                             => '/etc/puppetlabs/puppet',
         :codedir                                => '/etc/puppetlabs/code',
         :server_idle_timeout                    => 1200000,
+        :server_web_idle_timeout                => 30000,
         :server_connect_timeout                 => 120000,
         :server_enable_ruby_profiler            => false,
         :server_check_for_updates               => true,

--- a/templates/server/puppetserver/conf.d/webserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/webserver.conf.erb
@@ -16,4 +16,5 @@ webserver: {
 <%- if scope.lookupvar('puppet::server::ca') -%>
     ssl-cert-chain: <%= scope.lookupvar('puppet::server::ssl_chain') %>
 <%- end -%>
+    idle-timeout-milliseconds: <%= @server_web_idle_timeout %>
 }


### PR DESCRIPTION
This allows configuration of idle timeouts on the Jetty side. A reopening of #484 