### PR TITLE
Fixes #26199 - Fix dependency cycle when using git_repo

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -37,14 +37,4 @@ class puppet::server::install {
       Package[$server_package] -> User[$::puppet::server::user]
     }
   }
-
-  if $::puppet::server::git_repo {
-    Class['git'] -> User[$::puppet::server::user]
-
-    file { $puppet::vardir:
-      ensure => directory,
-      owner  => $::puppet::server::user,
-      group  => $::puppet::server::group,
-    }
-  }
 }

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -345,6 +345,8 @@ describe 'puppet' do
           super().merge(server_git_repo: true)
         end
 
+        it { is_expected.to compile.with_all_deps }
+
         it do
           should contain_class('puppet::server')
             .with_git_repo(true)
@@ -373,7 +375,7 @@ describe 'puppet' do
         it do
           should contain_file(vardir)
             .with_ensure('directory')
-            .with_owner('puppet')
+            .with_owner('root')
         end
 
         it do


### PR DESCRIPTION
Previously this resulted in a dependency cycle. The tests didn't compile so didn't catch it.

    dependency cycles found: (File[/opt/puppetlabs/puppet/cache] => Class[Puppet::Server::Install] => Class[Puppet::Server::Config] => File[/opt/puppetlabs/puppet] => File[/opt/puppetlabs/puppet/cache])

a61e010e8d24f2e44ab1ebba0cc4382b05ce9d37 introduced this by managing $sharedir in puppet::server::config. $vardir was managed in puppet::server::install. Since sharedir is actually /opt/puppetlabs/puppet and vardir is the cache directory within that, it created a cycle.