### PR TITLE
add compile_mode parameter to puppetserver.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -527,6 +527,8 @@
 # $server_puppetserver_trusted_agents::     Certificate names of puppet agents that are allowed to fetch *all* catalogs
 #                                           Defaults to [] and all agents are only allowed to fetch their own catalogs.
 #
+# $server_compile_mode::                    Used to control JRuby's "CompileMode", which may improve performance.
+#                                           Defaults to undef (off).
 # === Usage:
 #
 # * Simple usage:
@@ -725,6 +727,7 @@ class puppet (
   Optional[Array] $server_metrics_allowed = $::puppet::params::server_metrics_allowed,
   Boolean $server_puppetserver_experimental = $puppet::params::server_puppetserver_experimental,
   Array[String] $server_puppetserver_trusted_agents = $puppet::params::server_puppetserver_trusted_agents,
+  Optional[Enum['off', 'jit', 'force']] $server_compile_mode = $puppet::params::server_compile_mode,
 ) inherits puppet::params {
   include ::puppet::config
   Class['puppet::config'] -> Class['puppet']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class puppet::params {
   $server_crl_enable   = undef
   $prerun_command      = undef
   $postrun_command     = undef
+  $server_compile_mode = undef
   $dns_alt_names       = []
   $use_srv_records     = false
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -449,6 +449,7 @@ class puppet::server(
   Variant[Undef, Array] $metrics_allowed = $::puppet::server_metrics_allowed,
   Boolean $puppetserver_experimental = $::puppet::server_puppetserver_experimental,
   Array[String] $puppetserver_trusted_agents = $::puppet::server_puppetserver_trusted_agents,
+  Optional[Enum['off', 'jit', 'force']] $compile_mode = $::puppet::server_compile_mode,
 ) {
   if $implementation == 'master' and $ip != $puppet::params::ip {
     notify {

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -122,6 +122,7 @@ class puppet::server::puppetserver (
   $server_experimental                    = $::puppet::server::puppetserver_experimental,
   $server_trusted_agents                  = $::puppet::server::puppetserver_trusted_agents,
   $allow_header_cert_info                 = $::puppet::server::allow_header_cert_info,
+  $compile_mode                           = $::puppet::server::compile_mode,
 ) {
   include ::puppet::server
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -71,6 +71,7 @@ describe 'puppet::server::puppetserver' do
         :server_crl_enable                      => true,
         :server_trusted_agents                  => [],
         :allow_header_cert_info                 => false,
+        :compile_mode                           => 'off', # In reality defaults to undef
       } end
 
       describe 'with default parameters' do

--- a/templates/server/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/puppetserver.conf.erb
@@ -73,6 +73,9 @@ jruby-puppet: {
     # (optional) enable or disable environment class cache
     environment-class-cache-enabled: <%= @server_environment_class_cache_enabled %>
 <%- end -%>
+<%- if @compile_mode %>
+    compile-mode: <%= @compile_mode %>
+<%- end -%>
 }
 
 # settings related to HTTP client requests made by Puppet Server


### PR DESCRIPTION
Hello,
recently I wanted to try setting puppetserver's compile-mode to some value other than default, your module doesn't as of yet have this functionality. This PR should add it.