### PR TITLE
adding support for Amazon Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -342,14 +342,15 @@ class puppet::params {
       # PSBM is a CentOS 6 based distribution
       # it reports its $osreleasemajor as 2, not 6.
       # thats why we're matching for '2' in both parts
+      # Amazon Linux is like RHEL6 but reports its osreleasemajor as 2017.
       $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1') # workaround for the possibly missing operatingsystemmajrelease
       $agent_restart_command = $osreleasemajor ? {
-        /^(2|5|6)$/ => "/sbin/service ${service_name} reload",
+        /^(2|5|6|2017)$/ => "/sbin/service ${service_name} reload",
         '7'       => "/usr/bin/systemctl reload-or-restart ${service_name}",
         default   => undef,
       }
       $unavailable_runmodes = $osreleasemajor ? {
-        /^(2|5|6)$/ => ['systemd.timer'],
+        /^(2|5|6|2017)$/ => ['systemd.timer'],
         default   => [],
       }
     }


### PR DESCRIPTION
This has been tested on the latest Amazon Linux AMI in agent mode. 

Fixes:
`Error: /Stage[main]/Puppet::Agent::Service::Systemd/Service[puppet-run.timer]: Provider systemd is not functional on this host`

I have added "2017" to the regex of $agent_restart_command and $unavailable_runmodes. Without it, the code will try to stop the systemd timer which will fail because systemd is not being used on Amazon Linux (yet).