### PR TITLE
Allow camptocamp/systemd 3.x + use it for timers

### DIFF
--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -6,69 +6,22 @@ class puppet::agent::service::systemd (
   Optional[Integer[0,59]] $minute  = undef,
 ) {
   unless $puppet::runmode == 'unmanaged' or 'systemd.timer' in $puppet::unavailable_runmodes {
-    exec { 'systemctl-daemon-reload-puppet':
-      refreshonly => true,
-      path        => $::path,
-      command     => 'systemctl daemon-reload',
-    }
+    # Use the same times as for cron
+    $times = extlib::ip_to_cron($puppet::runinterval)
 
-    if $enabled {
-      # Use the same times as for cron
-      $times = extlib::ip_to_cron($puppet::runinterval)
+    # But only if they are not explicitly specified
+    $_hour = pick($hour, $times[0])
+    $_minute = pick($minute, $times[1])
 
-      # But only if they are not explicitly specified
-      $_hour = pick($hour, $times[0])
-      $_minute = pick($minute, $times[1])
+    $command = pick($puppet::systemd_cmd, "${puppet::puppet_cmd} agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize --detailed-exitcode --no-usecacheonfailure")
+    $randomizeddelaysec = $puppet::systemd_randomizeddelaysec
 
-      $command = $puppet::systemd_cmd ? {
-        undef   => "${puppet::puppet_cmd} agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize --detailed-exitcode --no-usecacheonfailure",
-        default => $puppet::systemd_cmd,
-      }
-
-      $randomizeddelaysec = $puppet::systemd_randomizeddelaysec
-
-      file { "/etc/systemd/system/${puppet::systemd_unit_name}.timer":
-        content => template('puppet/agent/systemd.puppet-run.timer.erb'),
-        notify  => [
-          Exec['systemctl-daemon-reload-puppet'],
-          Service['puppet-run.timer'],
-        ],
-      }
-
-      file { "/etc/systemd/system/${puppet::systemd_unit_name}.service":
-        content => template('puppet/agent/systemd.puppet-run.service.erb'),
-        notify  => Exec['systemctl-daemon-reload-puppet'],
-      }
-
-      service { 'puppet-run.timer':
-        ensure   => running,
-        provider => 'systemd',
-        name     => "${puppet::systemd_unit_name}.timer",
-        enable   => true,
-        require  => Exec['systemctl-daemon-reload-puppet'],
-      }
-    } else {
-      # Reverse order - stop, delete files, exec
-      service { 'puppet-run.timer':
-        ensure   => stopped,
-        provider => 'systemd',
-        name     => "${puppet::systemd_unit_name}.timer",
-        enable   => false,
-        before   => [
-          File["/etc/systemd/system/${puppet::systemd_unit_name}.timer"],
-          File["/etc/systemd/system/${puppet::systemd_unit_name}.service"],
-        ],
-      }
-
-      file { "/etc/systemd/system/${puppet::systemd_unit_name}.timer":
-        ensure => absent,
-        notify => Exec['systemctl-daemon-reload-puppet'],
-      }
-
-      file { "/etc/systemd/system/${puppet::systemd_unit_name}.service":
-        ensure => absent,
-        notify => Exec['systemctl-daemon-reload-puppet'],
-      }
+    systemd::timer { "${puppet::systemd_unit_name}.timer":
+      ensure          => bool2str($enabled, 'present', 'absent'),
+      active          => $enabled,
+      enable          => $enabled,
+      timer_content   => template('puppet/agent/systemd.puppet-run.timer.erb'),
+      service_content => template('puppet/agent/systemd.puppet-run.service.erb'),
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.9.0 < 3.0.0"
+      "version_requirement": ">= 2.9.0 < 4.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -107,14 +107,8 @@ describe 'puppet' do
         case os
         when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Aarchlinux-/
           it do
-            is_expected.to contain_exec('systemctl-daemon-reload-puppet')
-              .with_refreshonly(true)
-              .with_command('systemctl daemon-reload')
-          end
-
-          it do
             is_expected.to contain_service('puppet-run.timer')
-              .with_ensure(:stopped)
+              .with_ensure(false)
               .with_provider('systemd')
               .with_name('puppet-run.timer')
               .with_enable(false)
@@ -126,7 +120,6 @@ describe 'puppet' do
           it { is_expected.not_to contain_service('puppet-run.timer') }
           it { is_expected.not_to contain_file('/etc/systemd/system/puppet-run.timer') }
           it { is_expected.not_to contain_file('/etc/systemd/system/puppet-run.service') }
-          it { is_expected.not_to contain_exec('systemctl-daemon-reload-puppet') }
         end
       end
 
@@ -213,7 +206,7 @@ describe 'puppet' do
                 .with_enable('false')
             end
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(false) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
             it do
               is_expected.to contain_cron('puppet')
                 .with_command("#{bindir}/puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize")
@@ -259,7 +252,7 @@ describe 'puppet' do
                 .with_enable('false')
             end
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(false) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
             it do
               is_expected.to contain_cron('puppet')
                 .with_command("#{bindir}/puppet agent --config #{confdir}/puppet.conf --onetime --no-daemonize")
@@ -294,7 +287,7 @@ describe 'puppet' do
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(true) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:running) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(true) }
 
             it do
               is_expected.to contain_file('/etc/systemd/system/puppet-run.timer')
@@ -312,17 +305,11 @@ describe 'puppet' do
             end
 
             it do
-              is_expected.to contain_exec('systemctl-daemon-reload-puppet')
-                .with_refreshonly(true)
-                .with_command('systemctl daemon-reload')
-            end
-
-            it do
               is_expected.to contain_service('puppet-run.timer')
                 .with_provider('systemd')
-                .with_ensure('running')
+                .with_ensure(true)
                 .with_name('puppet-run.timer')
-                .with_enable('true')
+                .with_enable(true)
             end
           else
             it { is_expected.to raise_error(Puppet::Error, /Runmode of systemd.timer not supported on #{facts[:kernel]} operating systems!/) }
@@ -343,7 +330,7 @@ describe 'puppet' do
             it { is_expected.to contain_class('puppet::agent::service::daemon').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::cron').with_enabled(false) }
             it { is_expected.to contain_class('puppet::agent::service::systemd').with_enabled(true) }
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:running) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(true) }
 
             it do
               is_expected.to contain_file('/etc/systemd/system/puppet-run.timer')
@@ -361,17 +348,11 @@ describe 'puppet' do
             end
 
             it do
-              is_expected.to contain_exec('systemctl-daemon-reload-puppet')
-                .with_refreshonly(true)
-                .with_command('systemctl daemon-reload')
-            end
-
-            it do
               is_expected.to contain_service('puppet-run.timer')
                 .with_provider('systemd')
-                .with_ensure('running')
+                .with_ensure(true)
                 .with_name('puppet-run.timer')
-                .with_enable('true')
+                .with_enable(true)
             end
           else
             it { is_expected.to raise_error(Puppet::Error, /Runmode of systemd.timer not supported on #{facts[:kernel]} operating systems!/) }
@@ -393,7 +374,7 @@ describe 'puppet' do
 
           case os
           when /\Adebian-/, /\A(redhat|centos|scientific)-(7|8)/, /\Afedora-/, /\Aubuntu-/, /\Aarchlinux-/
-            it { is_expected.to contain_service('puppet-run.timer').with_ensure(:stopped) }
+            it { is_expected.to contain_service('puppet-run.timer').with_ensure(false) }
           else
             it { is_expected.not_to contain_service('puppet-run.timer') }
           end


### PR DESCRIPTION
This allows camptocamp/systemd 3.x. Additionally, it goes back to using systemd::timer now that the cyclic dependency can no longer happen.