### PR TITLE
restart httpd when changing cert

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -487,11 +487,9 @@ class puppet::server(
   if $implementation == 'master' {
     $pm_service   = !$passenger and $service_fallback
     $ps_service   = undef
-    $rack_service = $passenger
   } elsif $implementation == 'puppetserver' {
     $pm_service   = undef
     $ps_service   = true
-    $rack_service = false
   }
 
   class { '::puppet::server::install': }
@@ -501,7 +499,7 @@ class puppet::server(
     httpd_service => $httpd_service,
     puppetmaster  => $pm_service,
     puppetserver  => $ps_service,
-    rack          => $rack_service,
+    rack          => $passenger,
   }
   -> Class['puppet::server']
 

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -135,7 +135,7 @@ describe 'puppet::server' do
           should contain_class('puppet::server::service').
             with_puppetmaster(nil).
             with_puppetserver(true).
-            with_rack(false)
+            with_rack(true)
         end
         it { should contain_class('puppet::server::puppetserver') }
         it { should contain_package('puppetserver') }


### PR DESCRIPTION
Currently if you `rm -f $::puppet::server::ssl_cert` and run foreman-installer it will regenerate certs but wont restart the service.