### PR TITLE
convert $::memorysize_mb when using facter 2.x

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -417,11 +417,16 @@ class puppet::params {
 
   # This is some very trivial "tuning". See the puppet reference:
   # https://docs.puppet.com/puppetserver/latest/tuning_guide.html
-  if 0 + $::memorysize_mb >= 2048 {
+  if $::memorysize_mb.is_a(String) {
+    $mem_in_mb = scanf($::memorysize_mb, '%i')[0]
+  } else {
+    $mem_in_mb = 0 + $::memorysize_mb
+  }
+  if $mem_in_mb >= 2048 {
     $server_jvm_min_heap_size = '2G'
     $server_jvm_max_heap_size = '2G'
     $server_max_active_instances = $::processorcount
-  } elsif 0 + $::memorysize_mb >= 1024 {
+  } elsif $mem_in_mb >= 1024 {
     $server_max_active_instances = 1
     $server_jvm_min_heap_size = '1G'
     $server_jvm_max_heap_size = '1G'


### PR DESCRIPTION
When using Puppet 4 with Facter 2 (mostly non-AIO built packages) the following Warning can be seen in the puppetserver log:
```
The string '994.95' was automatically coerced to the numerical value 994.95 at /etc/puppetlabs/code/environments/production/modules/puppet/manifests/params.pp:419:10
The string '994.95' was automatically coerced to the numerical value 994.95 at /etc/puppetlabs/code/environments/production/modules/puppet/manifests/params.pp:423:15
```