### PR TITLE
Change `server_puppetserver_profiler` and `server_puppetserver_metrics` defaults to true

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -439,10 +439,10 @@
 #                                           Defaults to 30000, using the Jetty default of 30s
 #
 # $server_puppetserver_metrics::            Enable puppetserver http-client metrics
-#                                           Defaults to false because that's the Puppet Inc. default behaviour.
+#                                           Defaults to true, matching defaults in Puppetserver 5+.
 #
 # $server_puppetserver_profiler::           Enable JRuby profiling.
-#                                           Defaults to true because that's the Puppet Inc. default behaviour (since Puppetserver 5.0.0).
+#                                           Defaults to true, matching defaults in Puppetserver 5+.
 #                                           If set to false, compiler and function metrics will not be available, (eg. when enabling graphite metrics)
 #
 # $server_metrics_jmx_enable::              Enable or disable JMX metrics reporter. Defaults to true
@@ -708,7 +708,7 @@ class puppet (
   Boolean $server_environment_class_cache_enabled = $puppet::params::server_environment_class_cache_enabled,
   Boolean $server_allow_header_cert_info = $puppet::params::server_allow_header_cert_info,
   Integer[0] $server_web_idle_timeout = $puppet::params::server_web_idle_timeout,
-  Boolean $server_puppetserver_metrics = false,
+  Boolean $server_puppetserver_metrics = true,
   Boolean $server_puppetserver_profiler = true,
   Boolean $server_metrics_jmx_enable = $puppet::params::server_metrics_jmx_enable,
   Boolean $server_metrics_graphite_enable = $puppet::params::server_metrics_graphite_enable,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -442,7 +442,8 @@
 #                                           Defaults to false because that's the Puppet Inc. default behaviour.
 #
 # $server_puppetserver_profiler::           Enable JRuby profiling.
-#                                           Defaults to false because that's the Puppet Inc. default behaviour.
+#                                           Defaults to true because that's the Puppet Inc. default behaviour (since Puppetserver 5.0.0).
+#                                           If set to false, compiler and function metrics will not be available, (eg. when enabling graphite metrics)
 #
 # $server_metrics_jmx_enable::              Enable or disable JMX metrics reporter. Defaults to true
 #
@@ -708,7 +709,7 @@ class puppet (
   Boolean $server_allow_header_cert_info = $puppet::params::server_allow_header_cert_info,
   Integer[0] $server_web_idle_timeout = $puppet::params::server_web_idle_timeout,
   Boolean $server_puppetserver_metrics = false,
-  Boolean $server_puppetserver_profiler = false,
+  Boolean $server_puppetserver_profiler = true,
   Boolean $server_metrics_jmx_enable = $puppet::params::server_metrics_jmx_enable,
   Boolean $server_metrics_graphite_enable = $puppet::params::server_metrics_graphite_enable,
   String $server_metrics_graphite_host = $puppet::params::server_metrics_graphite_host,

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -273,7 +273,7 @@ describe 'puppet' do
           it {
             should contain_file(puppetserver_conf)
               .with_content(/^    # Whether to enable http-client metrics; defaults to 'true'.\n    metrics-enabled: true$(.*)/)
-              .with_content(/^profiler: \{\n    # enable or disable profiling for the Ruby code;\n    enabled: false/)
+              .with_content(/^profiler: \{\n    # enable or disable profiling for the Ruby code;\n    enabled: true/)
           }
           it {
             should contain_file('/etc/custom/puppetserver/conf.d/metrics.conf')
@@ -292,9 +292,17 @@ describe 'puppet' do
           it {
             should contain_file(puppetserver_conf)
               .with_content(/^    # Whether to enable http-client metrics; defaults to 'true'.\n    metrics-enabled: false$/)
-              .with_content(/^profiler: \{\n    # enable or disable profiling for the Ruby code;\n    enabled: false/)
+              .with_content(/^profiler: \{\n    # enable or disable profiling for the Ruby code;\n    enabled: true/)
           }
           it { should contain_file('/etc/custom/puppetserver/conf.d/metrics.conf').with_ensure('file') }
+        end
+
+        context 'when server_profiler => false' do
+          let(:params) { super().merge(server_puppetserver_profiler: false) }
+          it {
+            should contain_file(puppetserver_conf)
+              .with_content(/^profiler: \{\n    # enable or disable profiling for the Ruby code;\n    enabled: false/)
+          }
         end
       end
 


### PR DESCRIPTION
Puppet Inc. enabled the profiler by default in Puppetserver 5.0.0
https://tickets.puppetlabs.com/browse/SERVER-1761

This module has been disabling by default though causing users to be
missing metrics they might reasonably expect to be present after reading
through the [Puppetserver documentation](https://puppet.com/docs/puppet/6/server/puppet_server_metrics.html#compiler-metrics).

**EDIT**
Also changed `server_puppetserver_metrics` (which enables http-client metrics) to `true`