### PR TITLE
Convert the systemd timer service to camptocamp/systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,6 @@ versions, which this module supports. It's recommended that you set the
 you have installed. By default the module will configure for the latest
 version available.
 
-# Soft Dependencies
-
-If you use a OS which uses systemd you may consider to download `camptocamp/systemd` module for compatibility. 
-It is **only** needed if you use the **puppetserver** feature. 
-
 # Contributing
 
 * Fork the project

--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -5,70 +5,23 @@ class puppet::agent::service::systemd (
   Optional[Integer[0,23]] $hour    = undef,
   Optional[Integer[0,59]] $minute  = undef,
 ) {
-  unless $::puppet::runmode == 'unmanaged' or 'systemd.timer' in $::puppet::unavailable_runmodes {
-    exec { 'systemctl-daemon-reload-puppet':
-      refreshonly => true,
-      path        => $::path,
-      command     => 'systemctl daemon-reload',
-    }
+  unless $puppet::runmode == 'unmanaged' or 'systemd.timer' in $puppet::unavailable_runmodes {
+    # Use the same times as for cron
+    $times = extlib::ip_to_cron($puppet::runinterval)
 
-    if $enabled {
-      # Use the same times as for cron
-      $times = extlib::ip_to_cron($::puppet::runinterval)
+    # But only if they are not explicitly specified
+    $_hour = pick($hour, $times[0])
+    $_minute = pick($minute, $times[1])
 
-      # But only if they are not explicitly specified
-      $_hour = pick($hour, $times[0])
-      $_minute = pick($minute, $times[1])
+    $command = pick($puppet::systemd_cmd, "${puppet::puppet_cmd} agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize --detailed-exitcode --no-usecacheonfailure")
+    $randomizeddelaysec = $puppet::systemd_randomizeddelaysec
 
-      $command = $::puppet::systemd_cmd ? {
-        undef   => "${::puppet::puppet_cmd} agent --config ${::puppet::dir}/puppet.conf --onetime --no-daemonize --detailed-exitcode --no-usecacheonfailure",
-        default => $::puppet::systemd_cmd,
-      }
-
-      $randomizeddelaysec = $::puppet::systemd_randomizeddelaysec
-
-      file { "/etc/systemd/system/${::puppet::systemd_unit_name}.timer":
-        content => template('puppet/agent/systemd.puppet-run.timer.erb'),
-        notify  => [
-          Exec['systemctl-daemon-reload-puppet'],
-          Service['puppet-run.timer'],
-        ],
-      }
-
-      file { "/etc/systemd/system/${::puppet::systemd_unit_name}.service":
-        content => template('puppet/agent/systemd.puppet-run.service.erb'),
-        notify  => Exec['systemctl-daemon-reload-puppet'],
-      }
-
-      service { 'puppet-run.timer':
-        ensure   => running,
-        provider => 'systemd',
-        name     => "${::puppet::systemd_unit_name}.timer",
-        enable   => true,
-        require  => Exec['systemctl-daemon-reload-puppet'],
-      }
-    } else {
-      # Reverse order - stop, delete files, exec
-      service { 'puppet-run.timer':
-        ensure   => stopped,
-        provider => 'systemd',
-        name     => "${::puppet::systemd_unit_name}.timer",
-        enable   => false,
-        before   => [
-          File["/etc/systemd/system/${::puppet::systemd_unit_name}.timer"],
-          File["/etc/systemd/system/${::puppet::systemd_unit_name}.service"],
-        ],
-      }
-
-      file { "/etc/systemd/system/${::puppet::systemd_unit_name}.timer":
-        ensure => absent,
-        notify => Exec['systemctl-daemon-reload-puppet'],
-      }
-
-      file { "/etc/systemd/system/${::puppet::systemd_unit_name}.service":
-        ensure => absent,
-        notify => Exec['systemctl-daemon-reload-puppet'],
-      }
+    systemd::timer { "${puppet::systemd_unit_name}.timer":
+      ensure          => bool2str($enabled, 'present', 'absent'),
+      active          => $enabled,
+      enable          => $enabled,
+      timer_content   => template('puppet/agent/systemd.puppet-run.timer.erb'),
+      service_content => template('puppet/agent/systemd.puppet-run.service.erb'),
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -26,6 +26,10 @@
     {
       "name": "puppet/extlib",
       "version_requirement": ">= 3.0.0 < 6.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 2.9.0 < 3.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -109,14 +109,8 @@ describe 'puppet' do
         case os
         when /\Adebian-/, /\A(redhat|centos|scientific)-7/, /\Afedora-/, /\Aubuntu-(16|18)/, /\Aarchlinux-/
           it do
-            is_expected.to contain_exec('systemctl-daemon-reload-puppet')
-              .with_refreshonly(true)
-              .with_command('systemctl daemon-reload')
-          end
-
-          it do
             is_expected.to contain_service('puppet-run.timer')
-              .with_ensure(:stopped)
+              .with_ensure(false)
               .with_provider('systemd')
               .with_name('puppet-run.timer')
               .with_enable(false)
@@ -128,7 +122,6 @@ describe 'puppet' do
           it { is_expected.not_to contain_service('puppet-run.timer') }
           it { is_expected.not_to contain_file('/etc/systemd/system/puppet-run.timer') }
           it { is_expected.not_to contain_file('/etc/systemd/system/puppet-run.service') }
-          it { is_expected.not_to contain_exec('systemctl-daemon-reload-puppet') }
         end
       end
 
@@ -215,7 +208,7 @@ describe 'puppet' do
                 .with_enable('false')
             end
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(false) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
             it do
               is_expected.to contain_cron('puppet')
                 .with_command("#{bindir}/puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize")
@@ -261,7 +254,7 @@ describe 'puppet' do
                 .with_enable('false')
             end
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(false) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
             it do
               is_expected.to contain_cron('puppet')
                 .with_command("#{bindir}/puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize")
@@ -296,7 +289,7 @@ describe 'puppet' do
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(true) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:running) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(true) }
 
             it do
               is_expected.to contain_file('/etc/systemd/system/puppet-run.timer')
@@ -314,17 +307,11 @@ describe 'puppet' do
             end
 
             it do
-              is_expected.to contain_exec('systemctl-daemon-reload-puppet')
-                .with_refreshonly(true)
-                .with_command('systemctl daemon-reload')
-            end
-
-            it do
               is_expected.to contain_service('puppet-run.timer')
                 .with_provider('systemd')
-                .with_ensure('running')
+                .with_ensure(true)
                 .with_name('puppet-run.timer')
-                .with_enable('true')
+                .with_enable(true)
             end
           else
             it { is_expected.to raise_error(Puppet::Error, /Runmode of systemd.timer not supported on #{facts[:kernel]} operating systems!/) }
@@ -345,7 +332,7 @@ describe 'puppet' do
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(true) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:running) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(true) }
 
             it do
               is_expected.to contain_file('/etc/systemd/system/puppet-run.timer')
@@ -363,17 +350,11 @@ describe 'puppet' do
             end
 
             it do
-              is_expected.to contain_exec('systemctl-daemon-reload-puppet')
-                .with_refreshonly(true)
-                .with_command('systemctl daemon-reload')
-            end
-
-            it do
               is_expected.to contain_service('puppet-run.timer')
                 .with_provider('systemd')
-                .with_ensure('running')
+                .with_ensure(true)
                 .with_name('puppet-run.timer')
-                .with_enable('true')
+                .with_enable(true)
             end
           else
             it { is_expected.to raise_error(Puppet::Error, /Runmode of systemd.timer not supported on #{facts[:kernel]} operating systems!/) }
@@ -395,7 +376,7 @@ describe 'puppet' do
 
           case os
           when /\Adebian-/, /\A(redhat|centos|scientific)-7/, /\Afedora-/, /\Aubuntu-(16|18)/, /\Aarchlinux-/
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
           else
             it { is_expected.not_to contain_service('puppet-run.timer') }
           end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,7 +13,6 @@ require 'beaker/module_install_helper'
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
-install_module_from_forge('camptocamp-systemd', '>= 2.0.0 < 3.0.0')
 
 RSpec.configure do |c|
   # Readable test descriptions


### PR DESCRIPTION
This was previously done manually, but there was already a soft dependency on systemd in the server side. This makes it a hard dependency and reuses logic.

Depends on https://github.com/camptocamp/puppet-systemd/pull/119 https://github.com/camptocamp/puppet-systemd/pull/122

Closes GH-704