### PR TITLE
Configurable minute and hour for cronjob and systemd.timer

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -39,11 +39,15 @@ class puppet::agent::service {
 
   class { 'puppet::agent::service::systemd':
     enabled => $systemd_enabled,
+    hour    => $::puppet::run_hour,
+    minute  => $::puppet::run_minute,
   }
   contain puppet::agent::service::systemd
 
   class { 'puppet::agent::service::cron':
     enabled => $cron_enabled,
+    hour    => $::puppet::run_hour,
+    minute  => $::puppet::run_minute,
   }
   contain puppet::agent::service::cron
 }

--- a/manifests/agent/service/cron.pp
+++ b/manifests/agent/service/cron.pp
@@ -1,17 +1,23 @@
 # Set up running the agent via cron
 # @api private
 class puppet::agent::service::cron (
-  Boolean $enabled = false,
+  Boolean                 $enabled = false,
+  Optional[Integer[0,23]] $hour    = undef,
+  Optional[Integer[0,59]] $minute  = undef,
 ) {
   unless $::puppet::runmode == 'unmanaged' or 'cron' in $::puppet::unavailable_runmodes {
     if $enabled {
       $command = pick($::puppet::cron_cmd, "${::puppet::puppet_cmd} agent --config ${::puppet::dir}/puppet.conf --onetime --no-daemonize")
       $times = extlib::ip_to_cron($::puppet::runinterval)
+
+      $_hour = pick($hour, $times[0])
+      $_minute = pick($minute, $times[1])
+
       cron { 'puppet':
         command => $command,
         user    => root,
-        hour    => $times[0],
-        minute  => $times[1],
+        hour    => $_hour,
+        minute  => $_minute,
       }
     } else{
       cron { 'puppet':

--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -1,7 +1,9 @@
 # Set up running the agent via a systemd timer
 # @api private
 class puppet::agent::service::systemd (
-  Boolean $enabled = false,
+  Boolean                 $enabled = false,
+  Optional[Integer[0,23]] $hour    = undef,
+  Optional[Integer[0,59]] $minute  = undef,
 ) {
   unless $::puppet::runmode == 'unmanaged' or 'systemd.timer' in $::puppet::unavailable_runmodes {
     exec { 'systemctl-daemon-reload-puppet':
@@ -13,6 +15,10 @@ class puppet::agent::service::systemd (
     if $enabled {
       # Use the same times as for cron
       $times = extlib::ip_to_cron($::puppet::runinterval)
+
+      # But only if they are not explicitly specified
+      $_hour = pick($hour, $times[0])
+      $_minute = pick($minute, $times[1])
 
       $command = $::puppet::systemd_cmd ? {
         undef   => "${::puppet::puppet_cmd} agent --config ${::puppet::dir}/puppet.conf --onetime --no-daemonize --detailed-exitcode --no-usecacheonfailure",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,12 @@
 #
 # $runmode::                                Select the mode to setup the puppet agent.
 #
+# $run_hour::                               The hour at which to run the puppet agent
+#                                           when runmode is cron or systemd.timer.
+#
+# $run_minute::                             The minute at which to run the puppet agent
+#                                           when runmode is cron or systemd.timer.
+#
 # $cron_cmd::                               Specify command to launch when runmode is
 #                                           set 'cron'.
 #
@@ -563,6 +569,8 @@ class puppet (
   Variant[Integer[0],Pattern[/^\d+[smhdy]?$/]] $runinterval = $puppet::params::runinterval,
   Boolean $usecacheonfailure = $puppet::params::usecacheonfailure,
   Enum['cron', 'service', 'systemd.timer', 'none', 'unmanaged'] $runmode = $puppet::params::runmode,
+  Optional[Integer[0,23]] $run_hour = undef,
+  Optional[Integer[0,59]] $run_minute = undef,
   Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,
   Optional[String] $cron_cmd = $puppet::params::cron_cmd,
   Optional[String] $systemd_cmd = $puppet::params::systemd_cmd,

--- a/templates/agent/systemd.puppet-run.timer.erb
+++ b/templates/agent/systemd.puppet-run.timer.erb
@@ -5,7 +5,7 @@
 Description=Systemd Timer for Puppet Agent
 
 [Timer]
-OnCalendar=*-*-* <%= Array(@times[0]).join(',') %>:<%= Array(@times[1]).join(',') %>:00
+OnCalendar=*-*-* <%= Array(@_hour).join(',') %>:<%= Array(@_minute).join(',') %>:00
 Persistent=true
 RandomizedDelaySec=<%= @randomizeddelaysec %>
 


### PR DESCRIPTION
This PR enables you to configure the minute and hour at which your Puppet Cronjob/systemd timer runs.

This is useful for advanced scenarios where you want to limit when the Puppet agent runs.

The change is fully backwards compatible as it does not change any defaults