### PR TITLE
Implement optional Katello integration

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -296,21 +296,7 @@ class puppet::server::config inherits puppet::config {
     }
   }
 
-  ## Foreman
   if $puppet::server::foreman {
-    # Include foreman components for the puppetmaster
-    # ENC script, reporting script etc.
-    class { 'puppetserver_foreman':
-      foreman_url      => $puppet::server::foreman_url,
-      enc_upload_facts => $puppet::server::server_foreman_facts,
-      enc_timeout      => $puppet::server::request_timeout,
-      puppet_home      => $puppet::server::puppetserver_vardir,
-      puppet_basedir   => $puppet::server::puppet_basedir,
-      puppet_etcdir    => $puppet::dir,
-      ssl_ca           => pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert),
-      ssl_cert         => pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert),
-      ssl_key          => pick($puppet::server::foreman_ssl_key, $puppet::server::ssl_cert_key),
-    }
-    contain puppetserver_foreman
+    contain puppet::server::foreman
   }
 }

--- a/manifests/server/foreman.pp
+++ b/manifests/server/foreman.pp
@@ -1,0 +1,18 @@
+# @summary Set up Foreman integration
+# @api private
+class puppet::server::foreman {
+  # Include foreman components for the puppetmaster
+  # ENC script, reporting script etc.
+  class { 'puppetserver_foreman':
+    foreman_url      => $puppet::server::foreman_url,
+    enc_upload_facts => $puppet::server::server_foreman_facts,
+    enc_timeout      => $puppet::server::request_timeout,
+    puppet_home      => $puppet::server::puppetserver_vardir,
+    puppet_basedir   => $puppet::server::puppet_basedir,
+    puppet_etcdir    => $puppet::dir,
+    ssl_ca           => pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert),
+    ssl_cert         => pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert),
+    ssl_key          => pick($puppet::server::foreman_ssl_key, $puppet::server::ssl_cert_key),
+  }
+  contain puppetserver_foreman
+}

--- a/manifests/server/foreman.pp
+++ b/manifests/server/foreman.pp
@@ -1,6 +1,21 @@
 # @summary Set up Foreman integration
 # @api private
-class puppet::server::foreman {
+class puppet::server::foreman (
+  Boolean $katello = false,
+) {
+  if $katello {
+    include certs::puppet
+    Class['certs::puppet'] -> Class['puppetserver_foreman']
+
+    $ssl_ca = $certs::puppet::ssl_ca_cert
+    $ssl_cert = $certs::puppet::client_cert
+    $ssl_key = $keys::puppet::client_key
+  } else {
+    $ssl_ca = pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert)
+    $ssl_cert = pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert)
+    $ssl_key = pick($puppet::server::foreman_ssl_key, $puppet::server::ssl_cert_key)
+  }
+
   # Include foreman components for the puppetmaster
   # ENC script, reporting script etc.
   class { 'puppetserver_foreman':
@@ -10,9 +25,9 @@ class puppet::server::foreman {
     puppet_home      => $puppet::server::puppetserver_vardir,
     puppet_basedir   => $puppet::server::puppet_basedir,
     puppet_etcdir    => $puppet::dir,
-    ssl_ca           => pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert),
-    ssl_cert         => pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert),
-    ssl_key          => pick($puppet::server::foreman_ssl_key, $puppet::server::ssl_cert_key),
+    ssl_ca           => $ssl_ca,
+    ssl_cert         => $ssl_cert,
+    ssl_key          => $ssl_key,
   }
   contain puppetserver_foreman
 }


### PR DESCRIPTION
Katello uses a different certificate structure. This moves over the integration bits from puppet-foreman_proxy_content to this module. It also means fewer variables need to be set in the installer itself.

This is still very early (needs a related change in puppet-foreman_proxy_content and an installer migration), but submitting for a general design idea.