### PR TITLE
Restore the share directory

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -280,7 +280,7 @@ class puppet::params {
   $server_envs_dir             = "${codedir}/environments"
   $server_envs_target          = undef
   # Modules in this directory would be shared across all environments
-  $server_common_modules_path  = ["${server_envs_dir}/common", "${codedir}/modules", "${sharedir}/modules"]
+  $server_common_modules_path  = unique(["${server_envs_dir}/common", "${codedir}/modules", "${sharedir}/modules", '/usr/share/puppet/modules'])
 
   # Dynamic environments config, ignore if the git_repo is 'false'
   # Path to the repository

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -129,6 +129,12 @@ class puppet::server::config inherits puppet::config {
     mode   => '0750',
   }
 
+  # Create Foreman share dir which does not depend on Puppet version
+  exec { 'mkdir -p /usr/share/puppet/modules':
+    creates => '/usr/share/puppet/modules',
+    path    => ['/usr/bin', '/bin'],
+  }
+
   ## SSL and CA configuration
   # Open read permissions to private keys to puppet group for foreman, proxy etc.
   file { "${::puppet::server::ssl_dir}/private_keys":

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -158,7 +158,7 @@ describe 'puppet::server::config' do
           if Puppet.version >= '3.6'
             should contain_puppet__config__main("environmentpath").with({'value' => "#{codedir}/environments"})
             should contain_puppet__config__main("basemodulepath").with({
-              'value'  => ["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules"],
+              'value'  => ["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules","/usr/share/puppet/modules"],
               'joiner' => ':'})
           end
 
@@ -498,7 +498,7 @@ describe 'puppet::server::config' do
 
           it 'should configure puppet.conf' do
             should contain_puppet__config__main('environmentpath').with({'value' => "#{environments_dir}"})
-            should contain_puppet__config__main('basemodulepath').with({'value' => ["#{environments_dir}/common","#{codedir}/modules","#{sharedir}/modules"]})
+            should contain_puppet__config__main('basemodulepath').with({'value' => ["#{environments_dir}/common","#{codedir}/modules","#{sharedir}/modules","/usr/share/puppet/modules"]})
           end
 
           it { should_not contain_puppet__server__env('development') }

--- a/spec/defines/puppet_server_env_spec.rb
+++ b/spec/defines/puppet_server_env_spec.rb
@@ -106,7 +106,7 @@ describe 'puppet::server::env' do
             should_not contain_puppet__config__environment('foo_config_version')
             should contain_puppet__config__environment('foo_modulepath').with({
               'key'    => 'modulepath',
-              'value'  => ["#{codedir}/environments/foo/modules",["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules"]],
+              'value'  => ["#{codedir}/environments/foo/modules",["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules","/usr/share/puppet/modules"]],
               'joiner' => ':',
               })
 
@@ -139,7 +139,7 @@ describe 'puppet::server::env' do
             should_not contain_puppet__config__environment('foo_templatedir')
             should contain_puppet__config__environment('foo_modulepath').with({
               'key'    => 'modulepath',
-              'value'  => ["#{codedir}/environments/foo/modules",["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules"]],
+              'value'  => ["#{codedir}/environments/foo/modules",["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules","/usr/share/puppet/modules"]],
               'joiner' => ':',
               })
             should contain_puppet__config__environment('foo_config_version').with({
@@ -180,7 +180,7 @@ describe 'puppet::server::env' do
             should_not contain_puppet__config__environment('foo_templatedir')
             should contain_puppet__config__environment('foo_modulepath').with({
               'key'    => 'modulepath',
-              'value'  => ["#{codedir}/environments/foo/modules",["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules"]],
+              'value'  => ["#{codedir}/environments/foo/modules",["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules","/usr/share/puppet/modules"]],
               'joiner' => ':',
               })
             should contain_puppet__config__environment('foo_config_version').with({
@@ -269,7 +269,7 @@ describe 'puppet::server::env' do
             should_not contain_puppet__config__environment('foo_config_version')
             should contain_puppet__config__environment('foo_modulepath').with({
               'key'    => 'modulepath',
-              'value'  => ["#{basedir}/foo/modules",["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules"]],
+              'value'  => ["#{basedir}/foo/modules",["#{codedir}/environments/common","#{codedir}/modules","#{sharedir}/modules","/usr/share/puppet/modules"]],
               'joiner' => ':',
               })
           end


### PR DESCRIPTION
 since the very first commit with [puppet 4 support](https://github.com/theforeman/puppet-puppet/commit/168ba94ae885acf8b5827a64e2c9609001156c72#diff-2f383a197b1a428561b364755701d60eR84) the shared directory does not seem to be compatible with our [puppet-foreman_scap_client](https://github.com/theforeman/foreman-packaging/blob/rpm/develop/puppet-foreman_scap_client/puppet-foreman_scap_client.spec#L4). We rely on this directory to be included in every environment. I wonder if there's any reason not to keep it to `/usr/share/puppet/modules`? I'd like to avoid changing the packaging definition since the module itself does not really care what puppet version it's being used with.

