### PR TITLE
also allow whitelisted admin clients to clean certs

### DIFF
--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -119,7 +119,17 @@ authorization: {
                 type: regex
                 method: [delete]
             },
-            allow: "$2"
+            allow: [
+                "$2",
+<%- @server_admin_api_whitelist.each do |client| -%>
+                "<%= client %>",
+<%- end -%>
+                {
+                    extensions: {
+                        pp_cli_auth: "true"
+                    }
+                }
+            ]
             sort-order: 500
         },
 <%- end -%>


### PR DESCRIPTION
During #728 a regression was introduced, denying the other whitelisted
admin clients cleaning/deletion of certificates:

```
2020-06-02T16:30:47.856+02:00 ERROR [qtp1105504743-114201] [p.t.a.rules] Forbidden request: puppetserver01.[...] access to /puppet-ca/v1/certificate_status/my.fancy.hostname (method :delete) (authenticated: true) denied by rule 'Allow nodes to delete their own certificates'.
```

The solution is to re-allow the entries within
`@server_admin_api_whitelist`, which usually contain "localhost" and the
fqdn of the puppetserver CA system.

Unfortunately I'm unable to run the test suite, it just fails pretty much everywhere which is unrelated to my changes.

I have deployed this patch in our infra and can confirm it fixes the auth deny issue when trying to clean certs locally on the puppetserver CA machine with `$server_ca_client_self_delete` enabled.