### PR TITLE
Add `server_puppetserver_trusted_certificate_extensions`

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -13,3 +13,6 @@
   beaker_puppet_collections:
     - puppet5
     - puppet6
+Gemfile:
+  extra:
+    - gem: hocon

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,6 @@ gem 'voxpupuli-test', '~> 1.4'
 gem 'github_changelog_generator', '>= 1.15.0', {"groups"=>["development"]}
 gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
 gem 'voxpupuli-acceptance', '~> 0.2', {"groups"=>["system_tests"]}
+gem 'hocon'
 
 # vim:ft=ruby

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -460,6 +460,24 @@
 # $server_puppetserver_trusted_agents::     Certificate names of puppet agents that are allowed to fetch *all* catalogs
 #                                           Defaults to [] and all agents are only allowed to fetch their own catalogs.
 #
+# $server_puppetserver_trusted_certificate_extensions:: An array of hashes of certificate extensions and values to be used in auth.conf
+#                                           A puppet client certificate containing valid extension(s) will be allowed to fetch
+#                                           *any* catalog.
+#                                           Defaults to [] and no certificate extensions are recognised as being allowed
+#                                           to fetch *any* catalog.
+#                                           Example: [{ 'pp_authorization' => 'catalog' }]
+#                                           Any client certificate containing the `pp_authorization` extension with value `catalog`
+#                                           will be permitted to fetch any catalog.
+#                                           Complicated example: [
+#                                             { '1.3.6.1.4.1.34380.1.3.1'  => 'catalog' },
+#                                             { '1.3.6.1.4.1.34380.1.1.13' => 'jenkins_server', '1.3.6.1.4.1.34380.1.1.24' => 'prod' }
+#                                           ]
+#                                           Clients presenting a certificate with `pp_authorization = catalog` *or* with `pp_role`
+#                                           *and* `pp_apptier` extensions set
+#                                           correctly will be authorized to fetch any catalog.
+#                                           NB. If server_ca == false, use oids instead of extension shortnames.
+#                                           See https://tickets.puppetlabs.com/browse/SERVER-1689
+#
 # $server_compile_mode::                    Used to control JRuby's "CompileMode", which may improve performance.
 #                                           Defaults to undef (off).
 #
@@ -694,6 +712,7 @@ class puppet (
   Boolean $server_puppetserver_experimental = $puppet::params::server_puppetserver_experimental,
   Optional[String[1]] $server_puppetserver_auth_template = $puppet::params::server_puppetserver_auth_template,
   Array[String] $server_puppetserver_trusted_agents = $puppet::params::server_puppetserver_trusted_agents,
+  Array[Hash] $server_puppetserver_trusted_certificate_extensions = $puppet::params::server_puppetserver_trusted_certificate_extensions,
   Optional[Enum['off', 'jit', 'force']] $server_compile_mode = $puppet::params::server_compile_mode,
   Optional[Integer[1]] $server_acceptor_threads = undef,
   Optional[Integer[1]] $server_selector_threads = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -440,4 +440,5 @@ class puppet::params {
 
   # Normally agents can only fetch their own catalogs.  If you want some nodes to be able to fetch *any* catalog, add them here.
   $server_puppetserver_trusted_agents = []
+  $server_puppetserver_trusted_certificate_extensions = []
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -285,6 +285,8 @@
 #
 # $puppetserver_trusted_agents::       Certificate names of agents that are allowed to fetch *all* catalogs. Defaults to empty array
 #
+# $puppetserver_trusted_certificate_extensions:: An array of hashes of certificate extensions and values.
+#                                      Example: [{ 'pp_authorization' => 'catalog' }]
 #
 # $ca_allow_sans::                     Allow CA to sign certificate requests that have Subject Alternative Names
 #                                      Defaults to false
@@ -431,6 +433,7 @@ class puppet::server(
   Boolean $puppetserver_experimental = $puppet::server_puppetserver_experimental,
   Optional[String[1]] $puppetserver_auth_template = $puppet::server_puppetserver_auth_template,
   Array[String] $puppetserver_trusted_agents = $puppet::server_puppetserver_trusted_agents,
+  Array[Hash] $puppetserver_trusted_certificate_extensions = $puppet::server_puppetserver_trusted_certificate_extensions,
   Optional[Enum['off', 'jit', 'force']] $compile_mode = $puppet::server_compile_mode,
   Optional[Integer[1]] $selector_threads = $puppet::server_selector_threads,
   Optional[Integer[1]] $acceptor_threads = $puppet::server_acceptor_threads,

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -122,6 +122,7 @@ class puppet::server::puppetserver (
   $server_experimental                    = $puppet::server::puppetserver_experimental,
   $server_auth_template                   = $puppet::server::puppetserver_auth_template,
   $server_trusted_agents                  = $puppet::server::puppetserver_trusted_agents,
+  $server_trusted_certificate_extensions  = $puppet::server::puppetserver_trusted_certificate_extensions,
   $allow_header_cert_info                 = $puppet::server::allow_header_cert_info,
   $compile_mode                           = $puppet::server::compile_mode,
   $acceptor_threads                       = $puppet::server::acceptor_threads,

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -12,7 +12,13 @@ authorization: {
                 type: regex
                 method: [get, post]
             }
-            allow: <%= @server_trusted_agents + ['$1'] %>
+<%= scope.call_function(
+  'to_json_pretty',
+  [
+    {'allow' => @server_trusted_agents + ['$1'] + @server_trusted_certificate_extensions.map { |extension| { 'extensions' => extension } } }
+  ]
+).lines.to_a[1..-2].map{ |line| "          #{line}"}.join
+-%>
             sort-order: 500
             name: "puppetlabs v3 catalog from agents"
         },
@@ -24,10 +30,16 @@ authorization: {
                 type: regex
                 method: post
             }
-<%- if @server_trusted_agents.empty? -%>
+<%- if @server_trusted_agents.empty? && @server_trusted_certificate_extensions.empty? -%>
             deny: "*"
 <%- else -%>
-            allow: <%= @server_trusted_agents %>
+<%= scope.call_function(
+  'to_json_pretty',
+  [
+    {'allow' => @server_trusted_agents + @server_trusted_certificate_extensions.map { |extension| { 'extensions' => extension } } }
+  ]
+).lines.to_a[1..-2].map{ |line| "          #{line}"}.join
+-%>
 <%- end -%>
             sort-order: 500
             name: "puppetlabs v4 catalog for services"


### PR DESCRIPTION
Accepts an array of hashes to allow for more complicated setups.
Typical use would probably just be a single array element such as...

```puppet
class { 'puppet':
  ...
  server_puppetserver_trusted_certificate_extensions => [{ 'pp_authorization' => 'catalog' }],
  ...
}
```