### PR TITLE
Use facter 3 facts during tests

### DIFF
--- a/spec/classes/puppet_agent_service_cron_spec.rb
+++ b/spec/classes/puppet_agent_service_cron_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'deep_merge'
 
 describe 'puppet::agent::service::cron' do
   on_os_under_test.each do |os, facts|
@@ -12,7 +13,7 @@ describe 'puppet::agent::service::cron' do
       end
 
       let :facts do
-        facts.merge(ipaddress: '192.0.2.100')
+        facts.deep_merge(networking: { ip: '192.0.2.100' })
       end
 
       describe 'when runmode is not cron' do

--- a/spec/classes/puppet_agent_service_systemd_spec.rb
+++ b/spec/classes/puppet_agent_service_systemd_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'deep_merge'
 
 describe 'puppet::agent::service::systemd' do
   on_os_under_test.each do |os, facts|
@@ -15,7 +16,7 @@ describe 'puppet::agent::service::systemd' do
       end
 
       let :facts do
-        facts.merge(ipaddress: '192.0.2.100')
+        facts.deep_merge(networking: { ip: '192.0.2.100' })
       end
 
       describe 'when runmode is not systemd' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ end
 
 # Use the above environment variables to limit the platforms under test
 def on_os_under_test
-  on_supported_os.reject do |os, facts|
+  on_supported_os(facterversion: '3.0.0').reject do |os, facts|
     (only_test_os() && !only_test_os.include?(os)) ||
       (exclude_test_os() && exclude_test_os.include?(os))
   end


### PR DESCRIPTION
By default, rspec-puppet-facts uses the facterdb facts that match the
version of the facter gem installed.  Starting with facter 3, facter
was no longer shipped as a gem (it was rewritten in C++).

This commit sets `facterversion` to `3.0.0` so that tests run with
more modern (structured) facts stubbed.

Puppet has been shipping facter 3 since puppet 4.2.0.  This module
supports puppet >= 4.6.1, (and puppet 4 is EOL at the end of 2018).

puppet-extlib's `ip_to_cron` function (used in
puppet::agent::service::cron) has recently moved to using the
`networking` structured fact not available in facter 2.