### PR TITLE
WIP: Add new puppet agent settings

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -13,6 +13,7 @@ class puppet::agent::config inherits puppet::config {
     'splaylimit':        value => $::puppet::splaylimit;
     'runinterval':       value => $::puppet::runinterval;
     'runtimeout':        value => $::puppet::runtimeout;
+    'disable_i18n':      value => $::puppet::disable_i18n;
     'noop':              value => $::puppet::agent_noop;
     'usecacheonfailure': value => $::puppet::usecacheonfailure;
   }

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -12,6 +12,7 @@ class puppet::agent::config inherits puppet::config {
     'splay':             value => $::puppet::splay;
     'splaylimit':        value => $::puppet::splaylimit;
     'runinterval':       value => $::puppet::runinterval;
+    'runtimeout':        value => $::puppet::runtimeout;
     'noop':              value => $::puppet::agent_noop;
     'usecacheonfailure': value => $::puppet::usecacheonfailure;
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,10 @@
 # $runinterval::                            Set up the interval (in seconds) to run
 #                                           the puppet agent.
 #
+# $runtimeout::                             The maximum amount of time an agent run is allowed
+#                                           to take. A Puppet agent run that exceeds this timeout
+#                                           will be aborted. Defaults to 0, which is unlimited.
+#
 # $autosign::                               If set to a boolean, autosign is enabled or disabled
 #                                           for all incoming requests. Otherwise this has to be
 #                                           set to the full file path of an autosign.conf file or
@@ -450,7 +454,7 @@
 #                                           JRuby from the pool. (Puppetserver 5.x only)
 #                                           Defaults to 0 (disabled) for Puppetserver >= 5.0
 #
-# $server_max_retry_delay::                 Sets the upper limit for the random sleep set as a Retry-After header on 
+# $server_max_retry_delay::                 Sets the upper limit for the random sleep set as a Retry-After header on
 #                                           503 responses returned when max-queued-requests is enabled. (Puppetserver 5.x only)
 #                                           Defaults to 1800 for Puppetserver >= 5.0
 #
@@ -576,6 +580,7 @@ class puppet (
   Optional[String] $autosign_content = $puppet::params::autosign_content,
   Optional[String] $autosign_source = $puppet::params::autosign_source,
   Integer[0] $runinterval = $puppet::params::runinterval,
+  Integer[0] $runtimeout = $puppet::params::runtimeout,
   Boolean $usecacheonfailure = $puppet::params::usecacheonfailure,
   Enum['cron', 'service', 'systemd.timer', 'none'] $runmode = $puppet::params::runmode,
   Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,11 @@
 #                                           to take. A Puppet agent run that exceeds this timeout
 #                                           will be aborted. Defaults to 0, which is unlimited.
 #
+# $disable_i18n::                           If true, turns off all translations of Puppet and module
+#                                           log messages, which affects error, warning and info log
+#                                           messages, as well as any translations in the report
+#                                           and CLI. Defaults to false.
+#
 # $autosign::                               If set to a boolean, autosign is enabled or disabled
 #                                           for all incoming requests. Otherwise this has to be
 #                                           set to the full file path of an autosign.conf file or
@@ -581,6 +586,7 @@ class puppet (
   Optional[String] $autosign_source = $puppet::params::autosign_source,
   Integer[0] $runinterval = $puppet::params::runinterval,
   Integer[0] $runtimeout = $puppet::params::runtimeout,
+  Boolean $disable_i18n = $puppet::params::disable_i18n,
   Boolean $usecacheonfailure = $puppet::params::usecacheonfailure,
   Enum['cron', 'service', 'systemd.timer', 'none'] $runmode = $puppet::params::runmode,
   Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class puppet::params {
   $splay               = false
   $splaylimit          = '1800'
   $runinterval         = 1800
+  $runtimeout          = 0
   $runmode             = 'service'
 
   # Not defined here as the commands depend on module parameter "dir"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class puppet::params {
   $splaylimit          = '1800'
   $runinterval         = 1800
   $runtimeout          = 0
+  $disable_i18n        = false
   $runmode             = 'service'
 
   # Not defined here as the commands depend on module parameter "dir"


### PR DESCRIPTION
- `runtimeout` The maximum amount of time an agent run is allowed to take. [Release notes](https://puppet.com/docs/puppet/5.3/release_notes.html#new-features-1)

- `disable_i18n` If set to true, Puppet disables translated strings in log messages, reports, and parts of the command-line interface. This can improve performance, especially if you don’t need all strings translated from English. This setting is false by default in open source Puppet. [Release notes](https://puppet.com/docs/puppet/5.3/release_notes.html#new-feature-disabling-internationalized-strings)