### PR TITLE
updated auth.conf for the "puppet facts upload" command (puppetserver 5.5)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -448,7 +448,9 @@ class puppet::params {
   $server_use_legacy_auth_conf      = false
 
   # For Puppetserver, certain configuration parameters are version specific. We assume a particular version here.
-  if versioncmp($::puppetversion, '5.1.0') >= 0 {
+  if versioncmp($::puppetversion, '5.3.0') >= 0 {
+    $server_puppetserver_version = '5.3.0'
+  } elsif versioncmp($::puppetversion, '5.1.0') >= 0 {
     $server_puppetserver_version = '5.1.0'
   } elsif versioncmp($::puppetversion, '5.0.0') >= 0 {
     $server_puppetserver_version = '5.0.0'

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -707,6 +707,35 @@ describe 'puppet::server::puppetserver' do
         end
       end
 
+      describe 'puppet facts upload' do
+        context 'when server_puppetserver_version >= 5.3' do
+          let(:params) do
+            default_params.merge(
+              :server_puppetserver_version => '5.3.0',
+              :server_puppetserver_dir     => '/etc/custom/puppetserver',
+            )
+          end
+
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/auth.conf').
+              with_content(%r{^(\ *)path: "\^/puppet/v3/facts/(.*)$})
+          }
+        end
+
+        context 'when server_puppetserver_version < 5.3' do
+          let(:params) do
+            default_params.merge(
+              :server_puppetserver_version => '5.2.0',
+              :server_puppetserver_dir     => '/etc/custom/puppetserver',
+            )
+          end
+
+          it {
+            should contain_file('/etc/custom/puppetserver/conf.d/auth.conf').
+              without_content(%r{^(\ *)path: "\^/puppet/v3/facts/(.*)$})
+          }
+        end
+      end
 
       describe 'server_trusted_agents' do
         context 'when set' do

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -233,7 +233,7 @@ authorization: {
             name: "puppetlabs facts"
         },
 <%- end -%>
-	{
+        {
             match-request: {
                 path: "/puppet/v3/status"
                 type: path

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -220,7 +220,7 @@ authorization: {
             sort-order: 500
             name: "puppetlabs report"
         },
-<%- if scope.function_versioncmp([@server_puppetserver_version, '5.5']) >= 0 -%>
+<%- if scope.function_versioncmp([@server_puppetserver_version, '5.3']) >= 0 -%>
         {
             # Allow nodes to update their own facts
             match-request: {

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -220,7 +220,20 @@ authorization: {
             sort-order: 500
             name: "puppetlabs report"
         },
+<%- if scope.function_versioncmp([@server_puppetserver_version, '5.5']) >= 0 -%>
         {
+            # Allow nodes to update their own facts
+            match-request: {
+                path: "^/puppet/v3/facts/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs facts"
+        },
+<%- end -%>
+	{
             match-request: {
                 path: "/puppet/v3/status"
                 type: path


### PR DESCRIPTION
Updated auth.conf.erb to add support for the "puppet facts upload" command (as introduced in puppetserver v5.5).

See also:
- https://github.com/puppetlabs/puppetserver/blob/master/ezbake/config/conf.d/auth.conf (current default auth.conf)
- https://puppet.com/docs/puppet/5.5/man/facts.html (man page for puppet facts)
- https://tickets.puppetlabs.com/browse/PUP-8232 (Jira issue tickets.puppetlabs.com)  