### PR TITLE
add FreeBSD 11 to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -84,7 +84,8 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION
I deployed multiple boxes with freeBSD 11 + puppet agent. works
perfectly.