### PR TITLE
Fix `client_package` puppet type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -566,7 +566,7 @@ class puppet (
   String $auth_template = $puppet::params::auth_template,
   Boolean $allow_any_crl_auth = $puppet::params::allow_any_crl_auth,
   Array[String] $auth_allowed = $puppet::params::auth_allowed,
-  Array[String] $client_package = $puppet::params::client_package,
+  Variant[String, Array[String]] $client_package = $puppet::params::client_package,
   Boolean $agent = $puppet::params::agent,
   Boolean $remove_lock = $puppet::params::remove_lock,
   Variant[String, Boolean] $client_certname = $puppet::params::client_certname,


### PR DESCRIPTION
This parameter gets passed to a Package resource.  It should accept a
string or an array of strings.

See https://github.com/theforeman/puppet-puppet/pull/498#discussion_r129916260