### PR TITLE
Add server_jvm_cli_args parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -391,7 +391,10 @@
 # $server_jvm_extra_args::                  Additional java options to pass through.
 #                                           This can be used for Java versions prior to
 #                                           Java 8 to specify the max perm space to use:
-#                                           For example: '-XX:MaxPermSpace=128m'.
+#                                           For example: '-XX:MaxPermSize=128m'.
+#
+# $server_jvm_cli_args::                    Java options to use when using puppetserver
+#                                           subcommands (eg puppetserver gem).
 #
 # $server_jruby_gem_home::                  Where jruby gems are located for puppetserver
 #
@@ -665,6 +668,7 @@ class puppet (
   Pattern[/^[0-9]+[kKmMgG]$/] $server_jvm_min_heap_size = $puppet::params::server_jvm_min_heap_size,
   Pattern[/^[0-9]+[kKmMgG]$/] $server_jvm_max_heap_size = $puppet::params::server_jvm_max_heap_size,
   String $server_jvm_extra_args = $puppet::params::server_jvm_extra_args,
+  Optional[String] $server_jvm_cli_args = $puppet::params::server_jvm_cli_args,
   Optional[Stdlib::Absolutepath] $server_jruby_gem_home = $puppet::params::server_jruby_gem_home,
   Integer[1] $server_max_active_instances = $puppet::params::server_max_active_instances,
   Integer[0] $server_max_requests_per_instance = $puppet::params::server_max_requests_per_instance,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -420,6 +420,8 @@ class puppet::params {
     $server_jvm_extra_args = '-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger'
   }
 
+  $server_jvm_cli_args = undef
+
   # This is some very trivial "tuning". See the puppet reference:
   # https://docs.puppet.com/puppetserver/latest/tuning_guide.html
   if $::memorysize_mb.is_a(String) {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -219,7 +219,10 @@
 # $jvm_extra_args::            Additional java options to pass through.
 #                              This can be used for Java versions prior to
 #                              Java 8 to specify the max perm space to use:
-#                              For example: '-XX:MaxPermSpace=128m'.
+#                              For example: '-XX:MaxPermSize=128m'.
+#
+# $jvm_cli_args::              Java options to use when using puppetserver
+#                              subcommands (eg puppetserver gem).
 #
 # $jruby_gem_home::            Where jruby gems are located for puppetserver
 #
@@ -402,6 +405,7 @@ class puppet::server(
   Pattern[/^[0-9]+[kKmMgG]$/] $jvm_min_heap_size = $::puppet::server_jvm_min_heap_size,
   Pattern[/^[0-9]+[kKmMgG]$/] $jvm_max_heap_size = $::puppet::server_jvm_max_heap_size,
   String $jvm_extra_args = $::puppet::server_jvm_extra_args,
+  Optional[String] $jvm_cli_args = $::puppet::server_jvm_cli_args,
   Optional[Stdlib::Absolutepath] $jruby_gem_home = $::puppet::server_jruby_gem_home,
   Integer[1] $max_active_instances = $::puppet::server_max_active_instances,
   Integer[0] $max_requests_per_instance = $::puppet::server_max_requests_per_instance,

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -25,6 +25,7 @@ describe 'puppet::server::puppetserver' do
         :jvm_min_heap_size                      => '2G',
         :jvm_max_heap_size                      => '2G',
         :jvm_extra_args                         => '',
+        :jvm_cli_args                           => false, # In reality defaults to undef
         :server_ca_auth_required                => true,
         :server_ca_client_whitelist             => [ 'localhost', 'puppetserver123.example.com' ],
         :server_admin_api_whitelist             => [ 'localhost', 'puppetserver123.example.com' ],
@@ -688,6 +689,27 @@ describe 'puppet::server::puppetserver' do
                   with_changes([
                     'set JAVA_ARGS \'"-Xms2G -Xmx2G -XX:foo=bar -XX:bar=foo"\'',
                     'set JAVA_BIN /usr/bin/java',
+                  ]).
+                  with_context('/files/etc/default/puppetserver').
+                  with_incl('/etc/default/puppetserver').
+                  with_lens('Shellvars.lns').
+                  with({})
+          }
+        end
+      end
+
+      describe 'with cli_args parameter' do
+        let :params do
+          default_params.merge({
+            :jvm_cli_args => '-Djava.io.tmpdir=/var/puppettmp',
+          })
+        end
+        if facts[:osfamily] != 'FreeBSD'
+          it { should contain_augeas('puppet::server::puppetserver::jvm').
+                  with_changes([
+                    'set JAVA_ARGS \'"-Xms2G -Xmx2G"\'',
+                    'set JAVA_BIN /usr/bin/java',
+                    'set JAVA_ARGS_CLI \'"-Djava.io.tmpdir=/var/puppettmp"\'',
                   ]).
                   with_context('/files/etc/default/puppetserver').
                   with_incl('/etc/default/puppetserver').


### PR DESCRIPTION
Sets the JAVA_ARGS_CLI variable in /etc/sysconfig/puppetserver
This environment variable gets used when `puppetserver gem` is run.

You might need to do this if, for example, your /tmp is mounted with
noexec and you're using the puppetserver_gem package provider...