### PR TITLE
puppet_ca_proxy - include cert/key combo into apache vhosts

### DIFF
--- a/manifests/server/combine_certs.pp
+++ b/manifests/server/combine_certs.pp
@@ -5,17 +5,17 @@ define puppet::server::combine_certs(
   $cert     = $::puppet::server::ssl_cert,
   $key      = $::puppet::server::ssl_cert_key,
 ) {
-    $dir = dirname($combined)
+  $dir = dirname($combined)
 
-    $file_cert = file($cert)
-    $file_key  = file($key)
+  $file_cert = file($cert)
+  $file_key  = file($key)
 
-    file { $dir:
-      ensure => directory,
-    }
-
-    file { $combined:
-      ensure  => file,
-      content => "${file_cert}${file_key}",
-    }
+  file { $dir:
+    ensure => directory,
   }
+
+  file { $combined:
+    ensure  => file,
+    content => "${file_cert}${file_key}",
+  }
+}

--- a/manifests/server/combine_certs.pp
+++ b/manifests/server/combine_certs.pp
@@ -1,0 +1,21 @@
+# combine the public x509 certificate and private key into one file
+#
+define puppet::server::combine_certs(
+  $combined = $::puppet::server::passenger::ssl_combined,
+  $cert     = $::puppet::server::ssl_cert,
+  $key      = $::puppet::server::ssl_cert_key,
+) {
+    $dir = dirname($combined)
+
+    $file_cert = file($cert)
+    $file_key  = file($key)
+
+    file { $dir:
+      ensure => directory,
+    }
+
+    file { $combined:
+      ensure  => file,
+      content => "${file_cert}${file_key}",
+    }
+  }

--- a/manifests/server/combine_certs.pp
+++ b/manifests/server/combine_certs.pp
@@ -1,9 +1,9 @@
 # combine the public x509 certificate and private key into one file
 #
 define puppet::server::combine_certs(
-  $combined = $::puppet::server::passenger::ssl_combined,
-  $cert     = $::puppet::server::ssl_cert,
-  $key      = $::puppet::server::ssl_cert_key,
+  $combined = undef,
+  $cert     = undef,
+  $key      = undef,
 ) {
   $dir = dirname($combined)
 

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -60,7 +60,11 @@ class puppet::server::passenger (
   ]
 
   if $puppet_ca_proxy and $puppet_ca_proxy != '' {
-    puppet::server::combine_certs { $ssl_combined: }
+    puppet::server::combine_certs { $ssl_combined:
+      combined => $ssl_combined,
+      cert     => $ssl_cert,
+      key      => $ssl_cert_key,
+    }
 
     include ::apache::mod::proxy
     include ::apache::mod::proxy_http

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -32,22 +32,6 @@ class puppet::server::passenger (
   $ssl_combined_name = basename($ssl_cert)
   $ssl_combined = "${ssl_dir}/combined/${ssl_combined_name}"
 
-  define puppet::server::passenger::combined_certs($combined, $cert, $key) {
-    $dir = dirname($combined)
-
-    $file_cert = file($cert)
-    $file_key  = file($key)
-
-    file { $dir:
-      ensure => directory,
-    }
-
-    file { $combined:
-      ensure  => file,
-      content => "${file_cert}${file_key}",
-    }
-  }
-
   $directory = {
     'path'              => "${app_root}/public/",
     'passenger_enabled' => 'On',
@@ -76,11 +60,7 @@ class puppet::server::passenger (
   ]
 
   if $puppet_ca_proxy and $puppet_ca_proxy != '' {
-    puppet::server::passenger::combined_certs { $ssl_combined:
-      combined => $ssl_combined,
-      cert     => $ssl_cert,
-      key      => $ssl_cert_key,
-    }
+    puppet::server::combine_certs { $ssl_combined: }
 
     include ::apache::mod::proxy
     include ::apache::mod::proxy_http

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -32,19 +32,19 @@ class puppet::server::passenger (
   $ssl_combined_name = basename($ssl_cert)
   $ssl_combined = "${ssl_dir}/combined/${ssl_combined_name}"
 
-  define combined_certs($combined, $cert, $key) {
+  define puppet::server::passenger::combined_certs($combined, $cert, $key) {
     $dir = dirname($combined)
 
     $file_cert = file($cert)
-    $file_key = file($key)
+    $file_key  = file($key)
 
     file { $dir:
-      ensure => directory
+      ensure => directory,
     }
 
     file { $combined:
-      ensure => file,
-      content => "${file_cert}${file_key}"
+      ensure  => file,
+      content => "${file_cert}${file_key}",
     }
   }
 
@@ -76,10 +76,10 @@ class puppet::server::passenger (
   ]
 
   if $puppet_ca_proxy and $puppet_ca_proxy != '' {
-    combined_certs { $ssl_combined:
+    puppet::server::passenger::combined_certs { $ssl_combined:
       combined => $ssl_combined,
       cert     => $ssl_cert,
-      key      => $ssl_cert_key
+      key      => $ssl_cert_key,
     }
 
     include ::apache::mod::proxy

--- a/manifests/server/passenger.pp
+++ b/manifests/server/passenger.pp
@@ -29,6 +29,25 @@ class puppet::server::passenger (
   include ::apache::mod::passenger
   contain 'puppet::server::rack' # lint:ignore:relative_classname_inclusion (PUP-1597)
 
+  $ssl_combined_name = basename($ssl_cert)
+  $ssl_combined = "${ssl_dir}/combined/${ssl_combined_name}"
+
+  define combined_certs($combined, $cert, $key) {
+    $dir = dirname($combined)
+
+    $file_cert = file($cert)
+    $file_key = file($key)
+
+    file { $dir:
+      ensure => directory
+    }
+
+    file { $combined:
+      ensure => file,
+      content => "${file_cert}${file_key}"
+    }
+  }
+
   $directory = {
     'path'              => "${app_root}/public/",
     'passenger_enabled' => 'On',
@@ -57,10 +76,16 @@ class puppet::server::passenger (
   ]
 
   if $puppet_ca_proxy and $puppet_ca_proxy != '' {
+    combined_certs { $ssl_combined:
+      combined => $ssl_combined,
+      cert     => $ssl_cert,
+      key      => $ssl_cert_key
+    }
+
     include ::apache::mod::proxy
     include ::apache::mod::proxy_http
 
-    $custom_fragment = "ProxyPassMatch ^/([^/]+/certificate.*)$ ${puppet_ca_proxy}/\$1"
+    $custom_fragment = "ProxyPassMatch ^/([^/]+/certificate.*)$ ${puppet_ca_proxy}/\$1\n  SSLProxyMachineCertificateFile ${ssl_combined}"
     $ssl_proxyengine = true
   } else {
     $custom_fragment = undef


### PR DESCRIPTION
Change passenger.pp to combine the ssl_cert and ssl_cert_key into a combined
cert file, which can then be used for SSLProxyMachineCertificateFile
directive. Add the new directive to allow the ProxyPassMatch directive to
work with some protected URLs on the master CA. (ex:
certificate_revocation_list).

Fixes GH-611