### PR TITLE
Add support for managing jetty threads

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -537,6 +537,32 @@
 # $server_parser::                          Sets the parser to use. Valid options are 'current' or 'future'.
 #                                           Defaults to 'current'.
 #
+# $server_acceptor_threads::                This sets the number of threads that the webserver will dedicate to accepting
+#                                           socket connections for unencrypted HTTP traffic. If not provided, the webserver
+#                                           defaults to the number of virtual cores on the host divided by 8, with a minimum
+#                                           of 1 and maximum of 4.
+#
+# $server_selector_threads::                This sets the number of selectors that the webserver will dedicate to processing
+#                                           events on connected sockets for unencrypted HTTPS traffic. If not provided,
+#                                           the webserver defaults to the minimum of: virtual cores on the host divided by 2
+#                                           or max-threads divided by 16, with a minimum of 1.
+#
+# $server_max_threads::                     This sets the maximum number of threads assigned to responding to HTTP and/or
+#                                           HTTPS requests for a single webserver, effectively changing how many
+#                                           concurrent requests can be made at one time. If not provided, the
+#                                           webserver defaults to 200.
+#
+# $server_ssl_acceptor_threads::            This sets the number of threads that the webserver will dedicate to accepting
+#                                           socket connections for encrypted HTTPS traffic. If not provided, defaults to
+#                                           the number of virtual cores on the host divided by 8, with a minimum of 1 and maximum of 4.
+#
+# $server_ssl_selector_threads::            This sets the number of selectors that the webserver will dedicate to processing
+#                                           events on connected sockets for encrypted HTTPS traffic. Defaults to the number of
+#                                           virtual cores on the host divided by 2, with a minimum of 1 and maximum of 4.
+#                                           The number of selector threads actually used by Jetty is twice the number of selectors
+#                                           requested. For example, if a value of 3 is specified for the ssl-selector-threads setting,
+#                                           Jetty will actually use 6 selector threads.
+#
 # === Usage:
 #
 # * Simple usage:
@@ -735,6 +761,11 @@ class puppet (
   Boolean $server_puppetserver_experimental = $puppet::params::server_puppetserver_experimental,
   Array[String] $server_puppetserver_trusted_agents = $puppet::params::server_puppetserver_trusted_agents,
   Optional[Enum['off', 'jit', 'force']] $server_compile_mode = $puppet::params::server_compile_mode,
+  Optional[Integer[1]] $server_acceptor_threads = undef,
+  Optional[Integer[1]] $server_selector_threads = undef,
+  Optional[Integer[1]] $server_ssl_acceptor_threads = undef,
+  Optional[Integer[1]] $server_ssl_selector_threads = undef,
+  Optional[Integer[1]] $server_max_threads = undef,
 ) inherits puppet::params {
   contain puppet::config
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -454,6 +454,11 @@ class puppet::server(
   Boolean $puppetserver_experimental = $::puppet::server_puppetserver_experimental,
   Array[String] $puppetserver_trusted_agents = $::puppet::server_puppetserver_trusted_agents,
   Optional[Enum['off', 'jit', 'force']] $compile_mode = $::puppet::server_compile_mode,
+  Optional[Integer[1]] $selector_threads = $::puppet::server_selector_threads,
+  Optional[Integer[1]] $acceptor_threads = $::puppet::server_acceptor_threads,
+  Optional[Integer[1]] $ssl_selector_threads = $::puppet::server_ssl_selector_threads,
+  Optional[Integer[1]] $ssl_acceptor_threads = $::puppet::server_ssl_acceptor_threads,
+  Optional[Integer[1]] $max_threads = $::puppet::server_max_threads,
 ) {
   if $implementation == 'master' and $ip != $puppet::params::ip {
     notify {

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -123,6 +123,11 @@ class puppet::server::puppetserver (
   $server_trusted_agents                  = $::puppet::server::puppetserver_trusted_agents,
   $allow_header_cert_info                 = $::puppet::server::allow_header_cert_info,
   $compile_mode                           = $::puppet::server::compile_mode,
+  $acceptor_threads                       = $::puppet::server::acceptor_threads,
+  $selector_threads                       = $::puppet::server::selector_threads,
+  $ssl_acceptor_threads                   = $::puppet::server::ssl_acceptor_threads,
+  $ssl_selector_threads                   = $::puppet::server::ssl_selector_threads,
+  $max_threads                            = $::puppet::server::max_threads,
 ) {
   include ::puppet::server
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -75,6 +75,11 @@ describe 'puppet' do
             .with_content(/ssl-port:\s8140/)
             .without_content(/ host:\s/)
             .without_content(/ port:\s8139/)
+            .without_content(/selector-threads:/)
+            .without_content(/acceptor-threads:/)
+            .without_content(/ssl-selector-threads:/)
+            .without_content(/ssl-acceptor-threads:/)
+            .without_content(/max-threads:/)
         }
         it {
           should contain_file(auth_conf)
@@ -585,6 +590,29 @@ describe 'puppet' do
       describe 'when server_puppetserver_version < 2.2' do
         let(:params) { super().merge(server_puppetserver_version: '2.1.0') }
         it { should raise_error(Puppet::Error, /puppetserver <2.2 is not supported by this module version/) }
+      end
+
+      describe 'allow jetty specific server threads' do
+        context 'with thread config' do
+          let(:params) do
+            super().merge(
+              server_selector_threads:     1,
+              server_acceptor_threads:     2,
+              server_ssl_selector_threads: 3,
+              server_ssl_acceptor_threads: 4,
+              server_max_threads:          5
+            )
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/etc/custom/puppetserver/conf.d/webserver.conf').
+               with_content(/selector-threads: 1/).
+               with_content(/acceptor-threads: 2/).
+               with_content(/ssl-selector-threads: 3/).
+               with_content(/ssl-acceptor-threads: 4/).
+               with_content(/max-threads: 5/)
+          }
+        end
       end
     end
   end

--- a/templates/server/puppetserver/conf.d/webserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/webserver.conf.erb
@@ -27,4 +27,19 @@ webserver: {
         <%= cipher_suite %>,
     <%- end -%>
     ]
+<%- if @acceptor_threads -%>
+    acceptor-threads: <%= @acceptor_threads %>
+<%- end -%>
+<%- if @selector_threads -%>
+    selector-threads: <%= @selector_threads %>
+<%- end -%>
+<%- if @ssl_acceptor_threads -%>
+    ssl-acceptor-threads: <%= @ssl_acceptor_threads %>
+<%- end -%>
+<%- if @ssl_selector_threads -%>
+    ssl-selector-threads: <%= @ssl_selector_threads %>
+<%- end -%>
+<%- if @max_threads -%>
+    max-threads: <%= @max_threads %>
+<%- end -%>
 }


### PR DESCRIPTION
This is based on https://github.com/puppetlabs/trapperkeeper-webserver-jetty9/blob/master/doc/jetty-config.md