### PR TITLE
Set a fixed ipaddress fact in ip_to_cron tests

### DIFF
--- a/spec/classes/puppet_agent_service_cron_spec.rb
+++ b/spec/classes/puppet_agent_service_cron_spec.rb
@@ -19,7 +19,7 @@ describe 'puppet::agent::service::cron' do
       end
 
       let :facts do
-        facts.merge(additional_facts)
+        facts.merge(additional_facts).merge(:ipaddress => '192.0.2.100')
       end
 
       describe 'when runmode is not cron' do
@@ -47,7 +47,7 @@ describe 'puppet::agent::service::cron' do
             should contain_cron('puppet').with({
               :command  => "#{bindir}/puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize",
               :user     => 'root',
-              :minute   => ['15','45'],
+              :minute   => ['10','40'],
               :hour     => '*',
             })
           end

--- a/spec/classes/puppet_agent_service_systemd_spec.rb
+++ b/spec/classes/puppet_agent_service_systemd_spec.rb
@@ -18,7 +18,7 @@ describe 'puppet::agent::service::systemd' do
       end
 
       let :facts do
-        facts.merge(additional_facts)
+        facts.merge(additional_facts).merge(:ipaddress => '192.0.2.100')
       end
 
       describe 'when runmode is not systemd' do
@@ -81,7 +81,7 @@ describe 'puppet::agent::service::systemd' do
             })
 
             should contain_file('/etc/systemd/system/puppet-run.timer').
-            with_content(/.*OnCalendar\=\*-\*-\* \*\:15,45:00.*/)
+              with_content(/.*OnCalendar\=\*-\*-\* \*\:10,40:00.*/)
 
             should contain_file('/etc/systemd/system/puppet-run.service').
             with_content(/.*ExecStart=#{bindir}\/puppet agent --config #{confdir}\/puppet.conf --onetime --no-daemonize.*/)


### PR DESCRIPTION
We don't want to rely on facterdb for this value because they don't guarantee it won't change.

Split from https://github.com/theforeman/puppet-puppet/pull/541 since that'll take a bit longer to properly fix.