### PR TITLE
Revert "Convert the systemd timer service to camptocamp/systemd"

### DIFF
--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -6,22 +6,69 @@ class puppet::agent::service::systemd (
   Optional[Integer[0,59]] $minute  = undef,
 ) {
   unless $puppet::runmode == 'unmanaged' or 'systemd.timer' in $puppet::unavailable_runmodes {
-    # Use the same times as for cron
-    $times = extlib::ip_to_cron($puppet::runinterval)
+    exec { 'systemctl-daemon-reload-puppet':
+      refreshonly => true,
+      path        => $::path,
+      command     => 'systemctl daemon-reload',
+    }
 
-    # But only if they are not explicitly specified
-    $_hour = pick($hour, $times[0])
-    $_minute = pick($minute, $times[1])
+    if $enabled {
+      # Use the same times as for cron
+      $times = extlib::ip_to_cron($puppet::runinterval)
 
-    $command = pick($puppet::systemd_cmd, "${puppet::puppet_cmd} agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize --detailed-exitcode --no-usecacheonfailure")
-    $randomizeddelaysec = $puppet::systemd_randomizeddelaysec
+      # But only if they are not explicitly specified
+      $_hour = pick($hour, $times[0])
+      $_minute = pick($minute, $times[1])
 
-    systemd::timer { "${puppet::systemd_unit_name}.timer":
-      ensure          => bool2str($enabled, 'present', 'absent'),
-      active          => $enabled,
-      enable          => $enabled,
-      timer_content   => template('puppet/agent/systemd.puppet-run.timer.erb'),
-      service_content => template('puppet/agent/systemd.puppet-run.service.erb'),
+      $command = $puppet::systemd_cmd ? {
+        undef   => "${puppet::puppet_cmd} agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize --detailed-exitcode --no-usecacheonfailure",
+        default => $puppet::systemd_cmd,
+      }
+
+      $randomizeddelaysec = $puppet::systemd_randomizeddelaysec
+
+      file { "/etc/systemd/system/${puppet::systemd_unit_name}.timer":
+        content => template('puppet/agent/systemd.puppet-run.timer.erb'),
+        notify  => [
+          Exec['systemctl-daemon-reload-puppet'],
+          Service['puppet-run.timer'],
+        ],
+      }
+
+      file { "/etc/systemd/system/${puppet::systemd_unit_name}.service":
+        content => template('puppet/agent/systemd.puppet-run.service.erb'),
+        notify  => Exec['systemctl-daemon-reload-puppet'],
+      }
+
+      service { 'puppet-run.timer':
+        ensure   => running,
+        provider => 'systemd',
+        name     => "${puppet::systemd_unit_name}.timer",
+        enable   => true,
+        require  => Exec['systemctl-daemon-reload-puppet'],
+      }
+    } else {
+      # Reverse order - stop, delete files, exec
+      service { 'puppet-run.timer':
+        ensure   => stopped,
+        provider => 'systemd',
+        name     => "${puppet::systemd_unit_name}.timer",
+        enable   => false,
+        before   => [
+          File["/etc/systemd/system/${puppet::systemd_unit_name}.timer"],
+          File["/etc/systemd/system/${puppet::systemd_unit_name}.service"],
+        ],
+      }
+
+      file { "/etc/systemd/system/${puppet::systemd_unit_name}.timer":
+        ensure => absent,
+        notify => Exec['systemctl-daemon-reload-puppet'],
+      }
+
+      file { "/etc/systemd/system/${puppet::systemd_unit_name}.service":
+        ensure => absent,
+        notify => Exec['systemctl-daemon-reload-puppet'],
+      }
     }
   }
 }

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -106,8 +106,14 @@ describe 'puppet' do
         case os
         when /\Adebian-/, /\A(redhat|centos|scientific)-7/, /\Afedora-/, /\Aubuntu-(16|18)/, /\Aarchlinux-/
           it do
+            is_expected.to contain_exec('systemctl-daemon-reload-puppet')
+              .with_refreshonly(true)
+              .with_command('systemctl daemon-reload')
+          end
+
+          it do
             is_expected.to contain_service('puppet-run.timer')
-              .with_ensure(false)
+              .with_ensure(:stopped)
               .with_provider('systemd')
               .with_name('puppet-run.timer')
               .with_enable(false)
@@ -119,6 +125,7 @@ describe 'puppet' do
           it { is_expected.not_to contain_service('puppet-run.timer') }
           it { is_expected.not_to contain_file('/etc/systemd/system/puppet-run.timer') }
           it { is_expected.not_to contain_file('/etc/systemd/system/puppet-run.service') }
+          it { is_expected.not_to contain_exec('systemctl-daemon-reload-puppet') }
         end
       end
 
@@ -205,7 +212,7 @@ describe 'puppet' do
                 .with_enable('false')
             end
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(false) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
             it do
               is_expected.to contain_cron('puppet')
                 .with_command("#{bindir}/puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize")
@@ -251,7 +258,7 @@ describe 'puppet' do
                 .with_enable('false')
             end
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(false) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
             it do
               is_expected.to contain_cron('puppet')
                 .with_command("#{bindir}/puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize")
@@ -286,7 +293,7 @@ describe 'puppet' do
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(true) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(true) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:running) }
 
             it do
               is_expected.to contain_file('/etc/systemd/system/puppet-run.timer')
@@ -304,11 +311,17 @@ describe 'puppet' do
             end
 
             it do
+              is_expected.to contain_exec('systemctl-daemon-reload-puppet')
+                .with_refreshonly(true)
+                .with_command('systemctl daemon-reload')
+            end
+
+            it do
               is_expected.to contain_service('puppet-run.timer')
                 .with_provider('systemd')
-                .with_ensure(true)
+                .with_ensure('running')
                 .with_name('puppet-run.timer')
-                .with_enable(true)
+                .with_enable('true')
             end
           else
             it { is_expected.to raise_error(Puppet::Error, /Runmode of systemd.timer not supported on #{facts[:kernel]} operating systems!/) }
@@ -329,7 +342,7 @@ describe 'puppet' do
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(true) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(true) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:running) }
 
             it do
               is_expected.to contain_file('/etc/systemd/system/puppet-run.timer')
@@ -347,11 +360,17 @@ describe 'puppet' do
             end
 
             it do
+              is_expected.to contain_exec('systemctl-daemon-reload-puppet')
+                .with_refreshonly(true)
+                .with_command('systemctl daemon-reload')
+            end
+
+            it do
               is_expected.to contain_service('puppet-run.timer')
                 .with_provider('systemd')
-                .with_ensure(true)
+                .with_ensure('running')
                 .with_name('puppet-run.timer')
-                .with_enable(true)
+                .with_enable('true')
             end
           else
             it { is_expected.to raise_error(Puppet::Error, /Runmode of systemd.timer not supported on #{facts[:kernel]} operating systems!/) }
@@ -373,7 +392,7 @@ describe 'puppet' do
 
           case os
           when /\Adebian-/, /\A(redhat|centos|scientific)-7/, /\Afedora-/, /\Aubuntu-(16|18)/, /\Aarchlinux-/
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
           else
             it { is_expected.not_to contain_service('puppet-run.timer') }
           end


### PR DESCRIPTION
This reverts commit 4302973e8f47c77ed35b2a399c1ccef2d503b400, except the dependency bits. It's also updated to be lint clean.

The reason to revert this is that the integrated daemon reload in systemd::timer leads to dependency cycles in the Katello scenario.