### PR TITLE
Remove $deb_naio_package & puppet-common install

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,7 +51,6 @@ class puppet::params {
   $environment         = $::environment
 
   $aio_package      = ($::osfamily == 'Windows' or $::rubysitedir =~ /\/opt\/puppetlabs\/puppet/)
-  $deb_naio_package = ($::osfamily == 'Debian')
 
   $systemd_randomizeddelaysec = 0
 
@@ -131,9 +130,9 @@ class puppet::params {
         $server_jruby_gem_home      = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
       } else {
         $dir                        = '/etc/puppet'
-        $codedir                    =  $deb_naio_package ? {
-          true  => '/etc/puppet/code',
-          false => '/etc/puppet',
+        $codedir                    =  $::osfamily ? {
+          'Debian' => '/etc/puppet/code',
+          default  => '/etc/puppet',
         }
         $logdir                     = '/var/log/puppet'
         $rundir                     = '/var/run/puppet'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -278,11 +278,6 @@ class puppet::params {
 
   if $aio_package {
     $client_package = ['puppet-agent']
-  } elsif $::osfamily == 'Debian' {
-    $client_package = $deb_naio_package ? {
-      true    => ['puppet'],
-      default => ['puppet-common', 'puppet']
-    }
   } elsif ($::osfamily =~ /(FreeBSD|DragonFly)/) {
     if (versioncmp($::puppetversion, '5.0') > 0) {
       $client_package = ['puppet5']


### PR DESCRIPTION
* 7a1b62e Remove $deb_naio_package variable
* d22a852 Remove Debian package special case
This was an ancient workaround where puppet didn't properly depend on puppet-common. On Debian Jessie puppet already depends on puppet-common and everything newer has made puppet-common a dummy transitional package. This means we can remove the special case and fall back to the general else case.