### PR TITLE
Rely on the service_provider fact

### DIFF
--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -4,5 +4,5 @@ puppet::server_reports: 'store'
 puppet::server_external_nodes: ''
 # only for install test - don't think to use this in production!
 # https://docs.puppet.com/puppetserver/latest/tuning_guide.html
-puppet::server_jvm_max_heap_size: '256m'
+puppet::server_jvm_max_heap_size: '768m'
 puppet::server_jvm_min_heap_size: '256m'

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -94,7 +94,7 @@ describe 'puppet' do
 
         it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(false) }
         case os
-        when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Aarchlinux-/
+        when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Asles-12-/, /\Aarchlinux-/
           it do
             is_expected.to contain_service('puppet-run.timer')
               .with_ensure(false)
@@ -171,7 +171,7 @@ describe 'puppet' do
           case os
           when /\A(windows|archlinux)/
             it { is_expected.to raise_error(Puppet::Error, /Runmode of cron not supported on #{facts[:kernel]} operating systems!/) }
-          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/
+          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Asles-12/
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_concat__fragment('puppet.conf_agent') }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(true) }
@@ -219,7 +219,7 @@ describe 'puppet' do
           case os
           when /\A(windows|archlinux)/
             it { is_expected.to raise_error(Puppet::Error, /Runmode of cron not supported on #{facts[:kernel]} operating systems!/) }
-          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/
+          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Asles-12/
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(true) }
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it do
@@ -260,7 +260,7 @@ describe 'puppet' do
           end
 
           case os
-          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Aarchlinux-/
+          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Asles-12/, /\Aarchlinux-/
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(false) }
@@ -303,7 +303,7 @@ describe 'puppet' do
           end
 
           case os
-          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Aarchlinux-/
+          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Asles-12/, /\Aarchlinux-/
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(false) }
@@ -351,7 +351,7 @@ describe 'puppet' do
           it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(false) }
 
           case os
-          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Aarchlinux-/
+          when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Asles-12/, /\Aarchlinux-/
             it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
           else
             it { is_expected.not_to contain_service('puppet-run.timer') }


### PR DESCRIPTION
This avoids hardcoding the service provider and greatly simplifies the code.