### PR TITLE
Fix appending puppet config entry

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -73,6 +73,17 @@ class puppet::config(
     puppet::config::main { $key: value => $value }
   }
 
+  # Ensure there is a newline at the end of puppet.conf
+  $newline = $facts['os']['family'] ? {
+    'Windows' => "\r\n",
+    default   => "\n",
+  }
+  concat::fragment{'puppet.conf_eof_newline':
+    target  => "${puppet::dir}/puppet.conf",
+    content => $newline,
+    order   => '999_eof_newline',
+  }
+
   file { $puppet_dir:
     ensure => directory,
     owner  => $puppet::dir_owner,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -81,17 +81,15 @@ class puppet::config(
   -> case $facts['os']['family'] {
     'Windows': {
       concat { "${puppet_dir}/puppet.conf":
-        mode           => '0674',
-        ensure_newline => true,
+        mode  => '0674',
       }
     }
 
     default: {
       concat { "${puppet_dir}/puppet.conf":
-        owner          => 'root',
-        group          => $puppet::params::root_group,
-        mode           => '0644',
-        ensure_newline => true,
+        owner => 'root',
+        group => $puppet::params::root_group,
+        mode  => '0644',
       }
     }
   }

--- a/manifests/config/entry.pp
+++ b/manifests/config/entry.pp
@@ -30,7 +30,7 @@ define puppet::config::entry (
   # they make sure that '1_main ' is ordered before '1_main_*'
   ensure_resource('concat::fragment', "puppet.conf_${section}", {
       target  => "${puppet::dir}/puppet.conf",
-      content => "\n[${section}]",
+      content => "\n\n[${section}]",
       order   => "${sectionorder}_${section} ",
   })
 
@@ -39,7 +39,7 @@ define puppet::config::entry (
   if (!defined(Concat::Fragment["puppet.conf_${section}_${key}"])){
     concat::fragment{"puppet.conf_${section}_${key}":
       target  => "${puppet::dir}/puppet.conf",
-      content => "    ${key} = ${_value}",
+      content => "\n    ${key} = ${_value}",
       order   => "${sectionorder}_${section}_${key} ",
     }
   } else {

--- a/spec/defines/puppet_config_entry_spec.rb
+++ b/spec/defines/puppet_config_entry_spec.rb
@@ -20,7 +20,7 @@ describe 'puppet::config::entry' do
           }
         end
         it 'should contain the section header' do
-          should contain_concat__fragment('puppet.conf_main').with_content("\n[main]")
+          should contain_concat__fragment('puppet.conf_main').with_content("\n\n[main]")
           should contain_concat__fragment('puppet.conf_main').with_order("1_main ")
         end
         it 'should contain the keyvalue pair' do
@@ -41,7 +41,7 @@ describe 'puppet::config::entry' do
           }
         end
         it 'should contain the section header' do
-          should contain_concat__fragment('puppet.conf_main').with_content("\n[main]")
+          should contain_concat__fragment('puppet.conf_main').with_content("\n\n[main]")
           should contain_concat__fragment('puppet.conf_main').with_order("1_main ")
         end
         it 'should contain the keyvalue pair' do
@@ -63,7 +63,7 @@ describe 'puppet::config::entry' do
           }
         end
         it 'should contain the section header' do
-          should contain_concat__fragment('puppet.conf_main').with_content("\n[main]")
+          should contain_concat__fragment('puppet.conf_main').with_content("\n\n[main]")
           should contain_concat__fragment('puppet.conf_main').with_order("1_main ")
         end
         it 'should contain the keyvalue pair' do


### PR DESCRIPTION
This fixes issue #759 by reverting e87d8f2a7a008e2d92f5e41999fee83117edec25 and then adding a newline to the end of the puppet.conf file.