### PR TITLE
Order stopping of standalone master service before starting Apache

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -453,10 +453,11 @@ class puppet::server(
   class { '::puppet::server::install': }
   ~> class { '::puppet::server::config':  }
   ~> class { '::puppet::server::service':
-    app_root     => $app_root,
-    puppetmaster => $pm_service,
-    puppetserver => $ps_service,
-    rack         => $rack_service,
+    app_root      => $app_root,
+    httpd_service => $httpd_service,
+    puppetmaster  => $pm_service,
+    puppetserver  => $ps_service,
+    rack          => $rack_service,
   }
   -> Class['puppet::server']
 

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -52,6 +52,17 @@ describe 'puppet::server::service' do
             :enable => 'false',
           })
         end
+
+        describe 'and rack => true' do
+          let(:params) { {:puppetmaster => false, :rack => true} }
+          let(:pre_condition) { 'service { "httpd": }' }
+          it do
+            should contain_service(master_service).with({
+              :ensure => 'stopped',
+              :enable => 'false',
+            }).that_comes_before('Service[httpd]')
+          end
+        end
       end
 
       describe 'when puppetserver => false' do
@@ -61,6 +72,17 @@ describe 'puppet::server::service' do
             :ensure => 'stopped',
             :enable => 'false',
           })
+        end
+
+        describe 'and rack => true' do
+          let(:params) { {:puppetserver => false, :rack => true} }
+          let(:pre_condition) { 'service { "httpd": }' }
+          it do
+            should contain_service('puppetserver').with({
+              :ensure => 'stopped',
+              :enable => 'false',
+            }).that_comes_before('Service[httpd]')
+          end
         end
       end
 

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -31,6 +31,7 @@ describe 'puppet::server' do
             should contain_class('puppet::server::install')
             should contain_class('puppet::server::config')
             should contain_class('puppet::server::service').
+              with_httpd_service('httpd').
               with_puppetmaster(false).
               with_puppetserver(nil).
               with_rack(true)


### PR DESCRIPTION
When configuring a Passenger-based Puppet master on Debian, installation
of the master package will usually start the service and listen on the
master port. Starting Apache then fails as the port's in use.

This change orders the standalone master resource (with `ensure =>
stopped`) before the Apache service.