### PR TITLE
update common_modules_path to work in the server::config subclass

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -263,8 +263,8 @@ class puppet::server::config inherits puppet::config {
       ensure => directory,
     }
 
-    if $puppet::server_common_modules_path and $puppet::server_common_modules_path != '' {
-      file { $puppet::server_common_modules_path:
+    if $::puppet::server::common_modules_path and $::puppet::server::common_modules_path != '' {
+      file { $::puppet::server::common_modules_path:
         ensure => directory,
         owner  => $::puppet::server_environments_owner,
         group  => $::puppet::server_environments_group,


### PR DESCRIPTION
This allows defining `puppet::server::common_modules_path` to work the same as  `puppet::server_common_modules_path`  in the same fashion as the rest of the class parameters for `puppet::server`.

This fix addresses r10k purging $envpath of non-branch directories then puppet creating $envpath/common on each run triggering a refresh of the puppetserver service.