### PR TITLE
Update cipher suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Please see the notes about using puppetlabs/puppetdb 5.x with older versions of 
 newer releases of the module and set the values via hiera or an extra include of `puppetdb::globals` with
 `puppetdb_version` defined.
 
+Please also make sure your puppetdb ciphers are compatible with your puppet server ciphers, ie that the two following parameters match:
+```
+puppet::server::cipher_suites
+puppetdb::server::cipher_suites
+```
+
 # Installation
 
 Available from GitHub (via cloning or tarball), [Puppet Forge](https://forge.puppetlabs.com/theforeman/puppet)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -400,7 +400,7 @@ class puppet::params {
   $server_ca_auth_required                = true
   $server_admin_api_whitelist             = [ 'localhost', $lower_fqdn ]
   $server_ca_client_whitelist             = [ 'localhost', $lower_fqdn ]
-  $server_cipher_suites                   = [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA', 'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA' ]
+  $server_cipher_suites                   = [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA', 'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA', 'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256', 'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256', 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384' ]
   $server_ssl_protocols                   = [ 'TLSv1.2' ]
   $server_ssl_chain_filepath              = "${server_ssl_dir}/ca/ca_crt.pem"
   $server_check_for_updates               = true


### PR DESCRIPTION
This change is needed as puppetlabs is allowing only (non ?)-DH ciphers in puppetdb6, which in turn causes connectivity failures between puppet server and puppetdb if no common cipher is found. Unfortunately, changing the puppet server ciphers is not enough, setting the puppetdb ciphers is also necessary to make sure all communications are ok - this was added in the README in the puppetdb integration section as this change has to be done outside this module.

Fixes GH-714