### PR TITLE
Correctly configure the metrics endpoint in web-routes.conf for Puppet server >= 5.0.0

### DIFF
--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -487,6 +487,21 @@ describe 'puppet::server::puppetserver' do
         end
       end
 
+      describe 'metrics API endpoint' do
+        context 'when server_puppetserver_version >= 5.0.0' do
+          let(:params) do
+            default_params.merge({
+                                     :server_puppetserver_version => '5.0.0',
+                                     :server_puppetserver_dir => '/etc/custom/puppetserver',
+                                 })
+          end
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/web-routes.conf').
+              with_content(/^\s+"puppetlabs.trapperkeeper.services.metrics.metrics-service\/metrics-webservice": "\/metrics"/)
+          }
+        end
+      end
+
       describe 'product.conf' do
         context 'when server_puppetserver_version >= 2.7' do
           let(:params) do

--- a/templates/server/puppetserver/conf.d/web-routes.conf.erb
+++ b/templates/server/puppetserver/conf.d/web-routes.conf.erb
@@ -19,4 +19,9 @@ web-router-service: {
     # This controls the mount point for the status API
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
 <%- end -%>
+<%- if scope.function_versioncmp([@server_puppetserver_version, '5.0.0']) >= 0 -%>
+
+    # This controls the mount point for the metrics API
+    "puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice": "/metrics"
+<%- end -%>
 }


### PR DESCRIPTION
I thought I'd test the Puppet 5 nightly and it turns out that this module breaks the configuration because there is a new endpoint.

This PR fixes the issue, at least enough to allow puppetserver to start correctly. It does require configuring the puppet::server_puppetserver_version parameter to be '5.0.0' explicitly, but that's probably acceptable at this point.