### PR TITLE
Remove `systemd` from puppet::agent::service case

### DIFF
--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -13,7 +13,7 @@ class puppet::agent::service {
       $cron_enabled = true
       $systemd_enabled = false
     }
-    'systemd.timer', 'systemd': {
+    'systemd.timer': {
       $service_enabled = false
       $cron_enabled = false
       $systemd_enabled = true


### PR DESCRIPTION
Looks like #498 had a breaking change when it added an Enum for
`runmode` that didn't include `systemd` (only `systemd.timer`)

But that was a long time ago, so just tidying the code in
`puppet::agent::service`, instead of ammending the `Enum` in `init.pp`.