### PR TITLE
(#780) puppetserver: don't purge metrics.conf / Use dedicated parameter for jruby profiler 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -437,8 +437,8 @@
 #
 # $server_puppetserver_jruby9k::            For Puppetserver 5, use JRuby 9k? Defaults to false
 #
-# $server_puppetserver_metrics::            Enable metrics (Puppetserver 5.x only)
-#                                           Defaults to true on Puppetserver 5.x and to false on Puppetserver 2.x
+# $server_puppetserver_metrics::            Enable puppetserver http-client metrics
+#                                           Defaults to false because that's the Puppet Inc. default behaviour.
 #
 # $server_puppetserver_profiler::           Enable JRuby profiling.
 #                                           Defaults to false because that's the Puppet Inc. default behaviour.
@@ -709,7 +709,7 @@ class puppet (
   Boolean $server_allow_header_cert_info = $puppet::params::server_allow_header_cert_info,
   Integer[0] $server_web_idle_timeout = $puppet::params::server_web_idle_timeout,
   Boolean $server_puppetserver_jruby9k = $puppet::params::server_puppetserver_jruby9k,
-  Optional[Boolean] $server_puppetserver_metrics = $puppet::params::server_puppetserver_metrics,
+  Boolean $server_puppetserver_metrics = false,
   Boolean $server_puppetserver_profiler = false,
   Boolean $server_metrics_jmx_enable = $puppet::params::server_metrics_jmx_enable,
   Boolean $server_metrics_graphite_enable = $puppet::params::server_metrics_graphite_enable,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -437,8 +437,11 @@
 #
 # $server_puppetserver_jruby9k::            For Puppetserver 5, use JRuby 9k? Defaults to false
 #
-# $server_puppetserver_metrics::            Enable metrics (Puppetserver 5.x only) and JRuby profiling?
+# $server_puppetserver_metrics::            Enable metrics (Puppetserver 5.x only)
 #                                           Defaults to true on Puppetserver 5.x and to false on Puppetserver 2.x
+#
+# $server_puppetserver_profiler::           Enable JRuby profiling.
+#                                           Defaults to false because that's the Puppet Inc. default behaviour.
 #
 # $server_metrics_jmx_enable::              Enable or disable JMX metrics reporter. Defaults to true
 #
@@ -707,6 +710,7 @@ class puppet (
   Integer[0] $server_web_idle_timeout = $puppet::params::server_web_idle_timeout,
   Boolean $server_puppetserver_jruby9k = $puppet::params::server_puppetserver_jruby9k,
   Optional[Boolean] $server_puppetserver_metrics = $puppet::params::server_puppetserver_metrics,
+  Boolean $server_puppetserver_profiler = false,
   Boolean $server_metrics_jmx_enable = $puppet::params::server_metrics_jmx_enable,
   Boolean $server_metrics_graphite_enable = $puppet::params::server_metrics_graphite_enable,
   String $server_metrics_graphite_host = $puppet::params::server_metrics_graphite_host,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -261,6 +261,8 @@
 # $puppetserver_metrics::              Enable metrics (Puppetserver 5.x only) and JRuby profiling?
 #                                      Defaults to true on Puppetserver 5.x and to false on Puppetserver 2.x
 #
+# $puppetserver_profiler::             Enable JRuby profiling.
+#                                      Defaults to false because that's the Puppet Inc. default behaviour.#
 #
 # $metrics_jmx_enable::                Enable or disable JMX metrics reporter. Defaults to true
 #
@@ -423,6 +425,7 @@ class puppet::server(
   Boolean $allow_header_cert_info = $puppet::server_allow_header_cert_info,
   Boolean $puppetserver_jruby9k = $puppet::server_puppetserver_jruby9k,
   Optional[Boolean] $puppetserver_metrics = $puppet::server_puppetserver_metrics,
+  Boolean $puppetserver_profiler = $puppet::server_puppetserver_profiler,
   Boolean $metrics_jmx_enable = $puppet::server_metrics_jmx_enable,
   Boolean $metrics_graphite_enable = $puppet::server_metrics_graphite_enable,
   String $metrics_graphite_host = $puppet::server_metrics_graphite_host,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -258,11 +258,11 @@
 #
 # $puppetserver_jruby9k::              For Puppetserver 5, use JRuby 9k? Defaults to false
 #
-# $puppetserver_metrics::              Enable metrics (Puppetserver 5.x only) and JRuby profiling?
-#                                      Defaults to true on Puppetserver 5.x and to false on Puppetserver 2.x
+# $puppetserver_metrics::              Enable puppetserver http-client metrics
+#                                      Defaults to false because that's the Puppet Inc. default behaviour.
 #
 # $puppetserver_profiler::             Enable JRuby profiling.
-#                                      Defaults to false because that's the Puppet Inc. default behaviour.#
+#                                      Defaults to false because that's the Puppet Inc. default behaviour.
 #
 # $metrics_jmx_enable::                Enable or disable JMX metrics reporter. Defaults to true
 #
@@ -484,9 +484,6 @@ class puppet::server(
   } else  {
     $real_puppetserver_version = '5.3.6'
   }
-
-  # Prefer the user setting,otherwise disable for Puppetserver 2.x, enabled for 5.x
-  $real_puppetserver_metrics = pick($puppetserver_metrics, true)
 
   if $jvm_extra_args {
     $real_jvm_extra_args = $jvm_extra_args

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -262,13 +262,8 @@ class puppet::server::puppetserver (
     content => template('puppet/server/puppetserver/conf.d/product.conf.erb'),
   }
 
-  $metrics_conf_ensure = $server_metrics ? {
-    true    => file,
-    default => absent
-  }
-
   file { "${server_puppetserver_dir}/conf.d/metrics.conf":
-    ensure  => $metrics_conf_ensure,
+    ensure  => 'file',
     content => template('puppet/server/puppetserver/conf.d/metrics.conf.erb'),
   }
 }

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -112,6 +112,7 @@ class puppet::server::puppetserver (
   $server_environment_class_cache_enabled = $puppet::server::environment_class_cache_enabled,
   $server_jruby9k                         = $puppet::server::puppetserver_jruby9k,
   $server_metrics                         = $puppet::server::real_puppetserver_metrics,
+  $server_profiler                        = $puppet::server::puppetserver_profiler,
   $metrics_jmx_enable                     = $puppet::server::metrics_jmx_enable,
   $metrics_graphite_enable                = $puppet::server::metrics_graphite_enable,
   $metrics_graphite_host                  = $puppet::server::metrics_graphite_host,

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -111,7 +111,7 @@ class puppet::server::puppetserver (
   $server_check_for_updates               = $puppet::server::check_for_updates,
   $server_environment_class_cache_enabled = $puppet::server::environment_class_cache_enabled,
   $server_jruby9k                         = $puppet::server::puppetserver_jruby9k,
-  $server_metrics                         = $puppet::server::real_puppetserver_metrics,
+  $server_metrics                         = $puppet::server::puppetserver_metrics,
   $server_profiler                        = $puppet::server::puppetserver_profiler,
   $metrics_jmx_enable                     = $puppet::server::metrics_jmx_enable,
   $metrics_graphite_enable                = $puppet::server::metrics_graphite_enable,

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -261,7 +261,7 @@ describe 'puppet' do
               .with_content(/^    # Whether to enable http-client metrics; defaults to 'true'.\n    metrics-enabled: false$/)
               .with_content(/^profiler: \{\n    # enable or disable profiling for the Ruby code;\n    enabled: false/)
           }
-          it { should contain_file('/etc/custom/puppetserver/conf.d/metrics.conf').with_ensure('absent') }
+          it { should contain_file('/etc/custom/puppetserver/conf.d/metrics.conf').with_ensure('file') }
         end
       end
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -240,7 +240,7 @@ describe 'puppet' do
           it {
             should contain_file(puppetserver_conf)
               .with_content(/^    # Whether to enable http-client metrics; defaults to 'true'.\n    metrics-enabled: true$(.*)/)
-              .with_content(/^profiler: \{\n    # enable or disable profiling for the Ruby code;\n    enabled: true/)
+              .with_content(/^profiler: \{\n    # enable or disable profiling for the Ruby code;\n    enabled: false/)
           }
           it {
             should contain_file('/etc/custom/puppetserver/conf.d/metrics.conf')

--- a/templates/server/puppetserver/conf.d/puppetserver.conf.erb
+++ b/templates/server/puppetserver/conf.d/puppetserver.conf.erb
@@ -123,5 +123,5 @@ http-client: {
 # settings related to profiling the puppet Ruby code
 profiler: {
     # enable or disable profiling for the Ruby code;
-    enabled: <%= @server_metrics %>
+    enabled: <%= @server_profiler %>
 }


### PR DESCRIPTION
This introduces a new parameter to disable the profiling indepently from
the metrics. Previously this was enabled by default. However Puppet Inc.
disables it in their standard configuration and the profiler causes a
significate memory and CPU overhead so I guess we should stick with the
upstream default.