### PR TITLE
Modulesync: make voxpupuli helpers work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ junit/
 pkg/
 coverage/
 .yardoc/
+REFERENCE.md
 
 ## InteliJ / RubyMine
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,7 +280,7 @@
       `$server_http` parameter.
 * Other features:
     * Support native puppetserver package on FreeBSD
-    * Allow disabling crl when `server_ca => true` 
+    * Allow disabling crl when `server_ca => true`
     * Add SLES AIO agent support
     * Add support for Parallels PSBM
 * Other changes and fixes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,11 +178,33 @@ With all dependencies in place and up-to-date we can now run the tests:
 rake spec
 ```
 
-This will execute all the [rspec tests](http://rspec-puppet.com/) tests
-under [spec/defines](./spec/defines), [spec/classes](./spec/classes),
-and so on. rspec tests may have the same kind of dependencies as the
-module they are testing. While the module defines in its [Modulefile](./Modulefile),
+This will execute all the [rspec tests](http://rspec-puppet.com/) tests under
+[spec/defines](./spec/defines), [spec/classes](./spec/classes), and so on.
+rspec tests may have the same kind of dependencies as the module they are
+testing. While the module defines in its [metadata.json](./metadata.json),
 rspec tests define them in [.fixtures.yml](./fixtures.yml).
+
+To run specific tests, use the spec test file name and a filter like:
+
+```shell
+bundle exec rspec spec/classes/foreman_spec.rb -e 'should restart passenger'
+```
+More filter info available [here](https://relishapp.com/rspec/rspec-core/v/3-9/docs/command-line/example-option)
+
+To run OS specific tests:
+
+```shell
+SPEC_FACTS_OS=redhat-7-x86_64 bundle exec rspec spec/classes/foreman_spec.rb
+```
+
+If you have more than one version of `redhat` OS specified in metadata.json,
+you can run them all like:
+
+```shell
+SPEC_FACTS_OS=redhat bundle exec rspec spec/classes/foreman_spec.rb
+```
+For more information on running the tests, see [rspec-puppet-facts](https://github.com/mcanevet/rspec-puppet-facts)
+and specifically the [section for running tests](https://github.com/mcanevet/rspec-puppet-facts#running-your-tests).
 
 Writing Tests
 -------------

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ gem 'puppet-lint-param-docs', '>= 1.3.0'
 gem 'puppet-lint-spaceship_operator_without_tag-check'
 gem 'puppet-lint-strict_indent-check'
 gem 'puppet-lint-undef_in_function-check'
-gem 'voxpupuli-test', '~> 1.0'
+gem 'voxpupuli-test', '~> 1.3'
 gem 'github_changelog_generator', '>= 1.15.0', {"groups"=>["development"]}
-gem 'puppet-blacksmith', '>= 4.1.0', {"groups"=>["development"]}
-gem 'voxpupuli-acceptance', '~> 0.1', {"groups"=>["system_tests"]}
+gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
+gem 'voxpupuli-acceptance', '~> 0.2', {"groups"=>["system_tests"]}
 
 # vim:ft=ruby

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -234,7 +234,7 @@
       `$server_http` parameter.
 * Other features:
     * Support native puppetserver package on FreeBSD
-    * Allow disabling crl when `server_ca => true` 
+    * Allow disabling crl when `server_ca => true`
     * Add SLES AIO agent support
     * Add support for Parallels PSBM
 * Other changes and fixes:

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,9 @@
 
 require 'voxpupuli/test/rake'
 
+# We use fixtures in our modules, which is not the default
+task :beaker => 'spec_prep'
+
 # blacksmith isn't always present, e.g. on Travis with --without development
 begin
   require 'puppet_blacksmith/rake_tasks'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,8 +89,16 @@ class puppet::params {
       $server_puppetserver_vardir = '/var/puppet/server/data/puppetserver'
       $server_puppetserver_rundir = '/var/run/puppetserver'
       $server_puppetserver_logdir = '/var/log/puppetserver'
-      $ruby_gem_dir               = regsubst($facts['ruby']['version'], '^(\d+\.\d+).*$', '/usr/local/lib/ruby/gems/\1/gems')
-      $server_ruby_load_paths     = [$facts['ruby']['sitedir'], "${ruby_gem_dir}/facter-${::facterversion}/lib"]
+      if fact('ruby') {
+        $ruby_gem_dir               = regsubst($facts['ruby']['version'], '^(\d+\.\d+).*$', '/usr/local/lib/ruby/gems/\1/gems')
+        $server_ruby_load_paths     = [$facts['ruby']['sitedir'], "${ruby_gem_dir}/facter-${facts['facterversion']}/lib"]
+      } else {
+        # On FreeBSD 11 the ruby fact doesn't resolve - at least in facterdb
+        # lint:ignore:legacy_facts
+        $ruby_gem_dir               = regsubst($facts['rubyversion'], '^(\d+\.\d+).*$', '/usr/local/lib/ruby/gems/\1/gems')
+        $server_ruby_load_paths     = [$facts['rubysitedir'], "${ruby_gem_dir}/facter-${facts['facterversion']}/lib"]
+        # lint:endignore
+      }
       $server_jruby_gem_home      = '/var/puppet/server/data/puppetserver/jruby-gems'
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,8 @@ class puppet::params {
   $syslogfacility      = undef
   $environment         = $::environment
 
-  $aio_package      = ($facts['os']['family'] == 'Windows' or $facts['ruby']['sitedir'] =~ /\/opt\/puppetlabs\/puppet/)
+  # aio_agent_version is a core fact that's empty on non-AIO
+  $aio_package      = fact('aio_agent_version') =~ String[1]
 
   $systemd_randomizeddelaysec = 0
 

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'deep_merge'
 
 describe 'puppet' do
   on_supported_os.each do |os, facts|
@@ -29,11 +28,9 @@ describe 'puppet' do
         package_provider = nil
       end
 
-      let :facts do
-        facts.deep_merge(
-          # Cron/systemd timers are based on the IP - make it consistent
-          networking: { ip: '192.0.2.100' }
-        )
+      let(:facts) do
+        # Cron/systemd timers are based on the IP - make it consistent
+        override_facts(facts, networking: {ip: '192.0.2.100'})
       end
 
       let :params do

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'deep_merge'
 
 describe 'puppet' do
-  on_os_under_test.each do |os, facts|
+  on_supported_os.each do |os, facts|
     context "on #{os}" do
       case facts[:osfamily]
       when 'FreeBSD'

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'deep_merge'
 
 describe 'puppet' do
-  on_os_under_test.each do |os, facts|
+  on_supported_os.each do |os, facts|
     context "on #{os}" do
       case facts[:osfamily]
       when 'FreeBSD'

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'puppet' do
-  on_os_under_test.each do |os, facts|
+  on_supported_os.each do |os, facts|
     context "on #{os}" do
       case facts[:osfamily]
       when 'FreeBSD'

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -80,42 +80,37 @@ describe 'puppet' do
         it { should contain_puppet__config__main('ca_port').with_value(8140) }
       end
 
-      describe 'with package_source => Httpurl' do
-        let :params do {
-          :package_source => 'https://example.com:123/test'
-        } end
+      # compilation is broken due to paths
+      context 'on non-windows', unless: facts[:osfamily] == 'windows' do
+        describe 'with package_source => Httpurl' do
+          let :params do {
+            :package_source => 'https://example.com:123/test'
+          } end
 
-        if facts[:osfamily] != 'windows'
           it { is_expected.to compile }
         end
-      end
 
-      describe 'with package_source => Unixpath' do
-        let :params do {
-          :package_source => '/test/folder/path/source.rpm'
-        } end
+        describe 'with package_source => Unixpath' do
+          let :params do {
+            :package_source => '/test/folder/path/source.rpm'
+          } end
 
-        if facts[:osfamily] != 'windows'
           it { is_expected.to compile }
         end
-      end
 
-      describe 'with package_source => Windowspath' do
-        let :params do {
-          :package_source => 'C:\test\folder\path\source.exe'
-        } end
+        describe 'with package_source => Windowspath' do
+          let :params do {
+            :package_source => 'C:\test\folder\path\source.exe'
+          } end
 
-        if facts[:osfamily] != 'windows'
           it { is_expected.to compile }
         end
-      end
 
-      describe 'with package_source => foo' do
-        let :params do {
-          :package_source => 'foo'
-        } end
+        describe 'with package_source => foo' do
+          let :params do {
+            :package_source => 'foo'
+          } end
 
-        if facts[:osfamily] != 'windows'
           it { is_expected.not_to compile }
         end
       end

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'puppet' do
-  on_os_under_test.each do |os, facts|
+  on_supported_os.each do |os, facts|
     next if unsupported_puppetmaster_osfamily(facts[:osfamily])
     context "on #{os}" do
       let(:facts) do

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'puppet' do
-  on_os_under_test.each do |os, facts|
+  on_supported_os.each do |os, facts|
     context "on #{os}", unless: unsupported_puppetmaster_osfamily(facts[:osfamily]) do
       if facts[:osfamily] == 'FreeBSD'
         puppet_major = facts[:puppetversion].to_i

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -169,8 +169,8 @@ describe 'puppet' do
 
       describe 'with uppercase hostname' do
         let(:facts) do
-          super().merge(
-            fqdn: 'PUPPETMASTER.example.com',
+          override_facts(super(),
+            networking: {fqdn: 'PUPPETMASTER.example.com'},
             # clientcert is always lowercase by Puppet design
             clientcert: 'puppetmaster.example.com'
           )

--- a/spec/defines/puppet_config_entry_spec.rb
+++ b/spec/defines/puppet_config_entry_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'puppet::config::entry' do
-  on_os_under_test.each do |os, facts|
+  on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
 

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,5 @@
+if $facts['os']['name'] == 'Ubuntu' {
+  package { 'cron':
+    ensure => installed,
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,33 +3,6 @@
 
 require 'voxpupuli/test/spec_helper'
 
-# Rough conversion of grepping in the puppet source:
-# grep defaultfor lib/puppet/provider/service/*.rb
-add_custom_fact :service_provider, ->(os, facts) do
-  case facts[:osfamily].downcase
-  when 'archlinux'
-    'systemd'
-  when 'darwin'
-    'launchd'
-  when 'debian'
-    'systemd'
-  when 'freebsd'
-    'freebsd'
-  when 'gentoo'
-    'openrc'
-  when 'openbsd'
-    'openbsd'
-  when 'redhat'
-    facts[:operatingsystemrelease].to_i >= 7 ? 'systemd' : 'redhat'
-  when 'suse'
-    facts[:operatingsystemmajrelease].to_i >= 12 ? 'systemd' : 'redhat'
-  when 'windows'
-    'windows'
-  else
-    'init'
-  end
-end
-
 def get_content(subject, title)
   is_expected.to contain_file(title)
   content = subject.resource('file', title).send(:parameters)[:content]

--- a/spec/support/aio.rb
+++ b/spec/support/aio.rb
@@ -1,8 +1,6 @@
-aio = on_supported_os.reject do |os, facts|
-  ['Archlinux', 'FreeBSD', 'DragonFly', 'Windows'].include?(facts[:operatingsystem])
-end.keys
-
-add_custom_fact :rubysitedir, '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0', :confine => aio
+add_custom_fact :aio_agent_version, ->(os, facts) do
+  return facts[:puppetversion] unless ['Archlinux', 'FreeBSD', 'DragonFly', 'Windows'].include?(facts[:os]['family'])
+end
 
 def unsupported_puppetmaster_osfamily(osfamily)
   ['Archlinux', 'windows', 'Suse'].include?(osfamily)

--- a/spec/support/facts.rb
+++ b/spec/support/facts.rb
@@ -1,0 +1,27 @@
+# This fact is provided by puppetlabs-stdlib and uses the actual provider for
+# service. A rough conversion of grepping in the puppet source:
+# grep defaultfor lib/puppet/provider/service/*.rb
+add_custom_fact :service_provider, ->(os, facts) do
+  case facts[:osfamily].downcase
+  when 'archlinux'
+    'systemd'
+  when 'darwin'
+    'launchd'
+  when 'debian'
+    'systemd'
+  when 'freebsd'
+    'freebsd'
+  when 'gentoo'
+    'openrc'
+  when 'openbsd'
+    'openbsd'
+  when 'redhat'
+    facts[:operatingsystemrelease].to_i >= 7 ? 'systemd' : 'redhat'
+  when 'suse'
+    facts[:operatingsystemmajrelease].to_i >= 12 ? 'systemd' : 'redhat'
+  when 'windows'
+    'windows'
+  else
+    'init'
+  end
+end


### PR DESCRIPTION
46c40319775e2293a9e92556fe68755fa348f92d was merged too soon. This makes it work, with the exception of removal of Debian 10 + Puppet 5 (for which no packages are present). That's the only manual change left.