### PR TITLE
Restart Puppet Agent service after updating the package

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -5,6 +5,6 @@ class puppet::agent {
   contain puppet::agent::config
   contain puppet::agent::service
 
-  Class['puppet::agent::install'] ~> Class['puppet::agent::config']
+  Class['puppet::agent::install'] ~> Class['puppet::agent::config', 'puppet::agent::service']
   Class['puppet::config', 'puppet::agent::config'] ~> Class['puppet::agent::service']
 }


### PR DESCRIPTION
I'm using something like this on **FreeBSD** to manage Puppet Agent...

```
  class { 'puppet':
    agent                 => true,
    agent_restart_command => '/usr/sbin/service puppet restart',
    client_package        => 'puppet6',
    version               => '6.10.0',
  }
```

This works well for normal operation, but when performing an upgrade of Puppet Agent...

```
Info: Applying configuration version '1572887720'
Notice: /Stage[main]/Puppet::Agent::Install/Package[puppet6]/ensure: ensure changed '6.8.1' to '6.10.0' (corrective)
Applied catalog in 8.23 seconds
```

...things start to break. Note that the service was not restarted after performing the package upgrade. This leads to arbitrary errors during all subsequent Puppet Agent runs, here are some of my favorite errors:

```
err   Puppet  Could not autoload puppet/type/user: undefined method `sensitive' for Puppet::Type::User::Password:Class
err   Puppet  Failed to apply catalog: Could not autoload puppet/type/user: undefined method `sensitive' for Puppet::Type::User::Password:Class

-OR-

err   Puppet  Could not autoload puppet/type/concat_file: uninitialized constant Puppet::Type::File::Owner
err   Puppet  Could not autoload puppet/type/concat_file: uninitialized constant Puppet::Type::File::Owner
err   Puppet  Could not render to pson: Could not autoload puppet/type/concat_file: uninitialized constant Puppet::Type::File::Owner
err   Puppet  Could not retrieve catalog from remote server: Could not render to pson: Could not autoload puppet/type/concat_file: uninitialized constant Puppet::Type::File::Owner
err   Puppet  Failed to apply catalog: no parameter named 'ensure'
```

(Note that these errors won't occur on a manual Puppet run, they will only be triggered by the Puppet Agent service that survived the upgrade.)

I did some tests and apparently a restart of Puppet Agent is required to avoid these issues. So with the proposed patch applied the same upgrade looks like this:

```
Info: Applying configuration version '1572888070'
Notice: /Stage[main]/Puppet::Agent::Install/Package[puppet6]/ensure: ensure changed '6.8.1' to '6.10.0' (corrective)
Info: Class[Puppet::Agent::Install]: Scheduling refresh of Class[Puppet::Agent::Config]
Info: Class[Puppet::Agent::Install]: Scheduling refresh of Class[Puppet::Agent::Service]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[classfile]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[localconfig]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[default_schedules]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[report]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[masterport]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[environment]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[listen]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[splay]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[splaylimit]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[runinterval]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[noop]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[usecacheonfailure]
Info: Class[Puppet::Agent::Config]: Scheduling refresh of Puppet::Config::Agent[stringify_facts]
Info: Puppet::Config::Agent[classfile]: Scheduling refresh of Puppet::Config::Entry[agent_classfile]
Info: Puppet::Config::Agent[localconfig]: Scheduling refresh of Puppet::Config::Entry[agent_localconfig]
Info: Puppet::Config::Agent[default_schedules]: Scheduling refresh of Puppet::Config::Entry[agent_default_schedules]
Info: Puppet::Config::Agent[report]: Scheduling refresh of Puppet::Config::Entry[agent_report]
Info: Puppet::Config::Agent[masterport]: Scheduling refresh of Puppet::Config::Entry[agent_masterport]
Info: Puppet::Config::Agent[environment]: Scheduling refresh of Puppet::Config::Entry[agent_environment]
Info: Puppet::Config::Agent[listen]: Scheduling refresh of Puppet::Config::Entry[agent_listen]
Info: Puppet::Config::Agent[splay]: Scheduling refresh of Puppet::Config::Entry[agent_splay]
Info: Puppet::Config::Agent[splaylimit]: Scheduling refresh of Puppet::Config::Entry[agent_splaylimit]
Info: Puppet::Config::Agent[runinterval]: Scheduling refresh of Puppet::Config::Entry[agent_runinterval]
Info: Puppet::Config::Agent[noop]: Scheduling refresh of Puppet::Config::Entry[agent_noop]
Info: Puppet::Config::Agent[usecacheonfailure]: Scheduling refresh of Puppet::Config::Entry[agent_usecacheonfailure]
Info: Puppet::Config::Agent[stringify_facts]: Scheduling refresh of Puppet::Config::Entry[agent_stringify_facts]
Info: Puppet::Config::Entry[agent_classfile]: Scheduling refresh of Concat::Fragment[puppet.conf_agent]
Info: Puppet::Config::Entry[agent_classfile]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_classfile]
Info: Puppet::Config::Entry[agent_localconfig]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_localconfig]
Info: Puppet::Config::Entry[agent_default_schedules]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_default_schedules]
Info: Puppet::Config::Entry[agent_report]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_report]
Info: Puppet::Config::Entry[agent_masterport]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_masterport]
Info: Puppet::Config::Entry[agent_environment]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_environment]
Info: Puppet::Config::Entry[agent_listen]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_listen]
Info: Puppet::Config::Entry[agent_splay]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_splay]
Info: Puppet::Config::Entry[agent_splaylimit]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_splaylimit]
Info: Puppet::Config::Entry[agent_runinterval]: Scheduling refresh of Conat::Fragment[puppet.conf_agent_runinterval]
Info: Puppet::Config::Entry[agent_noop]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_noop]
Info: Puppet::Config::Entry[agent_usecacheonfailure]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_usecacheonfailure]
Info: Puppet::Config::Entry[agent_stringify_facts]: Scheduling refresh of Concat::Fragment[puppet.conf_agent_stringify_facts]
Info: Class[Puppet::Agent::Service]: Scheduling refresh of Class[Puppet::Agent::Service::Daemon]
Info: Class[Puppet::Agent::Service]: Scheduling refresh of Class[Puppet::Agent::Service::Systemd]
Info: Class[Puppet::Agent::Service]: Scheduling refresh of Class[Puppet::Agent::Service::Cron]
Info: Class[Puppet::Agent::Service::Daemon]: Scheduling refresh of Service[puppet]
Notice: /Stage[main]/Puppet::Agent::Service::Daemon/Service[puppet]: Triggered 'refresh' from 1 event
Notice: Applied catalog in 11.25 seconds
```

I was unable to reproduce this issue on Linux servers, so this might be an issue specific to Puppet Agent on FreeBSD. However, I think it's the right thing to restart the Puppet Agent service on all platforms.