### PR TITLE
adds param for user-provided puppetserver auth.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,8 +148,7 @@
 #                                           Windows and ['systemd.timer'] on other
 #                                           systems.
 #
-# $auth_template::                          Use a custom template for the auth
-#                                           configuration.
+# $auth_template::                          Use a custom template for /etc/puppetlabs/puppet/auth.conf
 #
 # $pluginsource::                           URL to retrieve Puppet plugins from during pluginsync
 #
@@ -456,6 +455,8 @@
 #
 # $server_puppetserver_experimental::       For Puppetserver 5, enable the /puppet/experimental route? Defaults to true
 #
+# $server_puppetserver_auth_template::      Template for generating /etc/puppetlabs/puppetserver/conf.d/auth.conf 
+#
 # $server_puppetserver_trusted_agents::     Certificate names of puppet agents that are allowed to fetch *all* catalogs
 #                                           Defaults to [] and all agents are only allowed to fetch their own catalogs.
 #
@@ -691,6 +692,7 @@ class puppet (
   Integer $server_metrics_graphite_interval = $puppet::params::server_metrics_graphite_interval,
   Optional[Array] $server_metrics_allowed = $puppet::params::server_metrics_allowed,
   Boolean $server_puppetserver_experimental = $puppet::params::server_puppetserver_experimental,
+  Optional[String[1]] $server_puppetserver_auth_template = $puppet::params::server_puppetserver_auth_template,
   Array[String] $server_puppetserver_trusted_agents = $puppet::params::server_puppetserver_trusted_agents,
   Optional[Enum['off', 'jit', 'force']] $server_compile_mode = $puppet::params::server_compile_mode,
   Optional[Integer[1]] $server_acceptor_threads = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -435,6 +435,9 @@ class puppet::params {
   # For Puppetserver 5, should the /puppet/experimental route be enabled?
   $server_puppetserver_experimental = true
 
+  # For custom auth.conf settings allow passing in a template
+  $server_puppetserver_auth_template = undef
+
   # Normally agents can only fetch their own catalogs.  If you want some nodes to be able to fetch *any* catalog, add them here.
   $server_puppetserver_trusted_agents = []
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -289,6 +289,8 @@
 #
 # $puppetserver_experimental::         For Puppetserver 5, enable the /puppet/experimental route? Defaults to true
 #
+# $puppetserver_auth_template::        Template for generating /etc/puppetlabs/puppetserver/conf.d/auth.conf 
+#
 # $puppetserver_trusted_agents::       Certificate names of agents that are allowed to fetch *all* catalogs. Defaults to empty array
 #
 #
@@ -435,6 +437,7 @@ class puppet::server(
   Integer $metrics_graphite_interval = $puppet::server_metrics_graphite_interval,
   Variant[Undef, Array] $metrics_allowed = $puppet::server_metrics_allowed,
   Boolean $puppetserver_experimental = $puppet::server_puppetserver_experimental,
+  Optional[String[1]] $puppetserver_auth_template = $puppet::server_puppetserver_auth_template,
   Array[String] $puppetserver_trusted_agents = $puppet::server_puppetserver_trusted_agents,
   Optional[Enum['off', 'jit', 'force']] $compile_mode = $puppet::server_compile_mode,
   Optional[Integer[1]] $selector_threads = $puppet::server_selector_threads,

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -120,6 +120,7 @@ class puppet::server::puppetserver (
   $metrics_graphite_interval              = $puppet::server::metrics_graphite_interval,
   $metrics_allowed                        = $puppet::server::metrics_allowed,
   $server_experimental                    = $puppet::server::puppetserver_experimental,
+  $server_auth_template                   = $puppet::server::puppetserver_auth_template,
   $server_trusted_agents                  = $puppet::server::puppetserver_trusted_agents,
   $allow_header_cert_info                 = $puppet::server::allow_header_cert_info,
   $compile_mode                           = $puppet::server::compile_mode,
@@ -244,9 +245,10 @@ class puppet::server::puppetserver (
     content => template('puppet/server/puppetserver/conf.d/puppetserver.conf.erb'),
   }
 
+  $auth_template = pick($server_auth_template, 'puppet/server/puppetserver/conf.d/auth.conf.erb')
   file { "${server_puppetserver_dir}/conf.d/auth.conf":
     ensure  => file,
-    content => template('puppet/server/puppetserver/conf.d/auth.conf.erb'),
+    content => template($auth_template),
   }
 
   file { "${server_puppetserver_dir}/conf.d/webserver.conf":


### PR DESCRIPTION
There are a lot of special use cases for auth.conf, and rather than 100% manage that file, this PR gives the module user a way to provide their own.  Ideally we would use an epp template and also provide a hash of arguments for the template , but I tried to just match the existing pattern in this PR.  This potentially address #752 .