### PR TITLE
Document campotocamp/systemd soft dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ versions, which this module supports. It's recommended that you set the
 you have installed. By default the module will configure for the latest
 version available.
 
+# Soft Dependencies
+
+If you use a OS which uses systemd you may consider to download `camptocamp/systemd` module for compatibility. 
+It is **only** needed if you use the **puppetserver** feature. 
+
 # Contributing
 
 * Fork the project


### PR DESCRIPTION
# Description
This pull request is to merge changes in files listing module dependencies. Latest version (12.0.0) didn't mention `camptocamp/systemd` module requirement hence when running `puppet module install theforeman-puppet` puppet run failed with the dependency error. 

# Changes
`README.md` - added new dependency section listing all the dependencies
`metadata.json` - added new values to add dependency for `camptocamp/systemd` module.