### PR TITLE
run Puppet agent from systemd only after network is brought up

### DIFF
--- a/templates/agent/systemd.puppet-run.service.erb
+++ b/templates/agent/systemd.puppet-run.service.erb
@@ -3,6 +3,7 @@
 #
 [Unit]
 Description=Systemd Timer Service for Puppet Agent
+After=network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Using `After` ensures proper ordering between the Puppet service and
the machine's networking. We could also have used `Wants` or
`Requires` but, according to the `systemd.unit(5)` manpage, `After`
only ensure *ordering*, while `Wants` and `Requires`
actually *trigger* units.

In other words, `After` ensures that `puppet-run` will be started
after networking is up, but will not *necessarily* run when networking
is up, nor will it attempt to bring up networking when ran.

Closes: #764