### PR TITLE
[WIP] Refs #23477 - Set PuppetCA-signscript as default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,9 +47,9 @@
 # $autosign::                               If set to a boolean, autosign is enabled or disabled
 #                                           for all incoming requests. Otherwise this has to be
 #                                           set to the full file path of an autosign.conf file or
-#                                           an autosign script. If this is set to a script, make
-#                                           sure that script considers the content of autosign.conf
-#                                           as otherwise Foreman functionality might be broken.
+#                                           an autosign script. Do not change if you want to use
+#                                           foreman's default token verification. The script will
+#                                           be provided by puppet-foreman_proxy for PuppetCAs.
 #
 # $autosign_entries::                       A list of certnames or domain name globs
 #                                           whose certificate requests will automatically be signed.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -154,9 +154,9 @@ class puppet::params {
 
   $configtimeout = undef
 
-  $autosign         = "${dir}/autosign.conf"
+  $autosign         = '/usr/libexec/puppet_signscript.rb'
   $autosign_entries = []
-  $autosign_mode    = '0664'
+  $autosign_mode    = '0770'
   $autosign_content = undef
   $autosign_source  = undef
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -196,13 +196,15 @@ class puppet::server::config inherits puppet::config {
     } else {
       $autosign_content = undef
     }
-    file { $::puppet::server::autosign:
-      ensure  => file,
-      owner   => $::puppet::server::user,
-      group   => $::puppet::server::group,
-      mode    => $::puppet::server::autosign_mode,
-      content => $autosign_content,
-      source  => $::puppet::server::autosign_source,
+    if $autosign_content != undef or $::puppet::server::autosign_source != undef {
+      file { $::puppet::server::autosign:
+        ensure  => file,
+        owner   => $::puppet::server::user,
+        group   => $::puppet::server::group,
+        mode    => $::puppet::server::autosign_mode,
+        content => $autosign_content,
+        source  => $::puppet::server::autosign_source,
+      }
     }
   }
 

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -142,13 +142,11 @@ describe 'puppet::server::config' do
           should contain_puppet__config__master('ca').with({'value' => 'true'})
           should contain_puppet__config__master('ssldir').with({'value' => "#{ssldir}"})
           should contain_puppet__config__master('parser').with({'value' => 'current'})
-          should contain_puppet__config__master("autosign").with({'value' => "#{etcdir}\/autosign.conf \{ mode = 0664 \}"})
+          should contain_puppet__config__master("autosign").with_value("/usr/libexec/puppet_signscript.rb { mode = 0770 }")
 
           should contain_concat(conf_file)
 
           should_not contain_puppet__config__master('storeconfigs')
-
-          should contain_file("#{etcdir}/autosign.conf")
         end
 
         it 'should not set configtimeout' do
@@ -191,12 +189,14 @@ describe 'puppet::server::config' do
       describe "when autosign_entries is not set" do
         let :pre_condition do
           "class {'puppet':
-              server  => true,
+              server        => true,
+              autosign      => \"#{confdir}/autosign.conf\",
+              autosign_mode => '0664',
            }"
         end
 
         it 'should contain autosign.conf with out content set' do
-          should contain_file("#{confdir}/autosign.conf")
+          should_not contain_file("#{confdir}/autosign.conf")
           should_not contain_file("#{confdir}/autosign.conf").with_content(/# Managed by Puppet/)
           should_not contain_file("#{confdir}/autosign.conf").with_content(/foo.bar/)
         end
@@ -207,6 +207,8 @@ describe 'puppet::server::config' do
           "class {'puppet':
               server           => true,
               autosign_entries => ['foo.bar'],
+              autosign         => \"#{confdir}/autosign.conf\",
+              autosign_mode    => '0664',
            }"
         end
 
@@ -221,6 +223,8 @@ describe 'puppet::server::config' do
         let :pre_condition do
           "class {'puppet':
               server           => true,
+              autosign         => \"#{confdir}/autosign.conf\",
+              autosign_mode    => '0664',
               autosign_content => 'foo.bar',
               autosign_entries => ['foo.bar'],
            }"
@@ -235,6 +239,8 @@ describe 'puppet::server::config' do
               server           => true,
               autosign_source  => 'puppet:///foo/bar',
               autosign_entries => ['foo.bar'],
+              autosign         => \"#{confdir}/autosign.conf\",
+              autosign_mode    => '0664',
            }"
         end
 


### PR DESCRIPTION
Sets the puppet_signscript that is distributed via puppet-forman_proxy on PuppetCA-SmartProxys as the default autosign-configuration in the puppet.conf to enable the new token based autosigning.

See also PRs in [foreman-core](https://github.com/theforeman/foreman/pull/5465), [smart-proxy](https://github.com/theforeman/smart-proxy/pull/576), [community-templates](https://github.com/theforeman/community-templates/pull/475) & [puppet-foreman_proxy](https://github.com/theforeman/puppet-foreman_proxy/pull/425).

We would like to see some feedback early on while we are testing this thoroughly.