### PR TITLE
Implement $server_max_open_files

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,6 +13,7 @@ fixtures:
     inifile:  'https://github.com/puppetlabs/puppetlabs-inifile.git'
     puppetdb: 'https://github.com/puppetlabs/puppetlabs-puppetdb.git'
     stdlib:   'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    systemd:  'https://github.com/camptocamp/puppet-systemd.git'
     yumrepo_core:
       repo: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'
       puppet_version: '>= 6.0.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -511,6 +511,9 @@
 # $server_ca_enable_infra_crl::             Enable the separate CRL for Puppet infrastructure nodes
 #                                           Defaults to false
 #
+# $server_max_open_files::                  Increase the max open files limit for Puppetserver.
+#                                           Defaults to undef
+#
 # === Usage:
 #
 # * Simple usage:
@@ -703,6 +706,7 @@ class puppet (
   Boolean $server_ca_allow_sans = $puppet::params::server_ca_allow_sans,
   Boolean $server_ca_allow_auth_extensions = $puppet::params::server_ca_allow_auth_extensions,
   Boolean $server_ca_enable_infra_crl = $puppet::params::server_ca_enable_infra_crl,
+  Optional[Integer[1]] $server_max_open_files = $puppet::params::server_max_open_files,
 ) inherits puppet::params {
   contain puppet::config
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -412,6 +412,7 @@ class puppet::params {
   $server_ca_allow_sans                   = false
   $server_ca_allow_auth_extensions        = false
   $server_ca_enable_infra_crl             = false
+  $server_max_open_files                  = undef
 
   $server_puppetserver_version      = undef
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -442,6 +442,7 @@ class puppet::server(
   Boolean $ca_allow_sans = $::puppet::server_ca_allow_sans,
   Boolean $ca_allow_auth_extensions = $::puppet::server_ca_allow_auth_extensions,
   Boolean $ca_enable_infra_crl = $::puppet::server_ca_enable_infra_crl,
+  Optional[Integer[1]] $max_open_files = $::puppet::server_max_open_files,
 ) {
   if $ca {
     $ssl_ca_cert     = "${ssl_dir}/ca/ca_crt.pem"

--- a/spec/acceptance/puppetserver_config_spec.rb
+++ b/spec/acceptance/puppetserver_config_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper_acceptance'
+
+describe 'Puppetserver config options', unless: ENV['BEAKER_PUPPET_COLLECTION'] == 'pc1' && fact('lsbdistcodename') == 'stretch' do
+  before(:context) do
+    if fact('lsbdistcodename') == 'jessie' && ENV['BEAKER_PUPPET_COLLECTION'] != 'pc1'
+      on default, "echo 'deb http://deb.debian.org/debian jessie-backports main' >/etc/apt/sources.list.d/backports.list"
+      on default, 'apt update'
+      on default, 'apt -y -t jessie-backports install openjdk-8-jdk-headless'
+    end
+    if check_for_package(default, 'puppetserver')
+      on default, puppet('resource package puppetserver ensure=purged')
+      on default, 'rm -rf /etc/sysconfig/puppetserver /etc/puppetlabs/puppetserver'
+      on default, 'find /etc/puppetlabs/puppet/ssl/ -type f -delete'
+    end
+
+    # puppetserver won't start with lower than 2GB memory
+    memoryfree_mb = fact('memoryfree_mb').to_i
+    raise 'At least 2048MB free memory required' if memoryfree_mb < 256
+  end
+
+  describe 'server_max_open_files' do
+    let(:pp) do
+      <<-MANIFEST
+      class { '::puppet':
+        server                   => true,
+        server_foreman           => false,
+        server_reports           => 'store',
+        server_external_nodes    => '',
+        # only for install test - don't think to use this in production!
+        # https://docs.puppet.com/puppetserver/latest/tuning_guide.html
+        server_jvm_max_heap_size => '256m',
+        server_jvm_min_heap_size => '256m',
+        server_max_open_files    => 32143,
+      }
+      MANIFEST
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    # pgrep -f java.*puppetserver would be better. But i cannot get it to work. Shellwords.escape() seems to break something
+    describe command("grep '^Max open files' /proc/`cat /var/run/puppetlabs/puppetserver/puppetserver.pid`/limits"), :sudo => true do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match %r{^Max open files\s+32143\s+32143\s+files\s*$} }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,38 @@ include RspecPuppetFacts
                                                                              # Original fact sources:
 add_custom_fact :puppet_environmentpath, '/etc/puppetlabs/code/environments' # puppetlabs-stdlib
 add_custom_fact :root_home, '/root'                                          # puppetlabs-stdlib
+# Rough conversion of grepping in the puppet source:
+# grep defaultfor lib/puppet/provider/service/*.rb
+add_custom_fact :service_provider, ->(os, facts) do
+  case facts[:osfamily].downcase
+  when 'archlinux'
+    'systemd'
+  when 'darwin'
+    'launchd'
+  when 'debian'
+    if facts[:operatingsystem] == 'Ubuntu'
+      facts[:operatingsystemmajrelease].to_i >= 15 ? 'systemd' : 'upstart'
+    elsif facts[:operatingsystem] == 'Debian' && facts[:operatingsystemmajrelease].to_i >= 8
+      'systemd'
+    else
+      'debian'
+    end
+  when 'freebsd'
+    'freebsd'
+  when 'gentoo'
+    'openrc'
+  when 'openbsd'
+    'openbsd'
+  when 'redhat'
+    facts[:operatingsystemrelease].to_i >= 7 ? 'systemd' : 'redhat'
+  when 'suse'
+    facts[:operatingsystemmajrelease].to_i >= 12 ? 'systemd' : 'redhat'
+  when 'windows'
+    'windows'
+  else
+    'init'
+  end
+end
 
 # Workaround for no method in rspec-puppet to pass undef through :params
 class Undef

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,6 +13,7 @@ require 'beaker/module_install_helper'
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
+install_module_from_forge('camptocamp-systemd', '>= 2.0.0 < 3.0.0')
 
 RSpec.configure do |c|
   # Readable test descriptions


### PR DESCRIPTION
This commit implements the $server_max_open_files parameter which allows
the user to configure the max open file descriptor limit for
Puppetserver.

Fixes #670.