### PR TITLE
Add server_multithreaded parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -387,6 +387,8 @@
 #                                           503 responses returned when max-queued-requests is enabled. (Puppetserver 5.x only)
 #                                           Defaults to 1800 for Puppetserver >= 5.0
 #
+# $server_multithreaded::                   Use multithreaded jruby. (Puppetserver >= 6.8 only).  Defaults to false.
+#
 # $server_idle_timeout::                    How long the server will wait for a response on an existing connection
 #
 # $server_connect_timeout::                 How long the server will wait for a response to a connection attempt
@@ -679,6 +681,7 @@ class puppet (
   Integer[0] $server_max_requests_per_instance = $puppet::params::server_max_requests_per_instance,
   Integer[0] $server_max_queued_requests = $puppet::params::server_max_queued_requests,
   Integer[0] $server_max_retry_delay = $puppet::params::server_max_retry_delay,
+  Boolean $server_multithreaded = $puppet::params::server_multithreaded,
   Boolean $server_use_legacy_auth_conf = $puppet::params::server_use_legacy_auth_conf,
   Boolean $server_check_for_updates = $puppet::params::server_check_for_updates,
   Boolean $server_environment_class_cache_enabled = $puppet::params::server_environment_class_cache_enabled,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -392,6 +392,7 @@ class puppet::params {
   $server_max_requests_per_instance       = 0
   $server_max_queued_requests             = 0
   $server_max_retry_delay                 = 1800
+  $server_multithreaded                   = false
   $server_idle_timeout                    = 1200000
   $server_web_idle_timeout                = 30000
   $server_connect_timeout                 = 120000

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -219,6 +219,8 @@
 #                                      503 responses returned when max-queued-requests is enabled. (Puppetserver 5.x only)
 #                                      Defaults to 1800 for Puppetserver >= 5.0
 #
+# $multithreaded::                     Use multithreaded jruby. (Puppetserver >= 6.8 only).  Defaults to false.
+#
 # $idle_timeout::                      How long the server will wait for a response on an existing connection
 #
 # $connect_timeout::                   How long the server will wait for a response to a connection attempt
@@ -418,6 +420,7 @@ class puppet::server(
   Integer[0] $max_requests_per_instance = $::puppet::server_max_requests_per_instance,
   Integer[0] $max_queued_requests = $puppet::server_max_queued_requests,
   Integer[0] $max_retry_delay = $puppet::server_max_retry_delay,
+  Boolean $multithreaded = $puppet::server_multithreaded,
   Boolean $use_legacy_auth_conf = $::puppet::server_use_legacy_auth_conf,
   Boolean $check_for_updates = $::puppet::server_check_for_updates,
   Boolean $environment_class_cache_enabled = $::puppet::server_environment_class_cache_enabled,

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -54,6 +54,9 @@
 #   Sets the upper limit for the random sleep set as a Retry-After
 #   header on 503 responses returned when max-queued-requests is enabled.
 #
+# @param server_multithreaded
+#   Configures the puppetserver to use multithreaded jruby.
+#
 # @example
 #
 #   # configure memory for java < 8
@@ -81,6 +84,7 @@ class puppet::server::puppetserver (
   $server_max_requests_per_instance       = $::puppet::server::max_requests_per_instance,
   $server_max_queued_requests             = $::puppet::server::max_queued_requests,
   $server_max_retry_delay                 = $::puppet::server::max_retry_delay,
+  $server_multithreaded                   = $::puppet::server::multithreaded,
   $server_ssl_protocols                   = $::puppet::server::ssl_protocols,
   $server_ssl_ca_crl                      = $::puppet::server::ssl_ca_crl,
   $server_ssl_ca_cert                     = $::puppet::server::ssl_ca_cert,

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -168,6 +168,28 @@ describe 'puppet' do
           end
       end
 
+      describe 'server_multithreaded' do
+        context 'with default parameters' do
+          context 'when server_puppetserver_version >= 5.3.6 and < 6.8.0' do
+            it { should contain_file(puppetserver_conf).without_content(/multithreaded/) }
+          end
+          context 'when server_puppetserver_version == 6.8.0' do
+            let(:params) { super().merge(server_puppetserver_version: '6.8.0') }
+            it { should contain_file(puppetserver_conf).with_content(/^    multithreaded: false\n/) }
+          end
+        end
+        context 'with custom server_multithreaded' do
+          let(:params) { super().merge(server_multithreaded: true) }
+          context 'when server_puppetserver_version >= 5.3.6 and < 6.8.0' do
+            it { should contain_file(puppetserver_conf).without_content(/multithreaded/) }
+          end
+          context 'when server_puppetserver_version == 6.8.0' do
+            let(:params) { super().merge(server_puppetserver_version: '6.8.0') }
+            it { should contain_file(puppetserver_conf).with_content(/^    multithreaded: true\n/) }
+          end
+        end
+      end
+
       describe 'ca.cfg' do
         context 'when server_ca => false' do
           let(:params) { super().merge(server_ca: false) }

--- a/templates/server/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/puppetserver.conf.erb
@@ -75,6 +75,9 @@ jruby-puppet: {
 
     compile-mode: <%= @compile_mode %>
 <%- end -%>
+<%- if scope.function_versioncmp([@server_puppetserver_version, '6.8']) >= 0 -%>
+    multithreaded: <%= @server_multithreaded %>
+<%- end -%>
 }
 
 # settings related to HTTPS client requests made by Puppet Server


### PR DESCRIPTION
Puppet Server 6.8 has just been released with an experimental new
feature.

> This release adds a new JRuby pool architecture that maintains a
> single JRuby instance through which requests to Puppet Server are run
> concurrently. In this mode, the server's memory footprint is
> significantly lighter, because it no longer needs to run multiple JRuby
> instances. Toggle this behavior by setting the
> `jruby-puppet.multithreaded` to `true`.

This commit adds support for this new setting.