### PR TITLE
Switch AIO detection to use aio_agent_version fact

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,8 @@ class puppet::params {
   $syslogfacility      = undef
   $environment         = $::environment
 
-  $aio_package      = ($facts['os']['family'] == 'Windows' or $facts['ruby']['sitedir'] =~ /\/opt\/puppetlabs\/puppet/)
+  # aio_agent_version is a core fact that's empty on non-AIO
+  $aio_package      = fact('aio_agent_version') =~ String[1]
 
   $systemd_randomizeddelaysec = 0
 

--- a/spec/support/aio.rb
+++ b/spec/support/aio.rb
@@ -1,8 +1,6 @@
-aio = on_supported_os.reject do |os, facts|
-  ['Archlinux', 'FreeBSD', 'DragonFly', 'Windows'].include?(facts[:operatingsystem])
-end.keys
-
-add_custom_fact :rubysitedir, '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0', :confine => aio
+add_custom_fact :aio_agent_version, ->(os, facts) do
+  return facts[:puppetversion] unless ['Archlinux', 'FreeBSD', 'DragonFly', 'Windows'].include?(facts[:os]['family'])
+end
 
 def unsupported_puppetmaster_osfamily(osfamily)
   ['Archlinux', 'windows', 'Suse'].include?(osfamily)


### PR DESCRIPTION
This fact is a core fact that's only set on AIO installs. Setting this custom fact is also easier than the structured fact in our test suite which increases reliability of our tests.

Its tests will fail until https://github.com/theforeman/puppet-puppet/pull/735 is merged, but this needs to go in the changelog as a separate entry. IMHO we should merge this if #735 is green.