### PR TITLE
Stop acceptance tests on EL7

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,6 @@
 ---
 .travis.yml:
   beaker_sets:
-    - centos7-64
     - centos6-64
     - debian9-64
   env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,28 +15,6 @@ matrix:
     - rvm: 2.5.1
       env:
         - BEAKER_PUPPET_COLLECTION=puppet5
-        - BEAKER_setfile=centos7-64{hostname=centos7-64.example.com}
-      script: bundle exec rake beaker
-      services: docker
-      bundler_args: --without development
-      before_install:
-        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
-        - sudo service docker restart
-
-    - rvm: 2.5.1
-      env:
-        - BEAKER_PUPPET_COLLECTION=puppet6
-        - BEAKER_setfile=centos7-64{hostname=centos7-64.example.com}
-      script: bundle exec rake beaker
-      services: docker
-      bundler_args: --without development
-      before_install:
-        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
-        - sudo service docker restart
-
-    - rvm: 2.5.1
-      env:
-        - BEAKER_PUPPET_COLLECTION=puppet5
         - BEAKER_setfile=centos6-64{hostname=centos6-64.example.com}
       script: bundle exec rake beaker
       services: docker


### PR DESCRIPTION
Because of https://github.com/moby/moby/issues/38749 we can't start puppetserver under systemd. That makes all our acceptance tests useless.