### PR TITLE
Allowing the package_source to be an Httpurl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -563,7 +563,7 @@ class puppet (
   Optional[String] $dir_owner = $puppet::params::dir_owner,
   Optional[String] $dir_group = $puppet::params::dir_group,
   Optional[String] $package_provider = $puppet::params::package_provider,
-  Optional[Stdlib::Absolutepath] $package_source = $puppet::params::package_source,
+  Optional[Variant[Stdlib::Absolutepath, Stdlib::Httpurl]] $package_source = $puppet::params::package_source,
   Integer[0, 65535] $port = $puppet::params::port,
   Boolean $listen = $puppet::params::listen,
   Array[String] $listen_to = $puppet::params::listen_to,

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -85,6 +85,46 @@ describe 'puppet' do
 
         it { should contain_puppet__config__main('ca_port').with_value(8140) }
       end
+
+      describe 'with package_source => Httpurl' do
+        let :params do {
+          :package_source => 'https://example.com:123/test'
+        } end
+
+        if facts[:osfamily] != 'windows'
+          it { is_expected.to compile }
+        end
+      end
+
+      describe 'with package_source => Unixpath' do
+        let :params do {
+          :package_source => '/test/folder/path/source.rpm'
+        } end
+
+        if facts[:osfamily] != 'windows'
+          it { is_expected.to compile }
+        end
+      end
+
+      describe 'with package_source => Windowspath' do
+        let :params do {
+          :package_source => 'C:\test\folder\path\source.exe'
+        } end
+
+        if facts[:osfamily] != 'windows'
+          it { is_expected.to compile }
+        end
+      end
+
+      describe 'with package_source => foo' do
+        let :params do {
+          :package_source => 'foo'
+        } end
+
+        if facts[:osfamily] != 'windows'
+          it { is_expected.not_to compile }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Allow httpurl arguments for the pacakge reosurce.

In previous releases this value was not checked and when used with providers like chocolatey, it can support httpurl. The module should not restrict this parameter type so heavily.