### PR TITLE
desupport Ubuntu/precise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,6 @@ gem 'beaker-puppet_install_helper', {"groups"=>["system_tests"]}
 gem 'metadata-json-lint'
 gem 'kafo_module_lint'
 gem 'rgen' # until https://tickets.puppetlabs.com/browse/PDOC-168 is resolved
+gem 'parallel_tests'
 
 # vim:ft=ruby

--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
         "14.04",
         "16.04"
       ]


### PR DESCRIPTION
Ubuntu/precise is EOL since 1st May 2017. This reduces the travis runtime hopefully enough to get under 50 minutes again.