### PR TITLE
Add shared gem path for Puppetserver >= 5.3

### DIFF
--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -140,6 +140,7 @@ class puppet::server::puppetserver (
   $jvm_cmd = strip(join(flatten($jvm_cmd_arr), ' '))
 
   if $::osfamily == 'FreeBSD' {
+    $server_gem_paths = [ '${jruby-puppet.gem-home}', "\"${server_puppetserver_vardir}/vendored-jruby-gems\"", ] # lint:ignore:single_quote_string_with_variables
     augeas { 'puppet::server::puppetserver::jvm':
       context => '/files/etc/rc.conf',
       changes => [ "set puppetserver_java_opts '\"${jvm_cmd}\"'" ],
@@ -170,6 +171,12 @@ class puppet::server::puppetserver (
       $bootstrap_paths = "${server_puppetserver_dir}/services.d/,/opt/puppetlabs/server/apps/puppetserver/config/services.d/"
     } else { # 2.4
       $bootstrap_paths = "${server_puppetserver_dir}/bootstrap.cfg"
+    }
+
+    if versioncmp($server_puppetserver_version, '5.3') >= 0 {
+      $server_gem_paths = [ '${jruby-puppet.gem-home}', "\"${server_puppetserver_vardir}/vendored-jruby-gems\"", "\"/opt/puppetlabs/puppet/lib/ruby/vendor_gems\""] # lint:ignore:single_quote_string_with_variables
+    } else {
+      $server_gem_paths = [ '${jruby-puppet.gem-home}', "\"${server_puppetserver_vardir}/vendored-jruby-gems\"", ] # lint:ignore:single_quote_string_with_variables
     }
 
     augeas { 'puppet::server::puppetserver::bootstrap':

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -830,6 +830,41 @@ describe 'puppet::server::puppetserver' do
         end
       end
 
+      describe 'gem-path' do
+        context 'when server_puppetserver_version > 2.7 but < 5.3' do
+          let(:params) do
+            default_params.merge(
+              :server_puppetserver_version => '5.0.0',
+            )
+          end
+
+          it 'should have gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"] in config' do
+            content = catalogue.resource('file', '/etc/custom/puppetserver/conf.d/puppetserver.conf').send(:parameters)[:content]
+            expect(content).to include(%Q[    gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"]\n])
+          end
+        end
+
+        context 'when server_puppetserver_version >= 5.3' do
+          let(:params) do
+            default_params.merge(
+              :server_puppetserver_version => '5.3.0',
+            )
+          end
+
+          if facts[:osfamily] == 'FreeBSD'
+            it 'should have gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems", "/opt/puppetlabs/puppet/lib/ruby/vendor_gems"] in config' do
+              content = catalogue.resource('file', '/etc/custom/puppetserver/conf.d/puppetserver.conf').send(:parameters)[:content]
+              expect(content).to include(%Q[    gem-path: [${jruby-puppet.gem-home}, "/var/puppet/server/data/puppetserver/vendored-jruby-gems"]\n])
+            end
+          else
+            it 'should have gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems", "/opt/puppetlabs/puppet/lib/ruby/vendor_gems"] in config' do
+              content = catalogue.resource('file', '/etc/custom/puppetserver/conf.d/puppetserver.conf').send(:parameters)[:content]
+              expect(content).to include(%Q[    gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems", "/opt/puppetlabs/puppet/lib/ruby/vendor_gems"]\n])
+            end
+          end
+        end
+      end
+
       describe 'when server_puppetserver_version < 2.2' do
         let(:params) do
           default_params.merge(:server_puppetserver_version => '2.1.0')

--- a/templates/server/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/puppetserver.conf.erb
@@ -16,7 +16,7 @@ jruby-puppet: {
     # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
     # the gem-home directory as well as any other directories that gems can be loaded
     # from (including the vendored gems directory for gems that ship with puppetserver)
-    gem-path: [${jruby-puppet.gem-home}, "<%= @server_puppetserver_vardir %>/vendored-jruby-gems"]
+    gem-path: [<%= @server_gem_paths.join(', ') %>]
 
 <%- end -%>
     # PLEASE NOTE: Use caution when modifying the below settings. Modifying


### PR DESCRIPTION
Since 5.3.0 Puppet Server can use some gems shipped by puppet-agent. For
this the gem-path settings of puppetserver.conf needs to be extend by
/opt/puppetlabs/puppet/lib/ruby/vendor_gems. This is the default as
shipped by Puppetlabs.

Fixes GH-630.