### PR TITLE
Pin networking.ip fact in specs

### DIFF
--- a/spec/classes/puppet_agent_service_cron_spec.rb
+++ b/spec/classes/puppet_agent_service_cron_spec.rb
@@ -12,7 +12,9 @@ describe 'puppet::agent::service::cron' do
       end
 
       let :facts do
-        facts.merge(ipaddress: '192.0.2.100')
+        result = facts.merge(ipaddress: '192.0.2.100')
+        result[:networking]['ip'] = '192.0.2.100' if result[:networking]
+        result
       end
 
       describe 'when runmode is not cron' do

--- a/spec/classes/puppet_agent_service_systemd_spec.rb
+++ b/spec/classes/puppet_agent_service_systemd_spec.rb
@@ -15,7 +15,9 @@ describe 'puppet::agent::service::systemd' do
       end
 
       let :facts do
-        facts.merge(ipaddress: '192.0.2.100')
+        result = facts.merge(ipaddress: '192.0.2.100')
+        result[:networking]['ip'] = '192.0.2.100' if result[:networking]
+        result
       end
 
       describe 'when runmode is not systemd' do


### PR DESCRIPTION
puppet-extlib ip_to_cron switched to the networking.ip fact. This pins the ip if networking is present to maintain compatibility with Facter 2.