### PR TITLE
Manage the puppet user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -326,6 +326,8 @@
 #
 # === Advanced server parameters:
 #
+# $server_manage_user::                     Whether to manage the server user resource
+#
 # $server_httpd_service::                   Apache/httpd service name to notify
 #                                           on configuration changes. Defaults
 #                                           to 'httpd' based on the default
@@ -583,6 +585,7 @@ class puppet (
   String $environment = $puppet::params::environment,
   Boolean $server = $puppet::params::server,
   Array[String] $server_admin_api_whitelist = $puppet::params::server_admin_api_whitelist,
+  Boolean $server_manage_user = $puppet::params::manage_user,
   String $server_user = $puppet::params::user,
   String $server_group = $puppet::params::group,
   String $server_dir = $puppet::params::dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class puppet::params {
 
   # Basic config
   $version             = 'present'
+  $manage_user         = true
   $user                = 'puppet'
   $group               = 'puppet'
   $ip                  = '0.0.0.0'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,6 +29,8 @@
 #
 # $hiera_config::              The hiera configuration file.
 #
+# $manage_user::               Whether to manage the puppet user resource
+#
 # $user::                      Name of the puppetmaster user.
 #
 # $group::                     Name of the puppetmaster group.
@@ -318,6 +320,7 @@ class puppet::server(
   Optional[String] $autosign_source = $::puppet::autosign_source,
   String $hiera_config = $::puppet::hiera_config,
   Array[String] $admin_api_whitelist = $::puppet::server_admin_api_whitelist,
+  Boolean $manage_user = $::puppet::server_manage_user,
   String $user = $::puppet::server_user,
   String $group = $::puppet::server_group,
   String $dir = $::puppet::server_dir,

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -409,6 +409,18 @@ describe 'puppet::server::config' do
           })
         end
 
+        it 'should create the puppet user' do
+          shell = case facts[:osfamily]
+                  when /^(FreeBSD|DragonFly)$/
+                    '/usr/local/bin/git-shell'
+                  else
+                    '/usr/bin/git-shell'
+                  end
+          should contain_user('puppet')
+            .with_shell(shell)
+            .that_requires('Class[git]')
+        end
+
         it 'should create the git repo' do
           should contain_file(vardir).with({
             :ensure => 'directory',

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -36,6 +36,7 @@ describe 'puppet::server' do
               with_puppetserver(nil).
               with_rack(true)
           end
+          it { should contain_user('puppet') }
           it { should_not contain_notify('ip_not_supported') }
           # No server_package for FreeBSD
           if not facts[:osfamily] == 'FreeBSD'


### PR DESCRIPTION
The use case is that puppet-certs deploys certificates with the owner puppet and now contains a require => Class['puppet::server::install'] but if the User resource is managed then puppet can autorequire it and there is less coupling between modules.