### PR TITLE
Make performance tuning defaults more safe

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -408,10 +408,10 @@ class puppet::params {
   } else {
     $mem_in_mb = 0 + $::memorysize_mb
   }
-  if $mem_in_mb >= 2048 {
+  if $mem_in_mb >= 3072 {
     $server_jvm_min_heap_size = '2G'
     $server_jvm_max_heap_size = '2G'
-    $server_max_active_instances = abs($::processorcount)
+    $server_max_active_instances = min(abs($::processorcount), 4)
   } elsif $mem_in_mb >= 1024 {
     $server_max_active_instances = 1
     $server_jvm_min_heap_size = '1G'


### PR DESCRIPTION
Only use 2G for puppetserver if at least 3G available. Don't use more than four instances, as 512MB memory per instance are recommended. 

Closes: #571