### PR TITLE
Set the codedir in puppet.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,6 +26,7 @@ class puppet::config(
     'privatekeydir': value => '$ssldir/private_keys { group = service }';
     'hostprivkey': value => '$privatekeydir/$certname.pem { mode = 640 }';
     'show_diff': value  => $::puppet::show_diff;
+    'codedir': value => $::puppet::codedir;
   }
 
   if $module_repository and !empty($module_repository) {


### PR DESCRIPTION
In GH-564 it was pointed out this is not propagated to the actual puppet.conf even though we have a setting for it.