### PR TITLE
Remove Puppet < 4.5 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -9,6 +9,14 @@ Rakefile:
     - manifests/init.pp
 spec/spec_helper.rb:
   extra_code: |
+    if Puppet.version >= '4.0'
+      aio = on_os_under_test.reject do |os, facts|
+        ['FreeBSD', 'DragonFly', 'Windows'].include?(facts[:operatingsystem])
+      end.keys
+
+      add_custom_fact :rubysitedir, '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0', :confine => aio
+    end
+
     def unsupported_puppetmaster_osfamily(osfamily)
       ['Archlinux', 'windows', 'Suse'].include?(osfamily)
     end

--- a/.sync.yml
+++ b/.sync.yml
@@ -9,13 +9,11 @@ Rakefile:
     - manifests/init.pp
 spec/spec_helper.rb:
   extra_code: |
-    if Puppet.version >= '4.0'
-      aio = on_os_under_test.reject do |os, facts|
-        ['FreeBSD', 'DragonFly', 'Windows'].include?(facts[:operatingsystem])
-      end.keys
+    aio = on_os_under_test.reject do |os, facts|
+      ['FreeBSD', 'DragonFly', 'Windows'].include?(facts[:operatingsystem])
+    end.keys
 
-      add_custom_fact :rubysitedir, '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0', :confine => aio
-    end
+    add_custom_fact :rubysitedir, '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0', :confine => aio
 
     def unsupported_puppetmaster_osfamily(osfamily)
       ['Archlinux', 'windows', 'Suse'].include?(osfamily)

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -1,10 +1,16 @@
 # Install the puppet client installation
-class puppet::agent::install {
-  if $::puppet::manage_packages == true or $::puppet::manage_packages == 'agent' {
-    package { $::puppet::client_package:
-      ensure   => $::puppet::version,
-      provider => $::puppet::package_provider,
-      source   => $::puppet::package_source,
+class puppet::agent::install(
+  $manage_packages = $::puppet::manage_packages,
+  $package_name = $::puppet::client_package,
+  $package_version = $::puppet::version,
+  $package_provider = $::puppet::package_provider,
+  $package_source = $::puppet::package_source,
+) {
+  if $manage_packages == true or $manage_packages == 'agent' {
+    package { $package_name:
+      ensure   => $package_version,
+      provider => $package_provider,
+      source   => $package_source,
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,11 +23,7 @@ class puppet::params {
   $agent_noop          = false
   $show_diff           = false
   $module_repository   = undef
-  if versioncmp($::puppetversion, '4.0') < 0 or versioncmp($::puppetversion, '4.5') >= 0 {
-    $hiera_config            = '$confdir/hiera.yaml'
-  } else {
-    $hiera_config            = '$codedir/hiera.yaml'
-  }
+  $hiera_config        = '$confdir/hiera.yaml'
   $usecacheonfailure   = true
   $ca_server           = undef
   $ca_port             = undef
@@ -52,16 +48,8 @@ class puppet::params {
   $syslogfacility      = undef
   $environment         = $::environment
 
-  if versioncmp($::puppetversion, '4.0') < 0 {
-    $aio_package      = false
-    $deb_naio_package = false
-  } elsif $::osfamily == 'Windows' or $::rubysitedir =~ /\/opt\/puppetlabs\/puppet/ {
-    $aio_package      = true
-    $deb_naio_package = false
-  } else {
-    $aio_package      = false
-    $deb_naio_package = ($::osfamily == 'Debian')
-  }
+  $aio_package      = ($::osfamily == 'Windows' or $::rubysitedir =~ /\/opt\/puppetlabs\/puppet/)
+  $deb_naio_package = ($::osfamily == 'Debian')
 
   case $::osfamily {
     'Windows' : {
@@ -160,11 +148,7 @@ class puppet::params {
     }
   }
 
-  if versioncmp($::puppetversion, '4.0') < 0 {
-    $configtimeout = 120
-  } else {
-    $configtimeout = undef
-  }
+  $configtimeout = undef
 
   $autosign         = "${dir}/autosign.conf"
   $autosign_entries = []
@@ -315,7 +299,7 @@ class puppet::params {
 
   if $aio_package {
     $client_package = ['puppet-agent']
-  } elsif ($::osfamily == 'Debian') {
+  } elsif $::osfamily == 'Debian' {
     $client_package = $deb_naio_package ? {
       true    => ['puppet'],
       default => ['puppet-common', 'puppet']
@@ -323,10 +307,8 @@ class puppet::params {
   } elsif ($::osfamily =~ /(FreeBSD|DragonFly)/) {
     if (versioncmp($::puppetversion, '5.0') > 0) {
       $client_package = ['puppet5']
-    } elsif (versioncmp($::puppetversion, '4.0') > 0) {
-      $client_package = ['puppet4']
     } else {
-      $client_package = ['puppet38']
+      $client_package = ['puppet4']
     }
   } else {
     $client_package = ['puppet']

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -25,13 +25,9 @@ class puppet::server::install {
   }
 
   if $::puppet::manage_packages == true or $::puppet::manage_packages == 'server' {
-    $puppet4 = (versioncmp($::puppetversion, '4.0') > 0)
     $server_package_default = $::puppet::server::implementation ? {
       'master'       => $::osfamily ? {
-        'Debian'                => $puppet4 ? {
-                                      true    => ['puppet-master'],
-                                      default => ['puppetmaster-common', 'puppetmaster'],
-                                    },
+        'Debian'                => ['puppet-master'],
         /^(FreeBSD|DragonFly)$/ => [],
         default                 => ['puppet-server'],
       },

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -26,7 +26,7 @@ class puppet::server::service(
     fail('Both puppetmaster and puppetserver cannot be enabled simultaneously')
   }
 
-  if $::osfamily == 'Debian' and (versioncmp($::puppetversion, '4.0') > 0) {
+  if $::osfamily == 'Debian' {
     $puppetmaster_service = 'puppet-master'
   } else {
     $puppetmaster_service = 'puppetmaster'

--- a/spec/classes/puppet_agent_install_spec.rb
+++ b/spec/classes/puppet_agent_install_spec.rb
@@ -9,7 +9,6 @@ describe 'puppet::agent::install' do
         else
           client_package = 'puppet'
         end
-        additional_facts = {}
       else
         if facts[:osfamily] == 'FreeBSD'
           if Puppet.version < '5.0'
@@ -17,19 +16,13 @@ describe 'puppet::agent::install' do
           else
             client_package = 'puppet5'
           end
-          additional_facts = {}
         else
           client_package = 'puppet-agent'
-          if facts[:osfamily] == 'windows'
-            additional_facts = {}
-          else
-            additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-          end
         end
       end
 
       let (:facts) do
-        facts.merge(additional_facts)
+        facts
       end
 
       describe 'with default parameters' do

--- a/spec/classes/puppet_agent_install_spec.rb
+++ b/spec/classes/puppet_agent_install_spec.rb
@@ -3,22 +3,14 @@ require 'spec_helper'
 describe 'puppet::agent::install' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        if facts[:osfamily] == 'FreeBSD'
-          client_package = 'puppet38'
+      if facts[:osfamily] == 'FreeBSD'
+        if Puppet.version < '5.0'
+          client_package = 'puppet4'
         else
-          client_package = 'puppet'
+          client_package = 'puppet5'
         end
       else
-        if facts[:osfamily] == 'FreeBSD'
-          if Puppet.version < '5.0'
-            client_package = 'puppet4'
-          else
-            client_package = 'puppet5'
-          end
-        else
-          client_package = 'puppet-agent'
-        end
+        client_package = 'puppet-agent'
       end
 
       let (:facts) do

--- a/spec/classes/puppet_agent_install_spec.rb
+++ b/spec/classes/puppet_agent_install_spec.rb
@@ -1,17 +1,72 @@
 require 'spec_helper'
 
 describe 'puppet::agent::install' do
+  context 'with explicit parameters' do
+    let :base_params do
+      {
+        :manage_packages  => true,
+        :package_name     => 'puppet-agent',
+        :package_version  => 'installed',
+        :package_provider => 'provider', # Can't set this to nil
+        :package_source   => 'source', # Can't set this to nil
+      }
+    end
+
+    describe 'base parameters' do
+      let :params do
+        base_params
+      end
+
+      it do
+        is_expected.to contain_package('puppet-agent').
+          with_ensure('installed').
+          with_provider('provider').
+          with_source('source')
+      end
+    end
+
+    describe 'when manage_packages => false' do
+      let :params do
+        base_params.merge(:manage_packages => false)
+      end
+
+      it { is_expected.not_to contain_package('puppet-agent') }
+    end
+
+    describe "when manage_packages => 'agent'" do
+      let :params do
+        base_params.merge(:manage_packages => 'agent')
+      end
+
+      it { is_expected.to contain_package('puppet-agent') }
+    end
+
+    describe "when manage_packages => 'server'" do
+      let :params do
+        base_params.merge(:manage_packages => 'sever')
+      end
+
+      it { is_expected.not_to contain_package('puppet-agent') }
+    end
+  end
+
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      if facts[:osfamily] == 'FreeBSD'
-        if Puppet.version < '5.0'
-          client_package = 'puppet4'
-        else
-          client_package = 'puppet5'
-        end
-      else
-        client_package = 'puppet-agent'
-      end
+      client_package = if facts[:osfamily] == 'FreeBSD'
+                         if Puppet.version < '5.0'
+                           'puppet4'
+                         else
+                           'puppet5'
+                         end
+                       else
+                         'puppet-agent'
+                       end
+
+      package_provider = if facts[:osfamily] == 'windows'
+                           'chocolatey'
+                         else
+                           nil
+                         end
 
       let (:facts) do
         facts
@@ -22,78 +77,25 @@ describe 'puppet::agent::install' do
           'include ::puppet'
         end
 
-        if facts[:osfamily] == 'windows'
-          it 'should define provider as chocolatey on Windows' do
-            should contain_package(client_package).with_provider('chocolatey')
-          end
-        else
-          it 'should not define provider on non-Windows' do
-            should contain_package(client_package).without_provider(nil)
-          end
-        end
-      end
-
-      describe "when manage_packages => false" do
-        let :pre_condition do
-          "class { 'puppet': manage_packages => false }"
+        # For windows we specify a package provider which doesn't compile
+        if facts[:osfamily] != 'windows'
+          it { is_expected.to compile.with_all_deps }
         end
 
-        it 'should not contain Package[puppet]' do
-          should_not contain_package('puppet')
+        it do
+          is_expected.to contain_class('puppet::agent::install').
+            with_manage_packages(true).
+            with_package_name([client_package]).
+            with_package_version('present').
+            with_package_provider(package_provider).
+            with_package_source(nil)
         end
 
-        it 'should not contain Package[puppet-agent]' do
-          should_not contain_package('puppet-agent')
-        end
-      end
-
-      describe "when manage_packages => 'agent'" do
-        let :pre_condition do
-          "class { 'puppet': manage_packages => 'agent' }"
-        end
-
-        it 'should contain Package[puppet]' do
-          should contain_package(client_package)
-        end
-      end
-
-      describe "when manage_packages => 'server'" do
-        let :pre_condition do
-          "class { 'puppet': manage_packages => 'server' }"
-        end
-
-        it 'should not contain Package[puppet]' do
-          should_not contain_package('puppet')
-        end
-
-        it 'should not contain Package[puppet-agent]' do
-          should_not contain_package('puppet-agent')
-        end
-      end
-
-      if facts[:osfamily] == 'windows'
-        describe "when package_provider => 'msi'" do
-          let :pre_condition do
-            "class { 'puppet': package_provider => 'msi', }"
-          end
-
-          it 'should define provider as msi' do
-            should contain_package(client_package).with_provider('msi')
-          end
-        end
-
-        describe "when package_provider => 'windows' and source is defined" do
-          let :pre_condition do
-            "class { 'puppet': package_provider => 'windows', package_source => 'C:\\Temp\\puppet.exe' }"
-          end
-
-          it 'should define provider as windows' do
-            should contain_package(client_package).with_provider('windows')
-          end
-
-          it 'should define source as C:\Temp\puppet.exe' do
-            should contain_package(client_package).with_source('C:\Temp\puppet.exe')
-          end
+        it do
+          is_expected.to contain_package(client_package).
+            with_ensure('present').
+            with_provider(package_provider).
+            with_source(nil)
         end
       end
     end

--- a/spec/classes/puppet_agent_service_cron_spec.rb
+++ b/spec/classes/puppet_agent_service_cron_spec.rb
@@ -3,17 +3,12 @@ require 'spec_helper'
 describe 'puppet::agent::service::cron' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        confdir = '/etc/puppet'
-        bindir = '/usr/bin'
-      else
-        confdir = '/etc/puppetlabs/puppet'
-        bindir = '/opt/puppetlabs/bin'
-      end
-
       if facts[:osfamily] == 'FreeBSD'
         bindir = '/usr/local/bin'
         confdir = '/usr/local/etc/puppet'
+      else
+        confdir = '/etc/puppetlabs/puppet'
+        bindir = '/opt/puppetlabs/bin'
       end
 
       let :facts do

--- a/spec/classes/puppet_agent_service_cron_spec.rb
+++ b/spec/classes/puppet_agent_service_cron_spec.rb
@@ -6,11 +6,9 @@ describe 'puppet::agent::service::cron' do
       if Puppet.version < '4.0'
         confdir = '/etc/puppet'
         bindir = '/usr/bin'
-        additional_facts = {}
       else
         confdir = '/etc/puppetlabs/puppet'
         bindir = '/opt/puppetlabs/bin'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
       if facts[:osfamily] == 'FreeBSD'
@@ -19,7 +17,7 @@ describe 'puppet::agent::service::cron' do
       end
 
       let :facts do
-        facts.merge(additional_facts).merge(:ipaddress => '192.0.2.100')
+        facts.merge(ipaddress: '192.0.2.100')
       end
 
       describe 'when runmode is not cron' do

--- a/spec/classes/puppet_agent_service_daemon_spec.rb
+++ b/spec/classes/puppet_agent_service_daemon_spec.rb
@@ -3,14 +3,10 @@ require 'spec_helper'
 describe 'puppet::agent::service::daemon' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        confdir = '/etc/puppet'
-      else
-        confdir = '/etc/puppetlabs/puppet'
-      end
-
       if facts[:osfamily] == 'FreeBSD'
         confdir = '/usr/local/etc/puppet'
+      else
+        confdir = '/etc/puppetlabs/puppet'
       end
 
       let :facts do

--- a/spec/classes/puppet_agent_service_daemon_spec.rb
+++ b/spec/classes/puppet_agent_service_daemon_spec.rb
@@ -5,10 +5,8 @@ describe 'puppet::agent::service::daemon' do
     context "on #{os}" do
       if Puppet.version < '4.0'
         confdir = '/etc/puppet'
-        additional_facts = {}
       else
         confdir = '/etc/puppetlabs/puppet'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
       if facts[:osfamily] == 'FreeBSD'
@@ -16,7 +14,7 @@ describe 'puppet::agent::service::daemon' do
       end
 
       let :facts do
-        facts.merge(additional_facts)
+        facts
       end
 
       describe 'when runmode => daemon' do

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -5,10 +5,8 @@ describe 'puppet::agent::service' do
     context "on #{os}" do
       if Puppet.version < '4.0'
         confdir = '/etc/puppet'
-        additional_facts = {}
       else
         confdir = '/etc/puppetlabs/puppet'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
       if facts[:osfamily] == 'FreeBSD'
@@ -16,7 +14,7 @@ describe 'puppet::agent::service' do
       end
 
       let :facts do
-        facts.merge(additional_facts)
+        facts
       end
 
       describe 'with no custom parameters' do

--- a/spec/classes/puppet_agent_service_spec.rb
+++ b/spec/classes/puppet_agent_service_spec.rb
@@ -3,14 +3,10 @@ require 'spec_helper'
 describe 'puppet::agent::service' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        confdir = '/etc/puppet'
-      else
-        confdir = '/etc/puppetlabs/puppet'
-      end
-
       if facts[:osfamily] == 'FreeBSD'
         confdir = '/usr/local/etc/puppet'
+      else
+        confdir = '/etc/puppetlabs/puppet'
       end
 
       let :facts do

--- a/spec/classes/puppet_agent_service_systemd_spec.rb
+++ b/spec/classes/puppet_agent_service_systemd_spec.rb
@@ -5,10 +5,8 @@ describe 'puppet::agent::service::systemd' do
     context "on #{os}" do
       if Puppet.version < '4.0'
         confdir = '/etc/puppet'
-        additional_facts = {}
       else
         confdir = '/etc/puppetlabs/puppet'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
       if facts[:osfamily] == 'FreeBSD'
@@ -18,7 +16,7 @@ describe 'puppet::agent::service::systemd' do
       end
 
       let :facts do
-        facts.merge(additional_facts).merge(:ipaddress => '192.0.2.100')
+        facts.merge(ipaddress: '192.0.2.100')
       end
 
       describe 'when runmode is not systemd' do

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -3,32 +3,20 @@ require 'spec_helper'
 describe 'puppet::agent' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        client_package = 'puppet'
-        confdir        = '/etc/puppet'
-        case facts[:osfamily]
-        when 'FreeBSD'
-          client_package = 'puppet38'
-          confdir        = '/usr/local/etc/puppet'
-        when 'windows'
-          client_package = 'puppet'
-          confdir        = 'C:/ProgramData/PuppetLabs/puppet/etc'
+      case facts[:osfamily]
+      when 'FreeBSD'
+        if Puppet.version < '5.0'
+          client_package = 'puppet4'
+        else
+          client_package = 'puppet5'
         end
+        confdir          = '/usr/local/etc/puppet'
+      when 'windows'
+        client_package = 'puppet-agent'
+        confdir        = 'C:/ProgramData/PuppetLabs/puppet/etc'
       else
         client_package = 'puppet-agent'
         confdir        = '/etc/puppetlabs/puppet'
-        case facts[:osfamily]
-          when 'FreeBSD'
-            if Puppet.version < '5.0'
-              client_package = 'puppet4'
-            else
-              client_package = 'puppet5'
-            end
-            confdir          = '/usr/local/etc/puppet'
-        when 'windows'
-          client_package   = 'puppet-agent'
-          confdir          = 'C:/ProgramData/PuppetLabs/puppet/etc'
-        end
       end
 
       let :facts do

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -14,11 +14,9 @@ describe 'puppet::agent' do
           client_package = 'puppet'
           confdir        = 'C:/ProgramData/PuppetLabs/puppet/etc'
         end
-        additional_facts = {}
       else
         client_package = 'puppet-agent'
         confdir        = '/etc/puppetlabs/puppet'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
         case facts[:osfamily]
           when 'FreeBSD'
             if Puppet.version < '5.0'
@@ -27,16 +25,14 @@ describe 'puppet::agent' do
               client_package = 'puppet5'
             end
             confdir          = '/usr/local/etc/puppet'
-            additional_facts = {}
         when 'windows'
           client_package   = 'puppet-agent'
           confdir          = 'C:/ProgramData/PuppetLabs/puppet/etc'
-          additional_facts = {}
         end
       end
 
       let :facts do
-        facts.merge(additional_facts)
+        facts
       end
 
       describe 'with no custom parameters' do

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -3,52 +3,38 @@ require 'spec_helper'
 describe 'puppet::config' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        codedir          = '/etc/puppet'
-        confdir          = '/etc/puppet'
-        logdir           = '/var/log/puppet'
-        rundir           = '/var/run/puppet'
-        ssldir           = '/var/lib/puppet/ssl'
-        vardir           = '/var/lib/puppet'
-        sharedir         = '/usr/share/puppet'
-        dir_owner        = 'puppet'
-        dir_group        = 'puppet'
-      else
-        codedir          = '/etc/puppetlabs/code'
-        confdir          = '/etc/puppetlabs/puppet'
-        logdir           = '/var/log/puppetlabs/puppet'
-        rundir           = '/var/run/puppetlabs'
-        ssldir           = '/etc/puppetlabs/puppet/ssl'
-        vardir           = '/opt/puppetlabs/puppet/cache'
-        sharedir         = '/opt/puppetlabs/puppet'
-        dir_owner        = 'root'
-        dir_group        = nil
-      end
 
       case facts[:osfamily]
       when 'FreeBSD'
-        codedir  = '/usr/local/etc/puppet'
-        confdir  = '/usr/local/etc/puppet'
-        logdir   = '/var/log/puppet'
-        rundir   = '/var/run/puppet'
-        ssldir   = '/var/puppet/ssl'
-        vardir   = '/var/puppet'
-        sharedir = '/usr/local/share/puppet'
-      when 'Suse'
-        if Puppet.version < '4.0'
-          dir_owner = 'root'
-          dir_group = nil
-        end
+        dir_owner = 'puppet'
+        dir_group = 'puppet'
+        codedir   = '/usr/local/etc/puppet'
+        confdir   = '/usr/local/etc/puppet'
+        logdir    = '/var/log/puppet'
+        rundir    = '/var/run/puppet'
+        ssldir    = '/var/puppet/ssl'
+        vardir    = '/var/puppet'
+        sharedir  = '/usr/local/share/puppet'
       when 'windows'
         dir_owner = nil
         dir_group = nil
-        codedir  = 'C:/ProgramData/PuppetLabs/puppet/etc'
-        confdir  = 'C:/ProgramData/PuppetLabs/puppet/etc'
-        logdir   = 'C:/ProgramData/PuppetLabs/puppet/var/log'
-        rundir   = 'C:/ProgramData/PuppetLabs/puppet/var/run'
-        ssldir   = 'C:/ProgramData/PuppetLabs/puppet/etc/ssl'
-        vardir   = 'C:/ProgramData/PuppetLabs/puppet/var'
-        sharedir = 'C:/ProgramData/PuppetLabs/puppet/share'
+        codedir   = 'C:/ProgramData/PuppetLabs/puppet/etc'
+        confdir   = 'C:/ProgramData/PuppetLabs/puppet/etc'
+        logdir    = 'C:/ProgramData/PuppetLabs/puppet/var/log'
+        rundir    = 'C:/ProgramData/PuppetLabs/puppet/var/run'
+        ssldir    = 'C:/ProgramData/PuppetLabs/puppet/etc/ssl'
+        vardir    = 'C:/ProgramData/PuppetLabs/puppet/var'
+        sharedir  = 'C:/ProgramData/PuppetLabs/puppet/share'
+      else
+        dir_owner = 'root'
+        dir_group = nil
+        codedir   = '/etc/puppetlabs/code'
+        confdir   = '/etc/puppetlabs/puppet'
+        logdir    = '/var/log/puppetlabs/puppet'
+        rundir    = '/var/run/puppetlabs'
+        ssldir    = '/etc/puppetlabs/puppet/ssl'
+        vardir    = '/opt/puppetlabs/puppet/cache'
+        sharedir  = '/opt/puppetlabs/puppet'
       end
 
       let :facts do
@@ -67,13 +53,8 @@ describe 'puppet::config' do
         end
 
         it 'should contain auth.conf' do
-          if Puppet.version >= '4.0'
-            should_not contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
-            should contain_file("#{confdir}/auth.conf").with_content(%r{/puppet/v3/})
-          else
-            should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
-            should_not contain_file("#{confdir}/auth.conf").with_content(%r{/puppet/v3/})
-          end
+          should_not contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nmethod find$})
+          should contain_file("#{confdir}/auth.conf").with_content(%r{/puppet/v3/})
         end
 
         it 'should_not contain default_manifest setting in puppet.conf' do
@@ -106,11 +87,7 @@ describe 'puppet::config' do
         end
 
         it 'should contain auth.conf with auth any' do
-          if Puppet.version >= '4.0'
-            should contain_file("#{confdir}/auth.conf").with_content(%r{^path /puppet-ca/v1/certificate_revocation_list/ca\nauth any$})
-          else
-            should contain_file("#{confdir}/auth.conf").with_content(%r{^path /certificate_revocation_list/ca\nauth any$})
-          end
+          should contain_file("#{confdir}/auth.conf").with_content(%r{^path /puppet-ca/v1/certificate_revocation_list/ca\nauth any$})
         end
       end
 

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -13,7 +13,6 @@ describe 'puppet::config' do
         sharedir         = '/usr/share/puppet'
         dir_owner        = 'puppet'
         dir_group        = 'puppet'
-        additional_facts = {}
       else
         codedir          = '/etc/puppetlabs/code'
         confdir          = '/etc/puppetlabs/puppet'
@@ -24,7 +23,6 @@ describe 'puppet::config' do
         sharedir         = '/opt/puppetlabs/puppet'
         dir_owner        = 'root'
         dir_group        = nil
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
       case facts[:osfamily]
@@ -54,7 +52,7 @@ describe 'puppet::config' do
       end
 
       let :facts do
-        facts.merge(additional_facts).merge({:domain => 'example.org'})
+        facts.merge(domain: 'example.org')
       end
 
       describe 'with default parameters' do

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -7,7 +7,6 @@ describe 'puppet' do
         puppet_concat    = '/etc/puppet/puppet.conf'
         puppet_directory = '/etc/puppet'
         puppet_package   = 'puppet'
-        additional_facts = {}
         case facts[:osfamily]
         when 'FreeBSD'
           puppet_concat    = '/usr/local/etc/puppet/puppet.conf'
@@ -22,7 +21,6 @@ describe 'puppet' do
         puppet_concat    = '/etc/puppetlabs/puppet/puppet.conf'
         puppet_directory = '/etc/puppetlabs/puppet'
         puppet_package   = 'puppet-agent'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
         case facts[:osfamily]
         when 'FreeBSD'
           puppet_concat    = '/usr/local/etc/puppet/puppet.conf'
@@ -32,17 +30,15 @@ describe 'puppet' do
           else
             puppet_package   = 'puppet5'
           end
-          additional_facts = {}
         when 'windows'
           puppet_concat    = 'C:/ProgramData/PuppetLabs/puppet/etc/puppet.conf'
           puppet_directory = 'C:/ProgramData/PuppetLabs/puppet/etc'
           puppet_package   = 'puppet-agent'
-          additional_facts = {}
         end
       end
 
       let :facts do
-        facts.merge(additional_facts)
+        facts
       end
 
       describe 'with no custom parameters' do

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -24,7 +24,6 @@ describe 'puppet::server::config' do
         sharedir            = '/usr/share/puppet'
         etcdir              = '/etc/puppet'
         puppetcacmd         = '/usr/bin/puppet cert'
-        additional_facts    = {}
       else
         codedir             = '/etc/puppetlabs/code'
         confdir             = '/etc/puppetlabs/puppet'
@@ -40,7 +39,6 @@ describe 'puppet::server::config' do
         sharedir            = '/opt/puppetlabs/puppet'
         etcdir              = '/etc/puppetlabs/puppet'
         puppetcacmd         = '/opt/puppetlabs/bin/puppet cert'
-        additional_facts    = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
       if facts[:osfamily] == 'FreeBSD'
@@ -58,11 +56,10 @@ describe 'puppet::server::config' do
         sharedir            = '/usr/local/share/puppet'
         etcdir              = '/usr/local/etc/puppet'
         puppetcacmd         = '/usr/local/bin/puppet cert'
-        additional_facts    = {}
       end
 
       let(:facts) do
-        facts.merge({:clientcert => 'puppetmaster.example.com'}).merge(additional_facts)
+        facts.merge(clientcert: 'puppetmaster.example.com')
       end
 
       describe 'with no custom parameters' do

--- a/spec/classes/puppet_server_passenger_spec.rb
+++ b/spec/classes/puppet_server_passenger_spec.rb
@@ -4,14 +4,8 @@ describe 'puppet::server::passenger' do
   on_os_under_test.each do |os, facts|
     next if unsupported_puppetmaster_osfamily(facts[:osfamily])
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        additional_facts = {}
-      else
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-      end
-
       let :facts do
-        facts.merge(additional_facts)
+        facts
       end
 
       let(:default_params) do {

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -9,14 +9,8 @@ describe 'puppet::server::puppetserver' do
         "class {'puppet': server_implementation => 'puppetserver'}"
       end
 
-      if Puppet.version < '4.0'
-        additional_facts = {}
-      else
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-      end
-
       let(:facts) do
-        facts.merge(additional_facts)
+        facts
       end
 
       let(:default_params) do {

--- a/spec/classes/puppet_server_rack_spec.rb
+++ b/spec/classes/puppet_server_rack_spec.rb
@@ -4,14 +4,8 @@ describe 'puppet::server::rack' do
   on_os_under_test.each do |os, facts|
     next if facts[:osfamily] == 'windows'
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        additional_facts = {}
-      else
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-      end
-
       let(:facts) do
-        facts.merge(additional_facts)
+        facts
       end
 
       let(:default_params) do {

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -4,18 +4,14 @@ describe 'puppet::server::service' do
   on_os_under_test.each do |os, facts|
     next if facts[:osfamily] == 'windows'
     context "on #{os}" do
-      master_service = 'puppetmaster'
-      if Puppet.version < '4.0'
-        additional_facts = {}
+      if Puppet.version > '4.0' && facts[:osfamily] == 'Debian'
+        master_service = 'puppet-master'
       else
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-        if facts[:osfamily] == 'Debian'
-          master_service = 'puppet-master'
-        end
+        master_service = 'puppetmaster'
       end
 
       let(:facts) do
-        facts.merge(additional_facts)
+        facts
       end
 
       describe 'default_parameters' do

--- a/spec/classes/puppet_server_service_spec.rb
+++ b/spec/classes/puppet_server_service_spec.rb
@@ -4,7 +4,7 @@ describe 'puppet::server::service' do
   on_os_under_test.each do |os, facts|
     next if facts[:osfamily] == 'windows'
     context "on #{os}" do
-      if Puppet.version > '4.0' && facts[:osfamily] == 'Debian'
+      if facts[:osfamily] == 'Debian'
         master_service = 'puppet-master'
       else
         master_service = 'puppetmaster'

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -7,19 +7,13 @@ describe 'puppet::server' do
       if facts[:osfamily] == 'FreeBSD'
         ssldir = '/var/puppet/ssl'
       else
-        if facts[:puppetversion].to_f > 4.0
-          ssldir = '/etc/puppetlabs/puppet/ssl'
-        else
-          ssldir = '/var/lib/puppet/ssl'
-        end
+        ssldir = '/etc/puppetlabs/puppet/ssl'
       end
 
-      server_package = 'puppet-server'
       if facts[:osfamily] == 'Debian'
-        server_package = 'puppetmaster'
-        if facts[:puppetversion].to_f > 4.0
-          server_package = 'puppet-master'
-        end
+        server_package = 'puppet-master'
+      else
+        server_package = 'puppet-server'
       end
 
       let(:facts) { facts }

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -7,7 +7,11 @@ describe 'puppet::server' do
       if facts[:osfamily] == 'FreeBSD'
         ssldir = '/var/puppet/ssl'
       else
-        ssldir = '/var/lib/puppet/ssl'
+        if facts[:puppetversion].to_f > 4.0
+          ssldir = '/etc/puppetlabs/puppet/ssl'
+        else
+          ssldir = '/var/lib/puppet/ssl'
+        end
       end
 
       server_package = 'puppet-server'
@@ -22,7 +26,7 @@ describe 'puppet::server' do
 
       describe 'basic case' do
         let :pre_condition do
-          "class {'puppet': server => true}"
+          "class {'puppet': server => true, server_implementation => 'master'}"
         end
 
         describe 'with no custom parameters' do
@@ -54,7 +58,7 @@ describe 'puppet::server' do
 
       describe 'with uppercase hostname' do
         let :pre_condition do
-          "class {'puppet': server => true}"
+          "class {'puppet': server => true, server_implementation => 'master'}"
         end
 
         let(:facts) do
@@ -78,7 +82,7 @@ describe 'puppet::server' do
       describe 'with ip parameter' do
         describe 'with default server implementation' do
           let :pre_condition do
-            "class {'puppet': server_ip => '127.0.0.1'}"
+            "class {'puppet': server_ip => '127.0.0.1', server_implementation => 'master'}"
           end
 
           it 'should issue a warning because server_ip is not supported by default implementation' do
@@ -99,7 +103,7 @@ describe 'puppet::server' do
 
       describe 'with server_passenger => false' do
         let :pre_condition do
-          "class {'puppet': server => true, server_passenger => false}"
+          "class {'puppet': server => true, server_implementation => 'master', server_passenger => false}"
         end
 
         it { should compile.with_all_deps }
@@ -113,7 +117,7 @@ describe 'puppet::server' do
 
         describe "and server_service_fallback => false" do
           let :pre_condition do
-            "class {'puppet': server => true, server_passenger => false, server_service_fallback => false}"
+            "class {'puppet': server => true, server_implementation => 'master', server_passenger => false, server_service_fallback => false}"
           end
 
           it { should compile.with_all_deps }
@@ -127,9 +131,6 @@ describe 'puppet::server' do
       end
 
       describe 'with server_implementation => "puppetserver"' do
-        let :facts do
-          facts.merge(:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0')
-        end
         let :pre_condition do
           "class {'puppet': server => true, server_implementation => 'puppetserver'}"
         end

--- a/spec/defines/puppet_config_entry_spec.rb
+++ b/spec/defines/puppet_config_entry_spec.rb
@@ -1,51 +1,9 @@
 require 'spec_helper'
 
 describe 'puppet::config::entry' do
-  on_supported_os.each do |os, facts|
-    next if only_test_os() and not only_test_os.include?(os)
-    next if exclude_test_os() and exclude_test_os.include?(os)
+  on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      let(:default_facts) do
-        facts.merge({
-          :clientcert       => 'puppetmaster.example.com',
-          :concat_basedir   => '/nonexistant',
-          :fqdn             => 'puppetmaster.example.com',
-          :rubyversion      => '1.9.3',
-          :puppetversion    => Puppet.version,
-        })
-      end
-
-      if Puppet.version < '4.0'
-        codedir = '/etc/puppet'
-        confdir = '/etc/puppet'
-        logdir  = '/var/log/puppet'
-        rundir  = '/var/run/puppet'
-        ssldir  = '/var/lib/puppet/ssl'
-        vardir  = '/var/lib/puppet'
-        sharedir = '/usr/share/puppet'
-        additional_facts = {}
-      else
-        codedir = '/etc/puppetlabs/code'
-        confdir = '/etc/puppetlabs/puppet'
-        logdir  = '/var/log/puppetlabs/puppet'
-        rundir  = '/var/run/puppetlabs'
-        ssldir  = '/etc/puppetlabs/puppet/ssl'
-        vardir  = '/opt/puppetlabs/puppet/cache'
-        sharedir = '/opt/puppetlabs/puppet'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
-      end
-
-      if facts[:osfamily] == 'FreeBSD'
-        codedir = '/usr/local/etc/puppet'
-        confdir = '/usr/local/etc/puppet'
-        logdir  = '/var/log/puppet'
-        rundir  = '/var/run/puppet'
-        ssldir  = '/var/puppet/ssl'
-        vardir  = '/var/puppet'
-        sharedir = '/usr/local/share/puppet'
-      end
-
-      let(:facts) { default_facts.merge(additional_facts) }
+      let(:facts) { facts }
 
       let(:title) { 'foo' }
 

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -5,24 +5,6 @@ describe 'puppet::server::env' do
     next if facts[:osfamily] == 'windows'
     next if facts[:osfamily] == 'Archlinux'
     context "on #{os}" do
-      if Puppet.version < '4.0'
-        codedir = '/etc/puppet'
-        confdir = '/etc/puppet'
-        logdir  = '/var/log/puppet'
-        rundir  = '/var/run/puppet'
-        ssldir  = '/var/lib/puppet/ssl'
-        vardir  = '/var/lib/puppet'
-        sharedir = '/usr/share/puppet'
-      else
-        codedir = '/etc/puppetlabs/code'
-        confdir = '/etc/puppetlabs/puppet'
-        logdir  = '/var/log/puppetlabs/puppet'
-        rundir  = '/var/run/puppetlabs'
-        ssldir  = '/etc/puppetlabs/puppet/ssl'
-        vardir  = '/opt/puppetlabs/puppet/cache'
-        sharedir = '/opt/puppetlabs/puppet'
-      end
-
       if facts[:osfamily] == 'FreeBSD'
         codedir = '/usr/local/etc/puppet'
         confdir = '/usr/local/etc/puppet'
@@ -31,6 +13,14 @@ describe 'puppet::server::env' do
         ssldir  = '/var/puppet/ssl'
         vardir  = '/var/puppet'
         sharedir = '/usr/local/share/puppet'
+      else
+        codedir = '/etc/puppetlabs/code'
+        confdir = '/etc/puppetlabs/puppet'
+        logdir  = '/var/log/puppetlabs/puppet'
+        rundir  = '/var/run/puppetlabs'
+        ssldir  = '/etc/puppetlabs/puppet/ssl'
+        vardir  = '/opt/puppetlabs/puppet/cache'
+        sharedir = '/opt/puppetlabs/puppet'
       end
 
       let(:facts) { facts }
@@ -120,8 +110,7 @@ describe 'puppet::server::env' do
 
           it 'should set config_version in environment.conf' do
             should contain_file("#{codedir}/environments/foo/environment.conf").
-              with_content(%r{\Aconfig_version\s+= bar\n\z}).
-              with({}) # So we can use a trailing dot on each with_content line
+              with_content(%r{\Aconfig_version\s+= bar\n\z})
           end
         end
 
@@ -161,8 +150,7 @@ describe 'puppet::server::env' do
 
           it 'should set config_version in environment.conf' do
             should contain_file("#{codedir}/environments/foo/environment.conf").
-              with_content(%r{\Aconfig_version\s+= bar\n\z}).
-              with({}) # So we can use a trailing dot on each with_content line
+              with_content(%r{\Aconfig_version\s+= bar\n\z})
           end
         end
 
@@ -195,8 +183,7 @@ describe 'puppet::server::env' do
           it 'should produce a symbolic link "environments" in codedir' do
             should contain_file("#{codedir}/environments").
               with_target('/foo').
-              with_ensure('link').
-              with({}) # So we can use a trailing dot on each with_content line
+              with_ensure('link')
           end
         end
       end
@@ -215,8 +202,7 @@ describe 'puppet::server::env' do
 
           it 'should set modulepath in environment.conf' do
             should contain_file("#{codedir}/environments/foo/environment.conf").
-              with_content(%r{\Amodulepath\s+= /etc/puppet/example/modules:/etc/puppet/vendor/modules\n}).
-              with({}) # So we can use a trailing dot on each with_content line
+              with_content(%r{\Amodulepath\s+= /etc/puppet/example/modules:/etc/puppet/vendor/modules\n})
           end
         end
       end
@@ -287,8 +273,7 @@ describe 'puppet::server::env' do
 
           it 'should set manifest in environment.conf' do
             should contain_file("#{codedir}/environments/foo/environment.conf").
-              with_content(%r{\Amanifest\s+= manifests/local.pp\n\z}).
-              with({}) # So we can use a trailing dot on each with_content line
+              with_content(%r{\Amanifest\s+= manifests/local.pp\n\z})
           end
         end
       end
@@ -307,8 +292,7 @@ describe 'puppet::server::env' do
 
           it 'should set environment_timeout in environment.conf' do
             should contain_file("#{codedir}/environments/foo/environment.conf").
-              with_content(%r{\Aenvironment_timeout\s+= unlimited\n\z}).
-              with({}) # So we can use a trailing dot on each with_content line
+              with_content(%r{\Aenvironment_timeout\s+= unlimited\n\z})
           end
         end
       end

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -13,7 +13,6 @@ describe 'puppet::server::env' do
         ssldir  = '/var/lib/puppet/ssl'
         vardir  = '/var/lib/puppet'
         sharedir = '/usr/share/puppet'
-        additional_facts = {}
       else
         codedir = '/etc/puppetlabs/code'
         confdir = '/etc/puppetlabs/puppet'
@@ -22,7 +21,6 @@ describe 'puppet::server::env' do
         ssldir  = '/etc/puppetlabs/puppet/ssl'
         vardir  = '/opt/puppetlabs/puppet/cache'
         sharedir = '/opt/puppetlabs/puppet'
-        additional_facts = {:rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0'}
       end
 
       if facts[:osfamily] == 'FreeBSD'
@@ -33,10 +31,9 @@ describe 'puppet::server::env' do
         ssldir  = '/var/puppet/ssl'
         vardir  = '/var/puppet'
         sharedir = '/usr/local/share/puppet'
-        additional_facts = {}
       end
 
-      let(:facts) { facts.merge(additional_facts) }
+      let(:facts) { facts }
 
       let(:title) { 'foo' }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,13 +63,11 @@ def verify_concat_fragment_exact_contents(subject, title, expected_lines)
   expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to match_array(expected_lines)
 end
 
-if Puppet.version >= '4.0'
-  aio = on_os_under_test.reject do |os, facts|
-    ['FreeBSD', 'DragonFly', 'Windows'].include?(facts[:operatingsystem])
-  end.keys
+aio = on_os_under_test.reject do |os, facts|
+  ['FreeBSD', 'DragonFly', 'Windows'].include?(facts[:operatingsystem])
+end.keys
 
-  add_custom_fact :rubysitedir, '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0', :confine => aio
-end
+add_custom_fact :rubysitedir, '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0', :confine => aio
 
 def unsupported_puppetmaster_osfamily(osfamily)
   ['Archlinux', 'windows', 'Suse'].include?(osfamily)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,6 +63,14 @@ def verify_concat_fragment_exact_contents(subject, title, expected_lines)
   expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to match_array(expected_lines)
 end
 
+if Puppet.version >= '4.0'
+  aio = on_os_under_test.reject do |os, facts|
+    ['FreeBSD', 'DragonFly', 'Windows'].include?(facts[:operatingsystem])
+  end.keys
+
+  add_custom_fact :rubysitedir, '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0', :confine => aio
+end
+
 def unsupported_puppetmaster_osfamily(osfamily)
   ['Archlinux', 'windows', 'Suse'].include?(osfamily)
 end

--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -7,13 +7,8 @@
 # otherwise, the general rules may "steal" requests that should be
 # governed by the specific rules.
 #
-<% if @puppetversion.to_f >= 4.0 -%>
 # See https://docs.puppetlabs.com/puppet/latest/reference/config_file_auth.html
 # for a more complete description of auth.conf's behavior.
-<% else -%>
-# See http://docs.puppetlabs.com/guides/rest_auth_conf.html for a more complete
-# description of auth.conf's behavior.
-<% end -%>
 #
 # Supported syntax:
 # Each stanza in auth.conf starts with a path to match, followed
@@ -42,7 +37,6 @@
 #
 # Examples:
 #
-<% if @puppetversion.to_f >= 4.0 -%>
 # path ~ ^/puppet/v3/path/to/resource    # Equivalent to `path /puppet/v3/path/to/resource`.
 # allow *                                # Allow all authenticated nodes (since auth
 #                                        # defaults to `yes`).
@@ -55,20 +49,6 @@
 # allow /^(.+)\.example\.com$/                             # mount point; note this must
 # allow_ip 192.168.100.0/24                                # go ABOVE the "/file" rule,
 #                                                          # since it is more specific.
-<% else -%>
-# path ~ ^/path/to/resource    # Equivalent to `path /path/to/resource`.
-# allow *                      # Allow all authenticated nodes (since auth
-#                              # defaults to `yes`).
-#
-# path ~ ^/catalog/([^/]+)$    # Permit nodes to access their own catalog (by
-# allow $1                     # certname), but not any other node's catalog.
-#
-# path ~ ^/file_(metadata|content)/extra_files/  # Only allow certain nodes to
-# auth yes                                       # access the "extra_files"
-# allow /^(.+)\.example\.com$/                   # mount point; note this must
-# allow_ip 192.168.100.0/24                      # go ABOVE the "/file" rule,
-#                                                # since it is more specific.
-<% end -%>
 #
 # environment:: restrict an ACL to a comma-separated list of environments
 # method:: restrict an ACL to a comma-separated list of HTTP methods
@@ -80,7 +60,6 @@
 ### Authenticated ACLs - these rules apply only when the client
 ### has a valid certificate and is thus authenticated
 
-<% if @puppetversion.to_f >= 4.0 -%>
 path /puppet/v3/environments
 method find
 allow *
@@ -90,75 +69,34 @@ path /puppet/v3/resource_type
 method search
 allow *
 <% end -%>
-<% end -%>
 
 # allow nodes to retrieve their own catalog
-<% if @puppetversion.to_f >= 4.0 -%>
 path ~ ^/puppet/v3/catalog/([^/]+)$
 method find
 allow <%= @auth_allowed.join(', ') %>
-<% else -%>
-path ~ ^/catalog/([^/]+)$
-method find
-allow <%= @auth_allowed.join(', ') %>
-<% end -%>
 
 # allow nodes to retrieve their own node definition
-<% if @puppetversion.to_f >= 4.0 -%>
 path ~ ^/puppet/v3/node/([^/]+)$
 method find
 allow <%= @auth_allowed.join(', ') %>
-<% else -%>
-path ~ ^/node/([^/]+)$
-method find
-allow <%= @auth_allowed.join(', ') %>
-<% end -%>
-
-<% if @puppetversion.to_f < 4.0 -%>
-# allow all nodes to access the certificates services
-path /certificate_revocation_list/ca
-<% if @allow_any_crl_auth -%>
-auth any
-<% end -%>
-method find
-allow *
-<% end -%>
 
 # allow all nodes to store their own reports
-<% if @puppetversion.to_f >= 4.0 -%>
 path ~ ^/puppet/v3/report/([^/]+)$
 method save
 allow <%= @auth_allowed.join(', ') %>
-<% else -%>
-path ~ ^/report/([^/]+)$
-method save
-allow <%= @auth_allowed.join(', ') %>
-<% end -%>
 
 # Allow all nodes to access all file services; this is necessary for
 # pluginsync, file serving from modules, and file serving from custom
 # mount points (see fileserver.conf). Note that the `/file` prefix matches
 # requests to both the file_metadata and file_content paths. See "Examples"
 # above if you need more granular access control for custom mount points.
-<% if @puppetversion.to_f >= 4.0 -%>
 path /puppet/v3/file
 allow *
-<% else -%>
-path /file
-allow *
-<% end -%>
 
-<% if @puppetversion.to_f >= 4.0 -%>
 path /puppet/v3/status
 method find
 allow *
-<% else -%>
-path /status
-method find
-allow *
-<% end -%>
 
-<% if @puppetversion.to_f >= 4.0 -%>
 # allow all nodes to access the certificates services
 path /puppet-ca/v1/certificate_revocation_list/ca
 <% if @allow_any_crl_auth -%>
@@ -167,61 +105,33 @@ auth any
 method find
 allow *
 
-<% end -%>
 ### Unauthenticated ACLs, for clients without valid certificates; authenticated
 ### clients can also access these paths, though they rarely need to.
 
 # allow access to the CA certificate; unauthenticated nodes need this
 # in order to validate the puppet master's certificate
-<% if @puppetversion.to_f >= 4.0 -%>
 path /puppet-ca/v1/certificate/ca
 auth any
 method find
 allow *
-<% else -%>
-path /certificate/ca
-auth any
-method find
-allow *
-<% end -%>
 
 # allow nodes to retrieve the certificate they requested earlier
-<% if @puppetversion.to_f >= 4.0 -%>
 path /puppet-ca/v1/certificate/
 auth any
 method find
 allow *
-<% else -%>
-path /certificate/
-auth any
-method find
-allow *
-<% end -%>
 
 # allow nodes to request a new certificate
-<% if @puppetversion.to_f >= 4.0 -%>
 path /puppet-ca/v1/certificate_request
 auth any
 method find, save
 allow *
-<% else -%>
-path /certificate_request
-auth any
-method find, save
-allow *
-<% end -%>
 
 <% if scope.lookupvar('::puppet::listen') -%>
 path /run
 auth any
 method save
 allow <%= if (!@listen_to.empty?) then @listen_to.join(",") elsif ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>
-<% end -%>
-
-<% if @puppetversion.to_f < 4.0 -%>
-path /v2.0/environments
-method find
-allow *
 <% end -%>
 
 # deny everything else; this ACL is not strictly necessary, but

--- a/templates/server/config.ru.erb
+++ b/templates/server/config.ru.erb
@@ -22,7 +22,6 @@ ARGV << "--vardir"  << "<%= @vardir %>"
 ARGV << "<%= server_rack_argument %>"
 <% end -%>
 
-<% if @puppetversion.to_f >= 4.0 -%>
 # always_cache_features is a performance improvement and safe for a master to
 # apply. This is intended to allow agents to recognize new features that may be
 # delivered during catalog compilation.
@@ -95,7 +94,6 @@ end
 
 use Puppet3Compat
 
-<% end -%>
 # NOTE: it's unfortunate that we have to use the "CommandLine" class
 #  here to launch the app, but it contains some initialization logic
 #  (such as triggering the parsing of the config file) that is very


### PR DESCRIPTION
We no longer test with Puppet < 4.0 so we can remove that conditional.  It also does some other style improvements.

By setting the ipaddress to a static value we get consistent output from ip_to_cron and don't rely on it to remain unchanged in facterdb.