### PR TITLE
Fix "No supported formats are acceptable (Accept: s, pson)" while bucketing from Puppet Agent v3

### DIFF
--- a/templates/server/config.ru.erb
+++ b/templates/server/config.ru.erb
@@ -79,9 +79,8 @@ class Puppet3Compat
       env['QUERY_STRING'] = Rack::Utils.build_query(@req.params)
     end
 
-    if @api =~ /^file_(content|bucket_file)/ && @req.get?
-      env["HTTP_ACCEPT"] = "binary"
-    elsif @api == "file_bucket_file" && (@req.post? || @req.put?)
+    env["HTTP_ACCEPT"] = env["HTTP_ACCEPT"].split(/\s*,\s*/).map { |a| a.sub(/^raw|s$/, 'binary') }.uniq.join(', ')
+    if @api == "file_bucket_file" && (@req.post? || @req.put?)
       env["CONTENT_TYPE"] = "application/octet-stream"
     end
 


### PR DESCRIPTION
See https://bugs.debian.org/869183