### PR TITLE
WIP: Add systemd_randomizeddelaysec

### DIFF
--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -18,6 +18,8 @@ class puppet::agent::service::systemd (
           default => $::puppet::systemd_cmd,
         }
 
+        $randomizeddelaysec = $::puppet::systemd_randomizeddelaysec
+
         file { "/etc/systemd/system/${::puppet::systemd_unit_name}.timer":
           content => template('puppet/agent/systemd.puppet-run.timer.erb'),
           notify  => [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -584,7 +584,7 @@ class puppet (
   Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,
   Optional[String] $cron_cmd = $puppet::params::cron_cmd,
   Optional[String] $systemd_cmd = $puppet::params::systemd_cmd,
-  Optional[Integer[0]] $systemd_randomizeddelaysec = $puppet::params::systemd_randomizeddelaysec,
+  Integer[0] $systemd_randomizeddelaysec = $puppet::params::systemd_randomizeddelaysec,
   Boolean $agent_noop = $puppet::params::agent_noop,
   Boolean $show_diff = $puppet::params::show_diff,
   Optional[Stdlib::HTTPUrl] $module_repository = $puppet::params::module_repository,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,7 +114,8 @@
 #                                           set 'systemd.timer'.
 #
 # $systemd_randomizeddelaysec::             Adds a random delay between 0 and this value
-#                                           (in seconds) to the timer.
+#                                           (in seconds) to the timer. Only relevant when
+#                                           runmode is 'systemd.timer'.
 #
 # $show_diff::                              Show and report changed files with diff output
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,9 @@
 # $systemd_cmd::                            Specify command to launch when runmode is
 #                                           set 'systemd.timer'.
 #
+# $systemd_randomizeddelaysec::             Adds a random delay between 0 and this value
+#                                           (in seconds) to the timer.
+#
 # $show_diff::                              Show and report changed files with diff output
 #
 # $module_repository::                      Use a different puppet module repository
@@ -581,6 +584,7 @@ class puppet (
   Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,
   Optional[String] $cron_cmd = $puppet::params::cron_cmd,
   Optional[String] $systemd_cmd = $puppet::params::systemd_cmd,
+  Optional[Integer[0]] $systemd_randomizeddelaysec = $puppet::params::systemd_randomizeddelaysec,
   Boolean $agent_noop = $puppet::params::agent_noop,
   Boolean $show_diff = $puppet::params::show_diff,
   Optional[Stdlib::HTTPUrl] $module_repository = $puppet::params::module_repository,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,8 @@ class puppet::params {
   $aio_package      = ($::osfamily == 'Windows' or $::rubysitedir =~ /\/opt\/puppetlabs\/puppet/)
   $deb_naio_package = ($::osfamily == 'Debian')
 
+  $systemd_randomizeddelaysec = 0
+
   case $::osfamily {
     'Windows' : {
       # Windows prefixes normal paths with the Data Directory's path and leaves 'puppet' off the end

--- a/spec/classes/puppet_agent_service_systemd_spec.rb
+++ b/spec/classes/puppet_agent_service_systemd_spec.rb
@@ -68,6 +68,9 @@ describe 'puppet::agent::service::systemd' do
             should contain_file('/etc/systemd/system/puppet-run.timer').
               with_content(/.*OnCalendar\=\*-\*-\* \*\:10,40:00.*/)
 
+            should contain_file('/etc/systemd/system/puppet-run.timer').
+              with_content(/.*RandomizedDelaySec\=0.*/)
+
             should contain_file('/etc/systemd/system/puppet-run.service').
               with_content(/.*ExecStart=#{bindir}\/puppet agent --config #{confdir}\/puppet.conf --onetime --no-daemonize.*/)
 

--- a/spec/classes/puppet_agent_service_systemd_spec.rb
+++ b/spec/classes/puppet_agent_service_systemd_spec.rb
@@ -69,7 +69,7 @@ describe 'puppet::agent::service::systemd' do
               with_content(/.*OnCalendar\=\*-\*-\* \*\:10,40:00.*/)
 
             should contain_file('/etc/systemd/system/puppet-run.timer').
-              with_content(/.*RandomizedDelaySec\=0.*/)
+              with_content(/^RandomizedDelaySec\=0$/)
 
             should contain_file('/etc/systemd/system/puppet-run.service').
               with_content(/.*ExecStart=#{bindir}\/puppet agent --config #{confdir}\/puppet.conf --onetime --no-daemonize.*/)

--- a/templates/agent/systemd.puppet-run.timer.erb
+++ b/templates/agent/systemd.puppet-run.timer.erb
@@ -4,6 +4,7 @@ Description=Systemd Timer for Puppet Agent
 [Timer]
 OnCalendar=*-*-* <%= Array(@times[0]).join(',') %>:<%= Array(@times[1]).join(',') %>:00
 Persistent=true
+RandomizedDelaySec=<%= @randomizeddelaysec %>
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Allow configuration of the RandomizedDelaySec parameter of the systemd
timer, which allows randomizing Puppet runs in a way that lets the
administrator see exact moment of the next Puppet run. There's no
incompatibility between Puppet's internal splay and this, but both
probably shouldn't be used together.

This probably still needs adjustments to existing tests.