### PR TITLE
Add `puppetserver_trusted_agents` parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -493,6 +493,9 @@
 #
 # $server_puppetserver_experimental::       For Puppetserver 5, enable the /puppet/experimental route? Defaults to true
 #
+# $server_puppetserver_trusted_agents::     Certificate names of puppet agents that are allowed to fetch *all* catalogs
+#                                           Defaults to [] and all agents are only allowed to fetch their own catalogs.
+#
 # === Usage:
 #
 # * Simple usage:
@@ -680,6 +683,7 @@ class puppet (
   Boolean $server_puppetserver_jruby9k = $puppet::params::server_puppetserver_jruby9k,
   Boolean $server_puppetserver_metrics = $puppet::params::server_puppetserver_metrics,
   Boolean $server_puppetserver_experimental = $puppet::params::server_puppetserver_experimental,
+  Array[String] $server_puppetserver_trusted_agents = $puppet::params::server_puppetserver_trusted_agents,
 ) inherits puppet::params {
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -481,4 +481,7 @@ class puppet::params {
 
   # For Puppetserver 5, should the /puppet/experimental route be enabled?
   $server_puppetserver_experimental = true
+
+  # Normally agents can only fetch their own catalogs.  If you want some nodes to be able to fetch *any* catalog, add them here.
+  $server_puppetserver_trusted_agents = []
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -308,6 +308,8 @@
 #
 # $puppetserver_experimental:: For Puppetserver 5, enable the /puppet/experimental route? Defaults to true
 #
+# $puppetserver_trusted_agents:: Certificate names of agents that are allowed to fetch *all* catalogs. Defaults to empty array
+#
 class puppet::server(
   Variant[Boolean, Stdlib::Absolutepath] $autosign = $::puppet::autosign,
   Array[String] $autosign_entries = $::puppet::autosign_entries,
@@ -416,6 +418,7 @@ class puppet::server(
   Boolean $puppetserver_jruby9k = $::puppet::server_puppetserver_jruby9k,
   Boolean $puppetserver_metrics = $::puppet::server_puppetserver_metrics,
   Boolean $puppetserver_experimental = $::puppet::server_puppetserver_experimental,
+  Array[String] $puppetserver_trusted_agents = $::puppet::server_puppetserver_trusted_agents,
 ) {
   if $implementation == 'master' and $ip != $puppet::params::ip {
     notify {

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -103,6 +103,7 @@ class puppet::server::puppetserver (
   $server_jruby9k                         = $::puppet::server::puppetserver_jruby9k,
   $server_metrics                         = $::puppet::server::puppetserver_metrics,
   $server_experimental                    = $::puppet::server::puppetserver_experimental,
+  $server_trusted_agents                  = $::puppet::server::puppetserver_trusted_agents,
 ) {
   include ::puppet::server
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -66,6 +66,7 @@ describe 'puppet::server::puppetserver' do
         :server_ssl_cert_key                    => '/etc/puppetlabs/puppet/ssl/private_keys/puppetserver123.example.com.pem',
         :server_ssl_chain                       => '/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem',
         :server_crl_enable                      => true,
+        :server_trusted_agents                  => [],
       } end
 
       describe 'with default parameters' do
@@ -646,6 +647,22 @@ describe 'puppet::server::puppetserver' do
           it {
             should contain_file('/etc/custom/puppetserver/conf.d/auth.conf').
               without_content(%r{^(\ *)path: "/puppet/experimental"$})
+          }
+        end
+      end
+
+      describe 'server_trusted_agents' do
+        context 'when set' do
+          let(:params) do
+            default_params.merge({
+                                   :server_puppetserver_version => '2.7.0',
+                                   :server_puppetserver_dir     => '/etc/custom/puppetserver',
+                                   :server_trusted_agents       => ['jenkins', 'octocatalog-diff'],
+                                 })
+          end
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/auth.conf').
+              with_content(%r{^            allow: \["jenkins", "octocatalog-diff", "\$1"\]$})
           }
         end
       end

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -9,7 +9,7 @@ authorization: {
                 type: regex
                 method: [get, post]
             }
-            allow: "$1"
+            allow: <%= @server_trusted_agents << '$1' %>
             sort-order: 500
             name: "puppetlabs catalog"
         },


### PR DESCRIPTION
I'm using octocatalog-diff to fetch catalogs from a puppetserver.
By default, agents can only fetch their own catalogs.  I need to
reconfigure the puppetserver so that octocatalog-diff can fetch
*any* catalog. This commit adds a new
`server_puppetserver_trusted_agents` parameter that makes this possible.

See.
https://github.com/github/octocatalog-diff/blob/master/doc/advanced-puppet-master.md#certificate-authorization