### PR TITLE
Drop listen parameter

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -8,7 +8,6 @@ class puppet::agent::config inherits puppet::config {
     'report':            value => $::puppet::report;
     'masterport':        value => $::puppet::port;
     'environment':       value => $::puppet::environment;
-    'listen':            value => $::puppet::listen;
     'splay':             value => $::puppet::splay;
     'splaylimit':        value => $::puppet::splaylimit;
     'runinterval':       value => $::puppet::runinterval;

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,6 @@ class puppet::config(
   $ca_server           = $::puppet::ca_server,
   $ca_port             = $::puppet::ca_port,
   $dns_alt_names       = $::puppet::dns_alt_names,
-  $listen_to           = $::puppet::listen_to,
   $module_repository   = $::puppet::module_repository,
   $pluginsource        = $::puppet::pluginsource,
   $pluginfactsource    = $::puppet::pluginfactsource,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,18 +18,6 @@
 #
 # $port::                                   Override the port of the master we connect to.
 #
-# $listen::                                 Should the puppet agent listen for connections.
-#
-# $listen_to::                              An array of servers allowed to initiate a puppet run.
-#                                           If $listen = true one of three things will happen:
-#                                           1) if $listen_to is not empty then this array
-#                                           will be used.
-#                                           2) if $listen_to is empty and $puppetmaster is
-#                                           defined then only $puppetmaster will be
-#                                           allowed.
-#                                           3) if $puppetmaster is not defined or empty,
-#                                           $fqdn will be used.
-#
 # $pluginsync::                             Enable pluginsync.
 #
 # $splay::                                  Switch to enable a random amount of time
@@ -560,8 +548,6 @@ class puppet (
   Optional[String] $package_provider = $puppet::params::package_provider,
   Optional[Variant[Stdlib::Absolutepath, Stdlib::HTTPUrl]] $package_source = $puppet::params::package_source,
   Integer[0, 65535] $port = $puppet::params::port,
-  Boolean $listen = $puppet::params::listen,
-  Array[String] $listen_to = $puppet::params::listen_to,
   Boolean $pluginsync = $puppet::params::pluginsync,
   Boolean $splay = $puppet::params::splay,
   Variant[Integer[0],Pattern[/^\d+[smhdy]?$/]] $splaylimit = $puppet::params::splaylimit,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,8 +9,6 @@ class puppet::params {
   $group               = 'puppet'
   $ip                  = '0.0.0.0'
   $port                = 8140
-  $listen              = false
-  $listen_to           = []
   $pluginsync          = true
   $splay               = false
   $splaylimit          = 1800

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -191,32 +191,6 @@ describe 'puppet' do
 
           it { is_expected.to contain_puppet__config__main('server').with_value('global.example.com') }
         end
-
-        context 'when listen' do
-          let :params do
-            super().merge(listen: true)
-          end
-
-          describe 'puppetmaster default value is used' do
-            it { is_expected.to contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow #{facts[:fqdn]}$}) }
-          end
-
-          describe 'puppetmaster has value' do
-            let :params do
-              super().merge(puppetmaster: 'mymaster.example.com')
-            end
-
-            it { is_expected.to contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow mymaster.example.com$}) }
-          end
-
-          describe 'listen_to has values' do
-            let :params do
-              super().merge(listen_to: ['node1.example.com', 'node2.example.com'])
-            end
-
-            it { is_expected.to contain_file("#{confdir}/auth.conf").with_content(%r{^path /run\nauth any\nmethod save\nallow node1\.example\.com,node2\.example\.com$}) }
-          end
-        end
       end
 
       describe 'with additional settings' do

--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -149,13 +149,6 @@ path /puppet-ca/v1/certificate_request
 auth any
 method find, save
 allow *
-<% if scope.lookupvar('::puppet::listen') -%>
-
-path /run
-auth any
-method save
-allow <%= if (!@listen_to.empty?) then @listen_to.join(",") elsif ( @puppetmaster and !@puppetmaster.empty? ) then @puppetmaster else @fqdn end %>
-<% end -%>
 
 # deny everything else; this ACL is not strictly necessary, but
 # illustrates the default policy.


### PR DESCRIPTION
Puppet 4 dropped puppet run/kick so this code has been dead for some time. It was missed in the big Puppet cleanups.