### PR TITLE
Add server_ca_client_self_delete to CA Servers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -421,6 +421,9 @@
 # $server_ca_auth_required::                Whether client certificates are needed to access the puppet-admin api
 #                                           Defaults to true
 #
+# $server_ca_client_self_delete::           Adds a rule to auth.conf, that allows a client to delete its own certificate
+#                                           Defaults to false
+#
 # $server_use_legacy_auth_conf::            Should the puppetserver use the legacy puppet auth.conf?
 #                                           Defaults to false (the puppetserver will use its own conf.d/auth.conf)
 #
@@ -611,6 +614,7 @@ class puppet (
   Boolean $server_ca_crl_sync = $puppet::params::server_ca_crl_sync,
   Optional[Boolean] $server_crl_enable = $puppet::params::server_crl_enable,
   Boolean $server_ca_auth_required = $puppet::params::server_ca_auth_required,
+  Boolean $server_ca_client_self_delete = $puppet::params::server_ca_client_self_delete,
   Array[String] $server_ca_client_whitelist = $puppet::params::server_ca_client_whitelist,
   Optional[Puppet::Custom_trusted_oid_mapping] $server_custom_trusted_oid_mapping = $puppet::params::server_custom_trusted_oid_mapping,
   Boolean $server_http = $puppet::params::server_http,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -397,6 +397,7 @@ class puppet::params {
   $server_web_idle_timeout                = 30000
   $server_connect_timeout                 = 120000
   $server_ca_auth_required                = true
+  $server_ca_client_self_delete           = false
   $server_admin_api_whitelist             = [ 'localhost', $lower_fqdn ]
   $server_ca_client_whitelist             = [ 'localhost', $lower_fqdn ]
   $server_cipher_suites                   = [

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -255,6 +255,9 @@
 # $ca_auth_required::                  Whether client certificates are needed to access the puppet-admin api
 #                                      Defaults to true
 #
+# $ca_client_self_delete::             Adds a rule to auth.conf, that allows a client to self delete its own certificate
+#                                      Defaults to false
+#
 # $use_legacy_auth_conf::              Should the puppetserver use the legacy puppet auth.conf?
 #                                      Defaults to false (the puppetserver will use its own conf.d/auth.conf)
 #
@@ -349,6 +352,7 @@ class puppet::server(
   Boolean $ca_crl_sync = $::puppet::server_ca_crl_sync,
   Optional[Boolean] $crl_enable = $::puppet::server_crl_enable,
   Boolean $ca_auth_required = $::puppet::server_ca_auth_required,
+  Boolean $ca_client_self_delete = $::puppet::server_ca_client_self_delete,
   Array[String] $ca_client_whitelist = $::puppet::server_ca_client_whitelist,
   Optional[Puppet::Custom_trusted_oid_mapping] $custom_trusted_oid_mapping = $::puppet::server_custom_trusted_oid_mapping,
   Boolean $http = $::puppet::server_http,

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -103,6 +103,7 @@ class puppet::server::puppetserver (
   $server_web_idle_timeout                = $::puppet::server::web_idle_timeout,
   $server_connect_timeout                 = $::puppet::server::connect_timeout,
   $server_ca_auth_required                = $::puppet::server::ca_auth_required,
+  $server_ca_client_self_delete           = $::puppet::server::ca_client_self_delete,
   $server_ca_client_whitelist             = $::puppet::server::ca_client_whitelist,
   $server_admin_api_whitelist             = $::puppet::server::admin_api_whitelist,
   $server_puppetserver_version            = $::puppet::server::real_puppetserver_version,

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -280,6 +280,14 @@ describe 'puppet' do
         end
       end
 
+      describe 'ca_client_self_delete' do
+        context 'when set' do
+          let(:params) { super().merge(server_ca_client_self_delete: true)}
+          it { should contain_file(auth_conf)
+            .with_content(%r{^(\ *)name: "Allow nodes to delete their own certificates",$}) }
+        end
+      end
+
       describe 'server_jruby9k', unless: facts[:osfamily] == 'FreeBSD' do
         context 'when server_jruby9k => true' do
           let(:params) { super().merge(server_puppetserver_jruby9k: true) }

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -107,6 +107,7 @@ describe 'puppet' do
             .with_content(%r{^(\ *)path: "/puppet/v3/tasks"$})
             .with_content(%r{^(\ *)path: "\^/puppet/v3/facts/(.*)$})
             .with_content(/^( *)pp_cli_auth: "true"$/)
+            .without_content(%r{^(\ *)name: "Allow nodes to delete their own certificates",$})
         }
       end
 

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -111,6 +111,18 @@ authorization: {
             sort-order: 500
             name: "puppetlabs cert statuses"
         },
+<%- if @server_ca_client_self_delete -%>
+        {
+            name: "Allow nodes to delete their own certificates",
+            match-request: {
+                path: "^/puppet-ca/v1/certificate(_status|_request)?/([^/]+)$"
+                type: regex
+                method: [delete]
+            },
+            allow: "$2"
+            sort-order: 500
+        },
+<%- end -%>
 <%- end -%>
         {
             # Allow unauthenticated access to the status service endpoint


### PR DESCRIPTION
Add the server_ca_client_self_delete boolean parameter to CA servers.
When true, allow puppet clients to delete their own certificate from
the Puppet CA.