### PR TITLE
Ensure config file ends with a new line

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -82,15 +82,17 @@ class puppet::config(
   -> case $::osfamily {
     'Windows': {
       concat { "${puppet_dir}/puppet.conf":
-        mode  => '0674',
+        mode           => '0674',
+        ensure_newline => true,
       }
     }
 
     default: {
       concat { "${puppet_dir}/puppet.conf":
-        owner => 'root',
-        group => $::puppet::params::root_group,
-        mode  => '0644',
+        owner          => 'root',
+        group          => $::puppet::params::root_group,
+        mode           => '0644',
+        ensure_newline => true,
       }
     }
   }

--- a/manifests/config/entry.pp
+++ b/manifests/config/entry.pp
@@ -30,7 +30,7 @@ define puppet::config::entry (
   # they make sure that '1_main ' is ordered before '1_main_*'
   ensure_resource('concat::fragment', "puppet.conf_${section}", {
       target  => "${::puppet::dir}/puppet.conf",
-      content => "\n\n[${section}]",
+      content => "\n[${section}]",
       order   => "${sectionorder}_${section} ",
   })
 
@@ -39,7 +39,7 @@ define puppet::config::entry (
   if (!defined(Concat::Fragment["puppet.conf_${section}_${key}"])){
     concat::fragment{"puppet.conf_${section}_${key}":
       target  => "${::puppet::dir}/puppet.conf",
-      content => "\n    ${key} = ${_value}",
+      content => "    ${key} = ${_value}",
       order   => "${sectionorder}_${section}_${key} ",
     }
   } else {

--- a/spec/defines/puppet_config_entry_spec.rb
+++ b/spec/defines/puppet_config_entry_spec.rb
@@ -20,7 +20,7 @@ describe 'puppet::config::entry' do
           }
         end
         it 'should contain the section header' do
-          should contain_concat__fragment('puppet.conf_main').with_content("\n\n[main]")
+          should contain_concat__fragment('puppet.conf_main').with_content("\n[main]")
           should contain_concat__fragment('puppet.conf_main').with_order("1_main ")
         end
         it 'should contain the keyvalue pair' do
@@ -41,7 +41,7 @@ describe 'puppet::config::entry' do
           }
         end
         it 'should contain the section header' do
-          should contain_concat__fragment('puppet.conf_main').with_content("\n\n[main]")
+          should contain_concat__fragment('puppet.conf_main').with_content("\n[main]")
           should contain_concat__fragment('puppet.conf_main').with_order("1_main ")
         end
         it 'should contain the keyvalue pair' do
@@ -63,7 +63,7 @@ describe 'puppet::config::entry' do
           }
         end
         it 'should contain the section header' do
-          should contain_concat__fragment('puppet.conf_main').with_content("\n\n[main]")
+          should contain_concat__fragment('puppet.conf_main').with_content("\n[main]")
           should contain_concat__fragment('puppet.conf_main').with_order("1_main ")
         end
         it 'should contain the keyvalue pair' do


### PR DESCRIPTION
The puppet.conf file doesn't end with a newline which makes it hard to `cat`. This ensure that the file will end with a newline.