### PR TITLE
 Fix installer failure when server_git_repo = false - Bug # 21501

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -123,7 +123,7 @@ class puppet::server::config inherits puppet::config {
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
-  }
+  } ->
   
   file { "${puppet::vardir}/reports":
     ensure => directory,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -118,6 +118,13 @@ class puppet::server::config inherits puppet::config {
     puppet::config::master { $key: value => $value }
   }
 
+  file { "${puppet::vardir}":
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+  
   file { "${puppet::vardir}/reports":
     ensure => directory,
     owner  => $::puppet::server::user,


### PR DESCRIPTION
In [manifests/params.pp](https://github.com/theforeman/puppet-puppet/blob/7e2c116ba2e2c6636feeb593b84f3935c411cb24/manifests/params.pp) on line 247, the module defaults to `$server_git_repo = false` and I am guessing the automated testing and most devs set this value to true. 

In [manifests/server.pp](https://github.com/theforeman/puppet-puppet/blob/a896520b64972b94eb85740f52e13360de80a315/manifests/server.pp) line 375 the module sets `Boolean $git_repo = $::puppet::server_git_repo,`

Then, in [manifests/server/install.pp](https://github.com/theforeman/puppet-puppet/blob/7e2c116ba2e2c6636feeb593b84f3935c411cb24/manifests/server/install.pp) lines 59-68:

    if $::puppet::server::git_repo {
        Class['git'] -> User[$::puppet::server::user]
    
        file { $puppet::vardir:
          ensure => directory,
          owner  => $::puppet::server::user,
          group  => $::puppet::server::group,
        }
      }

But nowhere else is $puppet::vardir created. Thus if `$server_git_repo = false` lines 121-126 of [manifests/server/config.pp](https://github.com/theforeman/puppet-puppet/blob/7e2c116ba2e2c6636feeb593b84f3935c411cb24/manifests/server/config.pp) fail:

      file { "${puppet::vardir}/reports":
        ensure => directory,
        owner  => $::puppet::server::user,
        group  => $::puppet::server::group,
        mode   => '0750',
      }

But if $server_git_repo = true it will succeed. The other option would be to change [manifests/server/install.pp](https://github.com/theforeman/puppet-puppet/blob/7e2c116ba2e2c6636feeb593b84f3935c411cb24/manifests/server/install.pp) from:

      if $::puppet::server::git_repo {
        Class['git'] -> User[$::puppet::server::user]

        file { $puppet::vardir:
          ensure => directory,
          owner  => $::puppet::server::user,
          group  => $::puppet::server::group,
        }
      }

to

      if $::puppet::server::git_repo {
        Class['git'] -> User[$::puppet::server::user]
      }
      file { $puppet::vardir:
        ensure => directory,
        owner  => $::puppet::server::user,
        group  => $::puppet::server::group,
      }

Either solution will fix [bug # 21501](http://projects.theforeman.org/issues/21501)