### PR TITLE
Handle the pluginsync setting deprecation

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -6,7 +6,6 @@ class puppet::agent::config inherits puppet::config {
     'localconfig':       value => '$vardir/localconfig';
     'default_schedules': value => false;
     'report':            value => $::puppet::report;
-    'pluginsync':        value => $::puppet::pluginsync;
     'masterport':        value => $::puppet::port;
     'environment':       value => $::puppet::environment;
     'listen':            value => $::puppet::listen;
@@ -29,6 +28,16 @@ class puppet::agent::config inherits puppet::config {
   if $::puppet::postrun_command {
     puppet::config::agent {
       'postrun_command': value => $::puppet::postrun_command;
+    }
+  }
+
+  unless $::puppet::pluginsync {
+    if versioncmp($facts['puppetserver'], '6.0.0') >= 0 {
+      fail('pluginsync is no longer a setting in Puppet 6')
+    } else {
+      puppet::config::agent { 'pluginsync':
+        value => $::puppet::pluginsync,
+      }
     }
   }
 


### PR DESCRIPTION
In Puppet 4 the pluginsync setting was deprecated. At least in Puppet 5 it generates a deprecation warning and in Puppet 6 it was removed.  Because the default was already true, we only emit it if it's non-default to avoid the deprecation warning. In Puppet 6 we can detect an invalid setting so we hard fail.