### PR TITLE
Support ssl-protocols option for puppetserver configuration

### DIFF
--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -585,6 +585,8 @@ class puppet::server::puppetserver (
     'webserver.ssl-key'                   => $server_ssl_cert_key,
     'webserver.ssl-ca-cert'               => $server_ssl_ca_cert,
     'webserver.idle-timeout-milliseconds' => $server_web_idle_timeout,
+    'webserver.ssl-protocols'             => $server_ssl_protocols,
+    'webserver.cipher-suites'             => $server_cipher_suites,
   }
 
   $webserver_general_settings.each |$setting, $value| {

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -770,6 +770,47 @@ describe 'puppet::server::config' do
         end
       end
 
+      describe 'with ssl_protocols overwritten' do
+        let :pre_condition do
+          "class {'puppet':
+              server                    => true,
+              server_implementation     => 'puppetserver',
+              server_ca                 => true,
+              server_puppetserver_dir   => '/etc/custom/puppetserver',
+              server_ssl_protocols      => ['TLSv1.1', 'TLSv1.2'],
+           }"
+        end
+
+        it 'should set the ssl protocols' do
+          should contain_hocon_setting('webserver.ssl-protocols').
+            with_path('/etc/custom/puppetserver/conf.d/webserver.conf').
+            with_setting('webserver.ssl-protocols').
+            with_value(['TLSv1.1', 'TLSv1.2']).
+            with_ensure('present')
+        end
+      end
+
+      describe 'with cipher-suites overwritten' do
+        let :pre_condition do
+          "class {'puppet':
+              server                    => true,
+              server_implementation     => 'puppetserver',
+              server_ca                 => true,
+              server_puppetserver_dir   => '/etc/custom/puppetserver',
+              server_cipher_suites      => ['TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA'],
+           }"
+        end
+
+        it 'should set the cipher suite' do
+          should contain_hocon_setting('webserver.cipher-suites').
+            with_path('/etc/custom/puppetserver/conf.d/webserver.conf').
+            with_setting('webserver.cipher-suites').
+            with_value(['TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA']).
+            with_ensure('present')
+        end
+      end
+
+
       describe 'with ssl_chain_filepath overwritten' do
         let :pre_condition do
           "class {'puppet':


### PR DESCRIPTION
When the initial puppetserver configs were done, I think there was some confusion about the various TLS settings for puppetserver.  Currently server_ssl_protocols and server_cipher_suites limit what puppetserver [will use as a client](https://github.com/theforeman/puppet-puppet/blob/master/templates/server/puppetserver/conf.d/puppetserver.conf.erb#L81-L95).  To also restrict what the server makes available, it needs to be done in webserver.conf, too.
