### PR TITLE
Move client_certname to [main]

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -31,11 +31,6 @@ class puppet::agent::config inherits puppet::config {
       'postrun_command': value => $::puppet::postrun_command;
     }
   }
-  if $::puppet::client_certname {
-    puppet::config::agent {
-      'certname':        value => $::puppet::client_certname;
-    }
-  }
 
   $::puppet::agent_additional_settings.each |$key,$value| {
     puppet::config::agent { $key: value => $value }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,6 +17,7 @@ class puppet::config(
   $srv_domain          = $::puppet::srv_domain,
   $use_srv_records     = $::puppet::use_srv_records,
   $additional_settings = $::puppet::additional_settings,
+  $client_certname     = $::puppet::client_certname,
 ) {
   puppet::config::main{
     'vardir': value => $::puppet::vardir;
@@ -62,6 +63,11 @@ class puppet::config(
   }
   if $syslogfacility and !empty($syslogfacility) {
     puppet::config::main{'syslogfacility': value => $syslogfacility; }
+  }
+  if $client_certname {
+    puppet::config::main {
+      'certname': value => $client_certname;
+    }
   }
 
   $additional_settings.each |$key,$value| {

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -31,8 +31,6 @@ describe 'puppet' do
 
       let :facts do
         facts.deep_merge(
-          # rspec-puppet(-facts) doesn't mock this
-          clientcert: 'client.example.com',
           # Cron/systemd timers are based on the IP - make it consistent
           networking: { ip: '192.0.2.100' }
         )
@@ -73,7 +71,6 @@ describe 'puppet' do
         it { is_expected.to contain_file(confdir).with_ensure('directory') }
         it { is_expected.to contain_concat("#{confdir}/puppet.conf") }
         it { is_expected.to contain_concat__fragment('puppet.conf_agent').with_content(/^\[agent\]/) }
-        it { is_expected.to contain_puppet__config__agent('certname').with_value(facts[:clientcert]) }
         it { is_expected.to contain_puppet__config__agent('report').with_value('true') }
         it { is_expected.not_to contain_puppet__config__agent('prerun_command') }
         it { is_expected.not_to contain_puppet__config__agent('postrun_command') }
@@ -349,14 +346,6 @@ describe 'puppet' do
         end
 
         it { should_not contain_file('/var/lib/puppet/state/agent_disabled.lock') }
-      end
-
-      context 'with client_certname => false' do
-        let :params do
-          super().merge(client_certname: false)
-        end
-
-        it { is_expected.not_to contain_puppet__config__agent('certname') }
       end
 
       context 'with report => false' do

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'deep_merge'
 
 describe 'puppet' do
   on_os_under_test.each do |os, facts|
@@ -129,6 +130,36 @@ describe 'puppet' do
 
           it { is_expected.to contain_puppet__config__main('use_srv_records').with_value(true) }
           it { is_expected.to contain_puppet__config__main('srv_domain').with_value('special.example.com') }
+        end
+      end
+
+      describe 'client_certname' do
+        context 'with client_certname => $::clientcert' do
+          let :facts do
+            # rspec-puppet(-facts) doesn't mock this
+            facts.deep_merge(clientcert: 'client.example.com')
+          end
+          let :params do
+            super().merge(client_certname: facts[:clientcert])
+          end
+
+          it { is_expected.to contain_puppet__config__main('certname').with_value(facts[:clientcert]) }
+        end
+
+        context 'with client_certname => "foobar"' do
+          let :params do
+            super().merge(client_certname: 'foobar')
+          end
+
+          it { is_expected.to contain_puppet__config__main('certname').with_value('foobar') }
+        end
+
+        context 'with client_certname => false' do
+          let :params do
+            super().merge(client_certname: false)
+          end
+
+          it { is_expected.not_to contain_puppet__config__main('certname') }
         end
       end
 


### PR DESCRIPTION
This is needed to ensure all Puppet subcommands can properly use it.

Fixes GH-680.