### PR TITLE
Add `puppet::package_install_options` variable to allow you to pass flags to package resource

### DIFF
--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -5,13 +5,15 @@ class puppet::agent::install(
   $package_name = $puppet::client_package,
   $package_version = $puppet::version,
   $package_provider = $puppet::package_provider,
+  $package_install_options = $puppet::package_install_options,
   $package_source = $puppet::package_source,
 ) {
   if $manage_packages == true or $manage_packages == 'agent' {
     package { $package_name:
-      ensure   => $package_version,
-      provider => $package_provider,
-      source   => $package_source,
+      ensure          => $package_version,
+      provider        => $package_provider,
+      install_options => $package_install_options,
+      source          => $package_source,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,6 +140,10 @@
 #                                           Defaults to undef. If 'windows' or 'msi' are
 #                                           used as the provider then this setting is
 #                                           required.
+# $package_install_options::                Flags that should be passed to the package manager
+#                                           during installation. Defaults to undef. May be
+#                                           a string or a hash, see Puppet Package resource
+#                                           documentation for the provider matching your package manager
 #
 # $unavailable_runmodes::                   Runmodes that are not available for the
 #                                           current system. This module will not try
@@ -563,6 +567,7 @@ class puppet (
   Optional[String] $dir_owner = $puppet::params::dir_owner,
   Optional[String] $dir_group = $puppet::params::dir_group,
   Optional[String] $package_provider = $puppet::params::package_provider,
+  Optional[Variant[String,Hash]] $package_install_options = $puppet::params::package_install_options,
   Optional[Variant[Stdlib::Absolutepath, Stdlib::HTTPUrl]] $package_source = $puppet::params::package_source,
   Integer[0, 65535] $port = $puppet::params::port,
   Boolean $pluginsync = $puppet::params::pluginsync,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -190,6 +190,7 @@ class puppet::params {
   }
 
   $package_source = undef
+  $package_install_options = undef
 
   # Need your own config templates? Specify here:
   $auth_template   = 'puppet/auth.conf.erb'

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -30,7 +30,8 @@ class puppet::server::install {
     $server_version = pick($puppet::server::version, $puppet::version)
 
     package { $server_package:
-      ensure => $server_version,
+      ensure          => $server_version,
+      install_options => $puppet::package_install_options,
     }
 
     if $puppet::server::manage_user {

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -61,6 +61,7 @@ describe 'puppet' do
             .with_ensure('present')
             .with_provider(package_provider)
             .with_source(nil)
+            .with_install_options(nil)
         end
 
         # config

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -35,7 +35,10 @@ describe 'puppet' do
         it { should_not contain_class('puppet::server') }
         it { should contain_file(puppet_directory).with_ensure('directory') }
         it { should contain_concat(puppet_concat) }
-        it { should contain_package(puppet_package).with_ensure('present') }
+        it { should contain_package(puppet_package)
+          .with_ensure('present')
+          .with_install_options(nil)
+        }
       end
 
       describe 'with server => true', :unless => unsupported_puppetmaster_osfamily(facts[:osfamily]) do

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -66,7 +66,7 @@ describe 'puppet' do
         # install
         it { should contain_class('puppet::server::install') }
         it { should contain_user('puppet') }
-        it { should contain_package(puppetserver_pkg) }
+        it { should contain_package(puppetserver_pkg).with_install_options(nil) }
 
         # config
         it { should contain_class('puppet::server::config') }


### PR DESCRIPTION
We needed this internally to add the `--diasableexclude=all` flag to the yum install, as puppet* is in the base "exclude=" statement to prevent unintentional upgrade of the puppet agent, by overzealous sysadmins who `yum -y update` I would expect this could be useful in any number of other situations where installation of the package requires specific options being passed to the installer. 

As far as I can tell all supported platforms default package management system supports the `install_options` flag. 