### PR TITLE
Mark as compatible with Puppet 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 6.0.0"
+      "version_requirement": ">= 4.6.1 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
054d079c739f25a6072915c9f2026748fc7c481e omitted this part.