### PR TITLE
Allow arrays for `server_jvm_extra_args` parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -707,7 +707,7 @@ class puppet (
   String $server_jvm_config = $puppet::params::server_jvm_config,
   Pattern[/^[0-9]+[kKmMgG]$/] $server_jvm_min_heap_size = $puppet::params::server_jvm_min_heap_size,
   Pattern[/^[0-9]+[kKmMgG]$/] $server_jvm_max_heap_size = $puppet::params::server_jvm_max_heap_size,
-  String $server_jvm_extra_args = $puppet::params::server_jvm_extra_args,
+  Variant[String,Array[String]] $server_jvm_extra_args = $puppet::params::server_jvm_extra_args,
   Optional[String] $server_jvm_cli_args = $puppet::params::server_jvm_cli_args,
   Optional[Stdlib::Absolutepath] $server_jruby_gem_home = $puppet::params::server_jruby_gem_home,
   Integer[1] $server_max_active_instances = $puppet::params::server_max_active_instances,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -427,7 +427,7 @@ class puppet::server(
   String $jvm_config = $::puppet::server_jvm_config,
   Pattern[/^[0-9]+[kKmMgG]$/] $jvm_min_heap_size = $::puppet::server_jvm_min_heap_size,
   Pattern[/^[0-9]+[kKmMgG]$/] $jvm_max_heap_size = $::puppet::server_jvm_max_heap_size,
-  String $jvm_extra_args = $::puppet::server_jvm_extra_args,
+  Variant[String,Array[String]] $jvm_extra_args = $::puppet::server_jvm_extra_args,
   Optional[String] $jvm_cli_args = $::puppet::server_jvm_cli_args,
   Optional[Stdlib::Absolutepath] $jruby_gem_home = $::puppet::server_jruby_gem_home,
   Integer[1] $max_active_instances = $::puppet::server_max_active_instances,


### PR DESCRIPTION
The tests for puppet::server::puppetserver already cover using an array
of strings for this parameter, but the base classes forbid it.
https://github.com/theforeman/puppet-puppet/blob/ee01cffe239c5080c784d17a37a34742fc7db0fe/spec/classes/puppet_server_puppetserver_spec.rb#L823