### PR TITLE
Update documentation for change from puppet master to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Puppet Forge](https://img.shields.io/puppetforge/v/theforeman/puppet.svg)](https://forge.puppetlabs.com/theforeman/puppet)
 [![Build Status](https://travis-ci.org/theforeman/puppet-puppet.svg?branch=master)](https://travis-ci.org/theforeman/puppet-puppet)
 
-# Puppet module for installing the Puppet agent and master
+# Puppet module for installing the Puppet agent and server
 
-Installs and configures the Puppet agent and optionally a Puppet master (when
+Installs and configures the Puppet agent and optionally a Puppet server (when
 `server` is true).  Part of the [Foreman installer](https://github.com/theforeman/foreman-installer)
 or to be used as a Puppet module.
 
@@ -13,7 +13,7 @@ If you know you'll be installing an earlier or specific version, you will
 need to override `server_puppetserver_version`. More information in the Puppet
 Server section below.
 
-Many puppet.conf options for agents, masters and other are parameterized, with
+Many puppet.conf options for agents, servers and other are parameterized, with
 class documentation provided at the top of the manifests. In addition, there
 are hash parameters for each configuration section that can be used to supply
 any options that are not explicitly supported.
@@ -36,17 +36,17 @@ Requires [theforeman/git](https://forge.puppetlabs.com/theforeman/git).
 
 With the 3.0.0 release the Foreman integration became optional.  It will still
 by default install the Foreman integration when `server` is true,
-so if you wish to run a Puppet master without Foreman, it can be disabled by
+so if you wish to run a Puppet server without Foreman, it can be disabled by
 setting `server_foreman` to false.
 
 Requires [theforeman/foreman](https://forge.puppetlabs.com/theforeman/foreman).
 
 ## PuppetDB integration
 
-The Puppet master can be configured to export catalogs and reports to a
+The Puppet server can be configured to export catalogs and reports to a
 PuppetDB instance, using the puppetlabs/puppetdb module.  Use its
 `puppetdb::server` class to install the PuppetDB server and this module to
-configure the Puppet master to connect to PuppetDB.
+configure the Puppet server to connect to PuppetDB.
 
 Requires [puppetlabs/puppetdb](https://forge.puppetlabs.com/puppetlabs/puppetdb)
 
@@ -80,7 +80,7 @@ wrapper classes or even your ENC (if it supports param classes). For example:
     # Agent and cron (or daemon):
     class { '::puppet': runmode => 'cron' }
 
-    # Agent and puppetmaster:
+    # Agent and puppetserver:
     class { '::puppet': server => true }
 
     # You want to use git?
@@ -99,7 +99,7 @@ wrapper classes or even your ENC (if it supports param classes). For example:
       server_post_hook_content => 'puppetserver/post-hook.puppet',
     }
 
-    # Configure master without Foreman integration
+    # Configure server without Foreman integration
     class { '::puppet':
       server                => true,
       server_foreman        => false,
@@ -130,21 +130,21 @@ as per the examples above, and the execute _puppet apply_ e.g:
 
 # Advanced scenarios
 
-An HTTP (non-SSL) puppetmaster instance can be set up (standalone or in addition to
+An HTTP (non-SSL) puppetserver instance can be set up (standalone or in addition to
 the SSL instance) by setting the `server_http` parameter to `true`. This is useful for
 reverse proxy or load balancer scenarios where the proxy/load balancer takes care of SSL
-termination. The HTTP puppetmaster instance expects the `X-Client-Verify`, `X-SSL-Client-DN`
+termination. The HTTP puppetserver instance expects the `X-Client-Verify`, `X-SSL-Client-DN`
 and `X-SSL-Subject` HTTP headers to have been set on the front end server.
 
 The listening port can be configured by setting `server_http_port` (which defaults to 8139).
 
 For puppetserver, this HTTP instance accepts **ALL** connections and no further restrictions can be configured.
 
-**Note that running an HTTP puppetmaster is a huge security risk when improperly
+**Note that running an HTTP puppetserver is a huge security risk when improperly
 configured. Allowed hosts should be tightly controlled; anyone with access to an allowed
 host can access all client catalogues and client certificates.**
 
-    # Configure an HTTP puppetmaster vhost in addition to the standard SSL vhost
+    # Configure an HTTP puppetserver vhost in addition to the standard SSL vhost
     class { '::puppet':
       server               => true,
       server_http          => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@
 #                                           Can also install only server packages with value
 #                                           of 'server' or only agent packages with 'agent'.
 #
-# $port::                                   Override the port of the master we connect to.
+# $port::                                   Override the port of the server we connect to.
 #
 # $pluginsync::                             Enable pluginsync.
 #
@@ -99,7 +99,7 @@
 # $syslogfacility::                         Facility name to use when logging to syslog
 #
 # $use_srv_records::                        Whether DNS SRV records will be used to resolve
-#                                           the Puppet master
+#                                           the Puppet server
 #
 # $srv_domain::                             Search domain for SRV records
 #
@@ -164,7 +164,7 @@
 #
 # $agent_noop::                             Run the agent in noop mode.
 #
-# $puppetmaster::                           Hostname of your puppetmaster (server
+# $puppetmaster::                           Hostname of your puppetserver (server
 #                                           directive in puppet.conf)
 #
 # $prerun_command::                         A command which gets excuted before each Puppet run
@@ -179,7 +179,7 @@
 # $client_certname::                        The node's certificate name, and the unique
 #                                           identifier it uses when requesting catalogs.
 #
-# $report::                                 Send reports to the Puppet Master
+# $report::                                 Send reports to the Puppet server
 #
 # == advanced agent parameters
 #
@@ -202,22 +202,22 @@
 #
 # == puppet::server parameters
 #
-# $server::                                 Should a puppet master be installed as well as the client
+# $server::                                 Should a puppet server be installed as well as the client
 #
-# $server_ip::                              Bind ip address of the puppetmaster
+# $server_ip::                              Bind ip address of the puppetserver
 #
-# $server_port::                            Puppet master port
+# $server_port::                            Puppet server port
 #
 # $server_ca::                              Provide puppet CA
 #
-# $server_ca_crl_sync::                     Sync puppet CA crl file to compile masters, Puppet CA Must be the Puppetserver
-#                                           for the compile masters. Defaults to false.
+# $server_ca_crl_sync::                     Sync puppet CA crl file to compilers, Puppet CA Must be the Puppetserver
+#                                           for the compilers. Defaults to false.
 #
 # $server_crl_enable::                      Turn on crl checking. Defaults to true when server_ca is true. Otherwise
 #                                           Defaults to false. Note unless you are using an external CA. It is recommended
-#                                           to set this to true. See $server_ca_crl_sync to enable syncing from CA Puppet Master
+#                                           to set this to true. See $server_ca_crl_sync to enable syncing from CA Puppet server
 #
-# $server_reports::                         List of report types to include on the puppetmaster
+# $server_reports::                         List of report types to include on the puppetserver
 #
 # $server_external_nodes::                  External nodes classifier executable
 #
@@ -259,16 +259,16 @@
 #
 # $server_manage_user::                     Whether to manage the server user resource
 #
-# $server_user::                            Name of the puppetmaster user.
+# $server_user::                            Name of the puppetserver user.
 #
-# $server_group::                           Name of the puppetmaster group.
+# $server_group::                           Name of the puppetserver group.
 #
 # $server_dir::                             Puppet configuration directory
 #
-# $server_http::                            Should the puppet master listen on HTTP as well as HTTPS.
+# $server_http::                            Should the puppet server listen on HTTP as well as HTTPS.
 #                                           Useful for load balancer or reverse proxy scenarios.
 #
-# $server_http_port::                       Puppet master HTTP port; defaults to 8139.
+# $server_http_port::                       Puppet server HTTP port; defaults to 8139.
 #
 # $server_config_version::                  How to determine the configuration version. When
 #                                           using git_repo, by default a git describe
@@ -332,9 +332,9 @@
 # $server_default_manifest_content::        A string to set the content of the default_manifest
 #                                           If set to '' it will not manage the file
 #
-# $server_package::                         Custom package name for puppet master
+# $server_package::                         Custom package name for puppet server
 #
-# $server_version::                         Custom package version for puppet master
+# $server_version::                         Custom package version for puppet server
 #
 # $server_ssl_dir::                         SSL directory
 #
@@ -455,7 +455,7 @@
 #
 # $server_puppetserver_experimental::       For Puppetserver 5, enable the /puppet/experimental route? Defaults to true
 #
-# $server_puppetserver_auth_template::      Template for generating /etc/puppetlabs/puppetserver/conf.d/auth.conf 
+# $server_puppetserver_auth_template::      Template for generating /etc/puppetlabs/puppetserver/conf.d/auth.conf
 #
 # $server_puppetserver_trusted_agents::     Certificate names of puppet agents that are allowed to fetch *all* catalogs
 #                                           Defaults to [] and all agents are only allowed to fetch their own catalogs.
@@ -535,7 +535,7 @@
 #
 #     include puppet
 #
-# * Installing a puppetmaster
+# * Installing a puppetserver
 #
 #   class {'puppet':
 #     server => true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -216,7 +216,7 @@ class puppet::params {
   $agent_additional_settings  = {}
   $server_additional_settings = {}
 
-  # Will this host be a puppetmaster?
+  # Will this host be a puppetserver?
   $server                          = false
   $server_ca                       = true
   $server_ca_crl_sync              = false
@@ -229,7 +229,7 @@ class puppet::params {
   $server_http                     = false
   $server_http_port                = 8139
 
-  # Need a new master template for the server?
+  # Need a new server template for the server?
   $server_template      = 'puppet/server/puppet.conf.erb'
   # Template for server settings in [main]
   $server_main_template = 'puppet/server/puppet.conf.main.erb'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,6 +1,6 @@
 # == Class: puppet::server
 #
-# Sets up a puppet master.
+# Sets up a puppet server.
 #
 # == puppet::server parameters
 #
@@ -31,32 +31,32 @@
 #
 # $manage_user::                       Whether to manage the puppet user resource
 #
-# $user::                              Name of the puppetmaster user.
+# $user::                              Name of the puppetserver user.
 #
-# $group::                             Name of the puppetmaster group.
+# $group::                             Name of the puppetserver group.
 #
 # $dir::                               Puppet configuration directory
 #
-# $ip::                                Bind ip address of the puppetmaster
+# $ip::                                Bind ip address of the puppetserver
 #
-# $port::                              Puppet master port
+# $port::                              Puppet server port
 #
 # $ca::                                Provide puppet CA
 #
 # $ca_crl_filepath::                   Path to ca_crl file
 #
-# $ca_crl_sync::                       Sync the puppet ca crl to compile masters. Requires compile masters to
-#                                      be agents of the CA master (MOM) defaults to false
+# $ca_crl_sync::                       Sync the puppet ca crl to compilers. Requires compilers to
+#                                      be agents of the CA server (MOM) defaults to false
 #
 # $crl_enable::                        Enable CRL processing, defaults to true when $ca is true else defaults
 #                                      to false
 #
-# $http::                              Should the puppet master listen on HTTP as well as HTTPS.
+# $http::                              Should the puppet server listen on HTTP as well as HTTPS.
 #                                      Useful for load balancer or reverse proxy scenarios.
 #
-# $http_port::                         Puppet master HTTP port; defaults to 8139.
+# $http_port::                         Puppet server HTTP port; defaults to 8139.
 #
-# $reports::                           List of report types to include on the puppetmaster
+# $reports::                           List of report types to include on the puppetserver
 #
 # $external_nodes::                    External nodes classifier executable
 #
@@ -97,9 +97,9 @@
 #
 # $ssl_dir::                           SSL directory
 #
-# $package::                           Custom package name for puppet master
+# $package::                           Custom package name for puppet server
 #
-# $version::                           Custom package version for puppet master
+# $version::                           Custom package version for puppet server
 #
 # $certname::                          The name to use when handling certificates.
 #
@@ -281,7 +281,7 @@
 #
 # $puppetserver_experimental::         For Puppetserver 5, enable the /puppet/experimental route? Defaults to true
 #
-# $puppetserver_auth_template::        Template for generating /etc/puppetlabs/puppetserver/conf.d/auth.conf 
+# $puppetserver_auth_template::        Template for generating /etc/puppetlabs/puppetserver/conf.d/auth.conf
 #
 # $puppetserver_trusted_agents::       Certificate names of agents that are allowed to fetch *all* catalogs. Defaults to empty array
 #

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -19,7 +19,7 @@ class puppet::server::config inherits puppet::config {
   }
 
   # Mirror the relationship, as defined() is parse-order dependent
-  # Ensures puppetmasters certs are generated before the proxy is needed
+  # Ensures puppetservers certs are generated before the proxy is needed
   if defined(Class['foreman_proxy::config']) and $foreman_proxy::ssl {
     Class['puppet::server::config'] ~> Class['foreman_proxy::config']
     Class['puppet::server::config'] ~> Class['foreman_proxy::service']
@@ -175,7 +175,7 @@ class puppet::server::config inherits puppet::config {
       ],
     }
   } elsif $puppet::server::ca_crl_sync {
-    # If not a ca AND sync the crl from the ca master
+    # If not a ca AND sync the crl from the ca server
     if defined('$::servername') {
       file { $puppet::server::ssl_ca_crl:
         ensure  => file,
@@ -285,7 +285,7 @@ class puppet::server::config inherits puppet::config {
 
   ## Foreman
   if $puppet::server::foreman {
-    # Include foreman components for the puppetmaster
+    # Include foreman components for the puppetserver
     # ENC script, reporting script etc.
     class { 'foreman::puppetmaster':
       foreman_url    => $puppet::server::foreman_url,

--- a/templates/auth.conf.erb
+++ b/templates/auth.conf.erb
@@ -2,7 +2,7 @@
 # Managed by Puppet
 #
 # This is the default auth.conf file, which implements the default rules
-# used by the puppet master. (That is, the rules below will still apply
+# used by the puppet server. (That is, the rules below will still apply
 # even if this file is deleted.)
 #
 # The ACLs are evaluated in top-down order. More specific stanzas should
@@ -132,7 +132,7 @@ allow *
 ### clients can also access these paths, though they rarely need to.
 
 # allow access to the CA certificate; unauthenticated nodes need this
-# in order to validate the puppet master's certificate
+# in order to validate the puppet server's certificate
 path /puppet-ca/v1/certificate/ca
 auth any
 method find

--- a/templates/server/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/puppetserver.conf.erb
@@ -63,7 +63,7 @@ jruby-puppet: {
     # (optional) Sets the upper limit for the random sleep set as a Retry-After header on 503 responses returned when max-queued-requests is enabled.
     max-retry-delay: <%= @server_max_retry_delay %>
 
-    # (optional) Authorize access to Puppet master endpoints via rules
+    # (optional) Authorize access to Puppet server endpoints via rules
     # specified in the legacy Puppet auth.conf file (if true) or via rules
     # specified in the Puppet Server HOCON-formatted auth.conf (if false or not
     # specified).


### PR DESCRIPTION
Puppet has been using `server` naming since 5.x, and the puppet master
implementation is long deprecated and unsupported. Additionally,
`compile masters` have been renamed to `compilers` in 6.x. Updating
our documentation to use the current nomenclature.
No parameters were renamed to preserve backwards compatibility.
Additionally, to minimize changes no changes were made with regards to
capitalization or refering to `puppetserver` vs. `puppet server`