### PR TITLE
add 2018 to osreleasemajor for agent_restart_command 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -307,7 +307,7 @@ class puppet::params {
       # PSBM is a CentOS 6 based distribution
       # it reports its $osreleasemajor as 2, not 6.
       # thats why we're matching for '2' in both parts
-      # Amazon Linux is like RHEL6 but reports its osreleasemajor as 2017.
+      # Amazon Linux is like RHEL6 but reports its osreleasemajor as 2017 or 2018.
       $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1') # workaround for the possibly missing operatingsystemmajrelease
       $agent_restart_command = $osreleasemajor ? {
         /^(2|5|6|2017|2018)$/ => "/sbin/service ${service_name} reload",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -310,12 +310,12 @@ class puppet::params {
       # Amazon Linux is like RHEL6 but reports its osreleasemajor as 2017.
       $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1') # workaround for the possibly missing operatingsystemmajrelease
       $agent_restart_command = $osreleasemajor ? {
-        /^(2|5|6|2017)$/ => "/sbin/service ${service_name} reload",
+        /^(2|5|6|2017|2018)$/ => "/sbin/service ${service_name} reload",
         '7'       => "/usr/bin/systemctl reload-or-restart ${service_name}",
         default   => undef,
       }
       $unavailable_runmodes = $osreleasemajor ? {
-        /^(2|5|6|2017)$/ => ['systemd.timer'],
+        /^(2|5|6|2017|2018)$/ => ['systemd.timer'],
         default   => [],
       }
     }


### PR DESCRIPTION
Amazon Linux now has a 2018 release date on their AMIs:

```
# cat /etc/issue

Amazon Linux AMI release 2018.03
Kernel \r on an \m

# facter -p os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "2018.03",
    major => "2018",
    minor => "03"
  },
  selinux => {
    enabled => false
  }
}
```

So, when not specifying $agent_restart_command, we get this:

```
Error: /Stage[main]/Puppet::Agent::Service::Systemd/Service[puppet-run.timer]: Provider systemd is not functional on this host
```