### PR TITLE
Add server_trusted_external_command parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -227,6 +227,9 @@
 #
 # $server_external_nodes::                  External nodes classifier executable
 #
+# $server_trusted_external_command::        The external trusted facts script to use.
+#                                           (Puppet >= 6.11 only).
+#
 # $server_git_repo::                        Use git repository as a source of modules
 #
 # $server_environments_owner::              The owner of the environments directory
@@ -633,6 +636,7 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_puppetserver_logdir = $puppet::params::server_puppetserver_logdir,
   Optional[Pattern[/^[\d]\.[\d]+\.[\d]+$/]] $server_puppetserver_version = $puppet::params::server_puppetserver_version,
   Variant[Undef, String[0], Stdlib::Absolutepath] $server_external_nodes = $puppet::params::server_external_nodes,
+  Optional[Stdlib::Absolutepath] $server_trusted_external_command = $puppet::params::server_trusted_external_command,
   Array[String] $server_cipher_suites = $puppet::params::server_cipher_suites,
   Optional[String] $server_config_version = $puppet::params::server_config_version,
   Integer[0] $server_connect_timeout = $puppet::params::server_connect_timeout,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -208,18 +208,19 @@ class puppet::params {
   $server_additional_settings = {}
 
   # Will this host be a puppetmaster?
-  $server                     = false
-  $server_ca                  = true
-  $server_ca_crl_sync         = false
-  $server_reports             = 'foreman'
-  $server_external_nodes      = "${dir}/node.rb"
-  $server_enc_api             = 'v2'
-  $server_report_api          = 'v2'
-  $server_request_timeout     = 60
-  $server_certname            = $::clientcert
-  $server_strict_variables    = false
-  $server_http                = false
-  $server_http_port           = 8139
+  $server                          = false
+  $server_ca                       = true
+  $server_ca_crl_sync              = false
+  $server_reports                  = 'foreman'
+  $server_external_nodes           = "${dir}/node.rb"
+  $server_trusted_external_command = undef
+  $server_enc_api                  = 'v2'
+  $server_report_api               = 'v2'
+  $server_request_timeout          = 60
+  $server_certname                 = $::clientcert
+  $server_strict_variables         = false
+  $server_http                     = false
+  $server_http_port                = 8139
 
   # Need a new master template for the server?
   $server_template      = 'puppet/server/puppet.conf.erb'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -60,6 +60,9 @@
 #
 # $external_nodes::                    External nodes classifier executable
 #
+# $server_trusted_external_command::   The external trusted facts script to use.
+#                                      (Puppet >= 6.11 only).
+#
 # $git_repo::                          Use git repository as a source of modules
 #
 # $environments_owner::                The owner of the environments directory
@@ -370,6 +373,7 @@ class puppet::server(
   Stdlib::Absolutepath $puppetserver_dir = $::puppet::server_puppetserver_dir,
   Optional[Pattern[/^[\d]\.[\d]+\.[\d]+$/]] $puppetserver_version = $::puppet::server_puppetserver_version,
   Variant[Undef, String[0], Stdlib::Absolutepath] $external_nodes = $::puppet::server_external_nodes,
+  Optional[Stdlib::Absolutepath] $trusted_external_command = $::puppet::server_trusted_external_command,
   Array[String] $cipher_suites = $::puppet::server_cipher_suites,
   Optional[String] $config_version = $::puppet::server_config_version,
   Integer[0] $connect_timeout = $::puppet::server_connect_timeout,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -36,10 +36,20 @@ class puppet::server::config inherits puppet::config {
   $server_storeconfigs_backend = $::puppet::server::storeconfigs_backend
   $server_external_nodes       = $::puppet::server::external_nodes
   $server_environment_timeout  = $::puppet::server::environment_timeout
+  $trusted_external_command    = $::puppet::server::trusted_external_command
 
   if $server_external_nodes and $server_external_nodes != '' {
     class{ '::puppet::server::enc':
       enc_path => $server_external_nodes,
+    }
+  }
+
+  if $trusted_external_command {
+    if versioncmp($::puppetversion, '6.11') < 0 {
+      fail('$server_trusted_external_command is only available for Puppet > 6.11')
+    }
+    puppet::config::master {
+      'trusted_external_command': value => $trusted_external_command,
     }
   }
 

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -87,6 +87,7 @@ describe 'puppet' do
         it { should_not contain_puppet__config__master('manifest') }
         it { should_not contain_puppet__config__master('modulepath') }
         it { should_not contain_puppet__config__master('config_version') }
+        it { should_not contain_puppet__config__master('trusted_external_command') }
 
         it { should contain_puppet__config__master('external_nodes').with_value("#{etcdir}\/node.rb") }
         it { should contain_puppet__config__master('node_terminus').with_value('exec') }
@@ -678,6 +679,42 @@ describe 'puppet' do
         end
 
         it { should contain_file("#{conf_d_dir}/auth.conf").with_content(/allow-header-cert-info: true/) }
+      end
+
+      describe 'server_trusted_external_command' do
+        context 'with default parameters' do
+          it { should_not contain_puppet__config__master('trusted_external_command') }
+        end
+
+        context 'with puppetversion >= 6.11' do
+          describe 'when server_trusted_external_command => /usr/local/sbin/trusted_external_command' do
+            let(:facts) do
+              super().merge(
+                puppetversion: '6.11.0'
+              )
+            end
+            let(:params) do
+              super().merge(server_trusted_external_command: '/usr/local/sbin/trusted_external_command' )
+            end
+
+            it { should contain_puppet__config__master('trusted_external_command').with_value('/usr/local/sbin/trusted_external_command') }
+          end
+        end
+
+        context 'with puppetversion < 6.11' do
+          describe 'when server_trusted_external_command => /usr/local/sbin/trusted_external_command' do
+            let(:facts) do
+              super().merge(
+                puppetversion: '6.5.0'
+              )
+            end
+            let(:params) do
+              super().merge(server_trusted_external_command: '/usr/local/sbin/trusted_external_command' )
+            end
+
+            it { is_expected.to raise_error(Puppet::Error, /\$server_trusted_external_command is only available for Puppet > 6\.11/) }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Make it possible to configure the 'trusted_external_command' parameter.
https://puppet.com/docs/puppet/latest/configuration.html#trustedexternalcommand

Fixes #730.