### PR TITLE
[WIP] Always manage the ssl_ca_crl if a host is a CA

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -165,6 +165,13 @@ class puppet::server::config inherits puppet::config {
                   Exec['puppet_server_config-create_ssl_dir'],
                   ],
     }
+
+    file { $::puppet::server::ssl_ca_crl:
+      ensure => file,
+      owner  => $::puppet::server::user,
+      group  => $::puppet::server::group,
+      mode   => '0644',
+    }
   } elsif $::puppet::server::ca_crl_sync {
     # If not a ca AND sync the crl from the ca master
     if defined('$::servername') {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -167,10 +167,11 @@ class puppet::server::config inherits puppet::config {
     }
 
     file { $::puppet::server::ssl_ca_crl:
-      ensure => file,
-      owner  => $::puppet::server::user,
-      group  => $::puppet::server::group,
-      mode   => '0644',
+      ensure  => file,
+      owner   => $::puppet::server::user,
+      group   => $::puppet::server::group,
+      mode    => '0644',
+      require => Exec['puppet_server_config-generate_ca_cert'],
     }
   } elsif $::puppet::server::ca_crl_sync {
     # If not a ca AND sync the crl from the ca master

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -166,7 +166,7 @@ class puppet::server::config inherits puppet::config {
                   ],
     }
 
-    file { $::puppet::server::ssl_ca_crl:
+    file { "${::puppet::server::ssl_dir}/crl.pem":
       ensure  => file,
       owner   => $::puppet::server::user,
       group   => $::puppet::server::group,


### PR DESCRIPTION
This fixes an issue where puppetserver is installed through puppet without the puppet user being available. It then falls back to the owner root. This causes puppetserver to refuse to restart.