### PR TITLE
Use the correct Stdlib::HTTPUrl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -563,7 +563,7 @@ class puppet (
   Optional[String] $dir_owner = $puppet::params::dir_owner,
   Optional[String] $dir_group = $puppet::params::dir_group,
   Optional[String] $package_provider = $puppet::params::package_provider,
-  Optional[Variant[Stdlib::Absolutepath, Stdlib::Httpurl]] $package_source = $puppet::params::package_source,
+  Optional[Variant[Stdlib::Absolutepath, Stdlib::HTTPUrl]] $package_source = $puppet::params::package_source,
   Integer[0, 65535] $port = $puppet::params::port,
   Boolean $listen = $puppet::params::listen,
   Array[String] $listen_to = $puppet::params::listen_to,


### PR DESCRIPTION
96a514149a35defcfbffefe085a0a9bebf920873 allowed an additional type but it's not matching the case of the type. Somehow the tests do pass so Puppet isn't that particular about it but it looks like Kafo is.