### PR TITLE
Drop Foreman API version parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -301,10 +301,6 @@
 #
 # $server_puppet_basedir::                  Where is the puppet code base located
 #
-# $server_enc_api::                         What version of enc script to deploy.
-#
-# $server_report_api::                      What version of report processor to deploy.
-#
 # $server_request_timeout::                 Timeout in node.rb script for fetching
 #                                           catalog from Foreman (in seconds).
 #
@@ -668,8 +664,6 @@ class puppet (
   Optional[Variant[String, Array[String]]] $server_package = $puppet::params::server_package,
   Optional[String] $server_version = $puppet::params::server_version,
   String $server_certname = $puppet::params::server_certname,
-  Enum['v2'] $server_enc_api = $puppet::params::server_enc_api,
-  Enum['v2'] $server_report_api = $puppet::params::server_report_api,
   Integer[0] $server_request_timeout = $puppet::params::server_request_timeout,
   Boolean $server_strict_variables = $puppet::params::server_strict_variables,
   Hash[String, Data] $server_additional_settings = $puppet::params::server_additional_settings,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -214,8 +214,6 @@ class puppet::params {
   $server_reports                  = 'foreman'
   $server_external_nodes           = "${dir}/node.rb"
   $server_trusted_external_command = undef
-  $server_enc_api                  = 'v2'
-  $server_report_api               = 'v2'
   $server_request_timeout          = 60
   $server_certname                 = $::clientcert
   $server_strict_variables         = false

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -145,10 +145,6 @@
 #
 # $puppet_basedir::                    Where is the puppet code base located
 #
-# $enc_api::                           What version of enc script to deploy.
-#
-# $report_api::                        What version of report processor to deploy.
-#
 # $compile_mode::                      Used to control JRuby's "CompileMode", which may improve performance.
 #
 #
@@ -409,8 +405,6 @@ class puppet::server(
   Optional[Variant[String, Array[String]]] $package = $puppet::server_package,
   Optional[String] $version = $puppet::server_version,
   String $certname = $puppet::server_certname,
-  Enum['v2'] $enc_api = $puppet::server_enc_api,
-  Enum['v2'] $report_api = $puppet::server_report_api,
   Integer[0] $request_timeout = $puppet::server_request_timeout,
   Boolean $strict_variables = $puppet::server_strict_variables,
   Hash[String, Data] $additional_settings = $puppet::server_additional_settings,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -297,8 +297,6 @@ class puppet::server::config inherits puppet::config {
       puppet_home    => $puppet::server::puppetserver_vardir,
       puppet_basedir => $puppet::server::puppet_basedir,
       puppet_etcdir  => $puppet::dir,
-      enc_api        => $puppet::server::enc_api,
-      report_api     => $puppet::server::report_api,
       timeout        => $puppet::server::request_timeout,
       ssl_ca         => pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert),
       ssl_cert       => pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert),


### PR DESCRIPTION
The latest theforeman-foreman has removed these and for older versions they have the only possible value as a default already.