### PR TITLE
Allow client_certname to be a boolean

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -8,7 +8,6 @@ class puppet::agent::config inherits puppet::config {
     'pluginsync':        value => $::puppet::pluginsync;
     'masterport':        value => $::puppet::port;
     'environment':       value => $::puppet::environment;
-    'certname':          value => $::puppet::client_certname;
     'listen':            value => $::puppet::listen;
     'splay':             value => $::puppet::splay;
     'splaylimit':        value => $::puppet::splaylimit;
@@ -18,17 +17,22 @@ class puppet::agent::config inherits puppet::config {
   }
   if $::puppet::configtimeout != undef {
     puppet::config::agent {
-      'configtimeout':     value => $::puppet::configtimeout;
+      'configtimeout':   value => $::puppet::configtimeout;
     }
   }
   if $::puppet::prerun_command {
     puppet::config::agent {
-      'prerun_command':    value => $::puppet::prerun_command;
+      'prerun_command':  value => $::puppet::prerun_command;
     }
   }
   if $::puppet::postrun_command {
     puppet::config::agent {
-      'postrun_command':   value => $::puppet::postrun_command;
+      'postrun_command': value => $::puppet::postrun_command;
+    }
+  }
+  if $::puppet::client_certname {
+    puppet::config::agent {
+      'certname':        value => $::puppet::client_certname;
     }
   }
 
@@ -39,7 +43,6 @@ class puppet::agent::config inherits puppet::config {
     hash     => $::puppet::agent_additional_settings,
     resource => '::puppet::config::agent',
   }
-
 
   if $::puppet::runmode == 'service' {
     $should_start = 'yes'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -565,7 +565,7 @@ class puppet (
   Array[String] $client_package = $puppet::params::client_package,
   Boolean $agent = $puppet::params::agent,
   Boolean $remove_lock = $puppet::params::remove_lock,
-  String $client_certname = $puppet::params::client_certname,
+  Variant[String, Boolean] $client_certname = $puppet::params::client_certname,
   Optional[String] $puppetmaster = $puppet::params::puppetmaster,
   String $systemd_unit_name = $puppet::params::systemd_unit_name,
   String $service_name = $puppet::params::service_name,

--- a/spec/classes/puppet_agent_config_spec.rb
+++ b/spec/classes/puppet_agent_config_spec.rb
@@ -27,6 +27,8 @@ describe 'puppet::agent::config' do
                with({})
           }
         end
+
+        it { should contain_puppet__config__agent('certname').with(facts[:certname]) }
       end
 
       context 'with runmode => cron', :unless => (facts[:osfamily] == 'Archlinux') do
@@ -68,6 +70,14 @@ describe 'puppet::agent::config' do
           }
           it { should_not contain_file('/var/lib/puppet/state/agent_disabled.lock') }
         end
+      end
+
+      context 'with client_certname => false' do
+        let :pre_condition do
+          'class { "::puppet": client_certname => false }'
+        end
+
+        it { should_not contain_puppet__config__agent('certname') }
       end
     end
   end


### PR DESCRIPTION
The purpose is to prevent setting of certname.  We use Puppet on systems where the root filesystem is often cloned from other systems and changing certname is cumbersome after a filesystem is cloned.

Default behavior is unchanged.