### PR TITLE
Fix `server_ssl_dir` parameter usage

### DIFF
--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -49,6 +49,30 @@ describe 'puppet' do
         it { is_expected.to compile.with_all_deps }
         it { should contain_class('puppet::server') }
         it { should contain_class('puppet::agent::service').that_requires('Class[puppet::server]') }
+
+        context 'with custom server_ssl_dir' do
+          let :params do {
+            :server => true,
+            :server_ssl_dir => '/etc/custom/ssl/dir',
+          } end
+
+          let :puppetserver_directory do
+            case facts[:osfamily]
+            when 'FreeBSD'
+              '/usr/local/etc/puppetserver'
+            else
+              '/etc/puppetlabs/puppetserver'
+            end
+          end
+
+          it {
+            should contain_file("#{puppetserver_directory}/conf.d/webserver.conf")
+              .with_content(/ssl-cert:\s\/etc\/custom\/ssl\/dir/)
+              .with_content(/ssl-key:\s\/etc\/custom\/ssl\/dir/)
+              .with_content(/ssl-crl-path:\s\/etc\/custom\/ssl\/dir/)
+              .with_content(/ssl-cert-chain:\s\/etc\/custom\/ssl\/dir/)
+          }
+        end
       end
 
       describe 'with empty ca_server' do


### PR DESCRIPTION
Class documentation says `$server_ssl_chain_filepath` has a default value: `"${ssl_dir}/ca/ca_crt.pem"` but the generated `webserver.conf` does not have the correct entry when `ssl_dir` is set.

Its mainly due to the `$server_ssl_chain_filepath` evaluation that is made at https://github.com/theforeman/puppet-puppet/blob/master/manifests/params.pp#L406 but at this moment `${server_ssl_dir}` match to the default (ie. depending on OS).
