### PR TITLE
Refactor PuppetDB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ wrapper classes or even your ENC (if it supports param classes). For example:
 
     # Want to integrate with an existing PuppetDB?
     class { '::puppet':
-      server                      => true,
-      server_puppetdb_host        => 'mypuppetdb.example.com',
-      server_reports              => 'puppetdb,foreman',
-      server_storeconfigs_backend => 'puppetdb',
+      server               => true,
+      server_puppetdb_host => 'mypuppetdb.example.com',
+      server_reports       => 'puppetdb,foreman',
+      server_storeconfigs  => true,
     }
 
 Look in _init.pp_ for what can be configured this way, see Contributing if anything

--- a/README.md
+++ b/README.md
@@ -50,9 +50,16 @@ configure the Puppet master to connect to PuppetDB.
 
 Requires [puppetlabs/puppetdb](https://forge.puppetlabs.com/puppetlabs/puppetdb)
 
-Please see the notes about using puppetlabs/puppetdb 5.x with older versions of Puppet (< 4.x) and PuppetDB (< 3.x) with
-newer releases of the module and set the values via hiera or an extra include of `puppetdb::globals` with
-`puppetdb_version` defined.
+```puppet
+class { 'puppet':
+  server              => true,
+  server_reports      => 'puppetdb,foreman',
+  server_storeconfigs => true,
+}
+class { 'puppet::server::puppetdb':
+  server => 'mypuppetdb.example.com',
+}
+```
 
 Please also make sure your puppetdb ciphers are compatible with your puppet server ciphers, ie that the two following parameters match:
 ```
@@ -102,10 +109,12 @@ wrapper classes or even your ENC (if it supports param classes). For example:
 
     # Want to integrate with an existing PuppetDB?
     class { '::puppet':
-      server               => true,
-      server_puppetdb_host => 'mypuppetdb.example.com',
-      server_reports       => 'puppetdb,foreman',
-      server_storeconfigs  => true,
+      server              => true,
+      server_reports      => 'puppetdb,foreman',
+      server_storeconfigs => true,
+    }
+    class { 'puppet::server::puppetdb':
+      server => 'mypuppetdb.example.com',
     }
 
 Look in _init.pp_ for what can be configured this way, see Contributing if anything

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -255,12 +255,6 @@
 #
 # $server_certname::                        The name to use when handling certificates.
 #
-# $server_puppetdb_host::                   PuppetDB host
-#
-# $server_puppetdb_port::                   PuppetDB port
-#
-# $server_puppetdb_swf::                    PuppetDB soft_write_failure
-#
 # === Advanced server parameters:
 #
 # $server_strict_variables::                if set to true, it will throw parse errors
@@ -673,9 +667,6 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_foreman_ssl_key = $puppet::params::server_foreman_ssl_key,
   Boolean $server_foreman_facts = $puppet::params::server_foreman_facts,
   Optional[Stdlib::Absolutepath] $server_puppet_basedir = $puppet::params::server_puppet_basedir,
-  Optional[String] $server_puppetdb_host = $puppet::params::server_puppetdb_host,
-  Integer[0, 65535] $server_puppetdb_port = $puppet::params::server_puppetdb_port,
-  Boolean $server_puppetdb_swf = $puppet::params::server_puppetdb_swf,
   Enum['current', 'future'] $server_parser = $puppet::params::server_parser,
   Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]] $server_environment_timeout = $puppet::params::server_environment_timeout,
   String $server_jvm_java_bin = $puppet::params::server_jvm_java_bin,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -251,8 +251,7 @@
 # $server_git_branch_map::                  Git branch to puppet env mapping for the
 #                                           default post receive hook
 #
-# $server_storeconfigs_backend::            Do you use storeconfigs?
-#                                           false if you don't, "puppetdb" for puppetdb
+# $server_storeconfigs::                    Whether to enable storeconfigs
 #
 # $server_certname::                        The name to use when handling certificates.
 #
@@ -654,7 +653,7 @@ class puppet (
   Integer[0] $server_idle_timeout = $puppet::params::server_idle_timeout,
   String $server_post_hook_content = $puppet::params::server_post_hook_content,
   String $server_post_hook_name = $puppet::params::server_post_hook_name,
-  Variant[Undef, Boolean, Enum['active_record', 'puppetdb']] $server_storeconfigs_backend = $puppet::params::server_storeconfigs_backend,
+  Boolean $server_storeconfigs = $puppet::params::server_storeconfigs,
   Array[Stdlib::Absolutepath] $server_ruby_load_paths = $puppet::params::server_ruby_load_paths,
   Stdlib::Absolutepath $server_ssl_dir = $puppet::params::server_ssl_dir,
   Boolean $server_ssl_dir_manage = $puppet::params::server_ssl_dir_manage,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -273,11 +273,7 @@ class puppet::params {
   $server_puppetdb_port = 8081
   $server_puppetdb_swf  = false
 
-  # Do you use storeconfigs? (note: not required)
-  # - undef if you don't
-  # - active_record for 2.X style db
-  # - puppetdb for puppetdb
-  $server_storeconfigs_backend = undef
+  $server_storeconfigs = false
 
   $puppet_major = regsubst($::puppetversion, '^(\d+)\..*$', '\1')
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -268,11 +268,6 @@ class puppet::params {
   $server_post_hook_name      = 'post-receive'
   $server_custom_trusted_oid_mapping = undef
 
-  # PuppetDB config
-  $server_puppetdb_host = undef
-  $server_puppetdb_port = 8081
-  $server_puppetdb_swf  = false
-
   $server_storeconfigs = false
 
   $puppet_major = regsubst($::puppetversion, '^(\d+)\..*$', '\1')

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -109,12 +109,6 @@
 # $additional_settings::               A hash of additional settings.
 #                                      Example: {trusted_node_data => true, ordering => 'manifest'}
 #
-# $puppetdb_host::                     PuppetDB host
-#
-# $puppetdb_port::                     PuppetDB port
-#
-# $puppetdb_swf::                      PuppetDB soft_write_failure
-#
 # $parser::                            Sets the parser to use. Valid options are 'current' or 'future'.
 #                                      Defaults to 'current'.
 #
@@ -393,7 +387,7 @@ class puppet::server(
   Integer[0] $idle_timeout = $puppet::server_idle_timeout,
   String $post_hook_content = $puppet::server_post_hook_content,
   String $post_hook_name = $puppet::server_post_hook_name,
-  Boolean $storeconfigs = $puppet::params::server_storeconfigs,
+  Boolean $storeconfigs = $puppet::server_storeconfigs,
   Array[Stdlib::Absolutepath] $ruby_load_paths = $puppet::server_ruby_load_paths,
   Stdlib::Absolutepath $ssl_dir = $puppet::server_ssl_dir,
   Boolean $ssl_dir_manage = $puppet::server_ssl_dir_manage,
@@ -413,9 +407,6 @@ class puppet::server(
   Optional[Stdlib::Absolutepath] $foreman_ssl_key = $puppet::server_foreman_ssl_key,
   Boolean $server_foreman_facts = $puppet::server_foreman_facts,
   Optional[Stdlib::Absolutepath] $puppet_basedir = $puppet::server_puppet_basedir,
-  Optional[String] $puppetdb_host = $puppet::server_puppetdb_host,
-  Integer[0, 65535] $puppetdb_port = $puppet::server_puppetdb_port,
-  Boolean $puppetdb_swf = $puppet::server_puppetdb_swf,
   Enum['current', 'future'] $parser = $puppet::server_parser,
   Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]] $environment_timeout = $puppet::server_environment_timeout,
   String $jvm_java_bin = $puppet::server_jvm_java_bin,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -93,9 +93,7 @@
 #
 # $post_hook_name::                    Name of a git hook
 #
-# $storeconfigs_backend::              Do you use storeconfigs? (note: not required)
-#                                      false if you don't, "active_record" for 2.X
-#                                      style db, "puppetdb" for puppetdb
+# $storeconfigs::                      Whether to enable storeconfigs
 #
 # $ssl_dir::                           SSL directory
 #
@@ -395,7 +393,7 @@ class puppet::server(
   Integer[0] $idle_timeout = $puppet::server_idle_timeout,
   String $post_hook_content = $puppet::server_post_hook_content,
   String $post_hook_name = $puppet::server_post_hook_name,
-  Variant[Undef, Boolean, Enum['active_record', 'puppetdb']] $storeconfigs_backend = $puppet::server_storeconfigs_backend,
+  Boolean $storeconfigs = $puppet::params::server_storeconfigs,
   Array[Stdlib::Absolutepath] $ruby_load_paths = $puppet::server_ruby_load_paths,
   Stdlib::Absolutepath $ssl_dir = $puppet::server_ssl_dir,
   Boolean $ssl_dir_manage = $puppet::server_ssl_dir_manage,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -298,16 +298,4 @@ class puppet::server::config inherits puppet::config {
     }
     contain foreman::puppetmaster
   }
-
-  ## PuppetDB
-  if $puppet::server::puppetdb_host {
-    class { 'puppetdb::master::config':
-      puppetdb_server             => $puppet::server::puppetdb_host,
-      puppetdb_port               => $puppet::server::puppetdb_port,
-      puppetdb_soft_write_failure => $puppet::server::puppetdb_swf,
-      manage_storeconfigs         => false,
-      restart_puppet              => false,
-    }
-    Class['puppetdb::master::puppetdb_conf'] ~> Class['puppet::server::service']
-  }
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -33,7 +33,6 @@ class puppet::server::config inherits puppet::config {
   ## General configuration
   $ca_server                   = $puppet::ca_server
   $ca_port                     = $puppet::ca_port
-  $server_storeconfigs_backend = $puppet::server::storeconfigs_backend
   $server_external_nodes       = $puppet::server::external_nodes
   $server_environment_timeout  = $puppet::server::environment_timeout
   $trusted_external_command    = $puppet::server::trusted_external_command
@@ -84,6 +83,7 @@ class puppet::server::config inherits puppet::config {
     'certname':           value => $puppet::server::certname;
     'parser':             value => $puppet::server::parser;
     'strict_variables':   value => $puppet::server::strict_variables;
+    'storeconfigs':       value => $puppet::server::storeconfigs;
   }
 
   if $puppet::server::ssl_dir_manage {
@@ -94,12 +94,6 @@ class puppet::server::config inherits puppet::config {
   if $server_environment_timeout {
     puppet::config::master {
       'environment_timeout':  value => $server_environment_timeout;
-    }
-  }
-  if $server_storeconfigs_backend {
-    puppet::config::master {
-      'storeconfigs':         value => true;
-      'storeconfigs_backend': value => $server_storeconfigs_backend;
     }
   }
 

--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -1,0 +1,39 @@
+# @summary PuppetDB integration
+#
+# This class relies on the puppetlabs/puppetdb and essentially wraps
+# puppetdb::master::config with the proper resource chaining.
+#
+# Note that this doesn't manage the server itself.
+#
+# @example
+#   class { 'puppet':
+#     server              => true,
+#     server_reports      => 'puppetdb,foreman',
+#     server_storeconfigs => true,
+#   }
+#   class { 'puppet::server::puppetdb':
+#     server => 'mypuppetdb.example.com',
+#   }
+#
+# @param server
+#   The PuppetDB server
+#
+# @param port
+#   The PuppetDB port
+#
+# @param soft_write_failure
+#   Whether to enable soft write failure
+class puppet::server::puppetdb (
+  Stdlib::Host $server = undef,
+  Stdlib::Port $port = 8081,
+  Boolean $soft_write_failure = false,
+) {
+  class { 'puppetdb::master::config':
+    puppetdb_server             => $server,
+    puppetdb_port               => $port,
+    puppetdb_soft_write_failure => $soft_write_failure,
+    manage_storeconfigs         => false,
+    restart_puppet              => false,
+  }
+  Class['puppetdb::master::puppetdb_conf'] ~> Class['puppet::server::service']
+}

--- a/spec/classes/puppet_server_puppetdb_spec.rb
+++ b/spec/classes/puppet_server_puppetdb_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'puppet::server::puppetdb' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}", unless: unsupported_puppetmaster_osfamily(os_facts[:osfamily]) do
+      let(:facts) { os_facts }
+      let(:params) { {server: 'mypuppetdb.example.com'} }
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'puppet':
+          server              => true,
+          server_reports      => 'puppetdb,foreman',
+          server_storeconfigs => true,
+        }
+        PUPPET
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_puppet__config__master('storeconfigs').with_value(true) }
+      it 'configures PuppetDB' do
+        is_expected.to contain_class('puppetdb::master::config')
+          .with_puppetdb_server('mypuppetdb.example.com')
+          .with_puppetdb_port(8081)
+          .with_puppetdb_soft_write_failure(false)
+          .with_manage_storeconfigs(false)
+          .with_restart_puppet(false)
+      end
+    end
+  end
+end

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -143,8 +143,6 @@ describe 'puppet' do
 
         it { should_not contain_puppet__config__agent('http_connect_timeout') }
         it { should_not contain_puppet__config__agent('http_read_timeout') }
-        it { should_not contain_class('puppetdb') }
-        it { should_not contain_class('puppetdb::master::config') }
         it { should_not contain_file("#{confdir}/custom_trusted_oid_mapping.yaml") }
 
         it { should contain_file("#{confdir}/autosign.conf") }
@@ -431,27 +429,6 @@ describe 'puppet' do
             .with_ssl_ca('/etc/example/ca.pem')
             .with_ssl_cert('/etc/example/cert.pem')
             .with_ssl_key('/etc/example/key.pem')
-        end
-      end
-
-      describe 'with a PuppetDB host set' do
-        let(:params) do
-          super().merge(
-            server_puppetdb_host: 'mypuppetdb.example.com',
-            server_storeconfigs: true,
-          )
-        end
-
-        it { should contain_puppet__config__master('storeconfigs').with_value(true) }
-
-        it 'should configure PuppetDB' do
-          should compile.with_all_deps
-          should contain_class('puppetdb::master::config')
-            .with_puppetdb_server('mypuppetdb.example.com')
-            .with_puppetdb_port(8081)
-            .with_puppetdb_soft_write_failure(false)
-            .with_manage_storeconfigs(false)
-            .with_restart_puppet(false)
         end
       end
 

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -81,9 +81,8 @@ describe 'puppet' do
         it { should contain_puppet__config__master('parser').with_value('current') }
         it { should contain_puppet__config__master('strict_variables').with_value('false') }
         it { should contain_puppet__config__master('ssldir').with_value(ssldir) }
+        it { should contain_puppet__config__master('storeconfigs').with_value(false) }
         it { should_not contain_puppet__config__master('environment_timeout') }
-        it { should_not contain_puppet__config__master('storeconfigs') }
-        it { should_not contain_puppet__config__master('storeconfigs_backend') }
         it { should_not contain_puppet__config__master('manifest') }
         it { should_not contain_puppet__config__master('modulepath') }
         it { should_not contain_puppet__config__master('config_version') }
@@ -439,9 +438,11 @@ describe 'puppet' do
         let(:params) do
           super().merge(
             server_puppetdb_host: 'mypuppetdb.example.com',
-            server_storeconfigs_backend: 'puppetdb'
+            server_storeconfigs: true,
           )
         end
+
+        it { should contain_puppet__config__master('storeconfigs').with_value(true) }
 
         it 'should configure PuppetDB' do
           should compile.with_all_deps


### PR DESCRIPTION
Since Puppet 4.0 the active record backend is gone and the only one is PuppetDB. This is the default value for backend is puppetdb so we can simply expose the storeconfigs boolean.

The PuppetDB parameters aren't for the puppetserver itself but rather the puppetdb config in a way that's compatible with this module. Separating it into a class makes it a bit clearer that it really needs an additional Puppet module.