### PR TITLE
Add `server_jolokia_metrics_whitelist` parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -537,6 +537,9 @@
 #                                           invokes when on static_file_content requests.
 #                                           Defaults to undef
 #
+# $server_jolokia_metrics_whitelist::       The whitelist of clients that
+#                                           can query the jolokia /metrics/v2 endpoint
+#
 # === Usage:
 #
 # * Simple usage:
@@ -732,6 +735,7 @@ class puppet (
   Optional[Integer[1]] $server_max_open_files = $puppet::params::server_max_open_files,
   Optional[Stdlib::Absolutepath] $server_versioned_code_id = undef,
   Optional[Stdlib::Absolutepath] $server_versioned_code_content = undef,
+  Array[String[1]] $server_jolokia_metrics_whitelist = [],
 ) inherits puppet::params {
   contain puppet::config
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -331,6 +331,9 @@
 # $versioned_code_content::            Contains the path to an executable script that Puppet Server invokes when an agent makes
 #                                      a static_file_content API request for the contents of a file resource that
 #                                      has a source attribute with a puppet:/// URI value.
+#
+# $jolokia_metrics_whitelist::         The whitelist of clients that
+#                                      can query the jolokia /metrics/v2 endpoint
 class puppet::server(
   Variant[Boolean, Stdlib::Absolutepath] $autosign = $puppet::autosign,
   Array[String] $autosign_entries = $puppet::autosign_entries,
@@ -449,6 +452,7 @@ class puppet::server(
   Optional[Integer[1]] $max_open_files = $puppet::server_max_open_files,
   Optional[Stdlib::Absolutepath] $versioned_code_id = $puppet::server_versioned_code_id,
   Optional[Stdlib::Absolutepath] $versioned_code_content = $puppet::server_versioned_code_content,
+  Array[String[1]] $jolokia_metrics_whitelist = $puppet::server_jolokia_metrics_whitelist,
 ) {
   # For Puppetserver, certain configuration parameters are version specific. We
   # assume a particular version here.

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -144,6 +144,7 @@ class puppet::server::puppetserver (
   $versioned_code_id                      = $puppet::server::versioned_code_id,
   $versioned_code_content                 = $puppet::server::versioned_code_content,
   $disable_fips                           = $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8',
+  $jolokia_metrics_whitelist              = $puppet::server::jolokia_metrics_whitelist,
 ) {
   include puppet::server
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -564,6 +564,23 @@ describe 'puppet' do
           }
         end
       end
+
+      describe 'jolokia_metrics_whitelist' do
+        let(:content) { catalogue.resource('file', auth_conf).send(:parameters)[:content] }
+        let(:rules) { Hocon.parse(content)['authorization']['rules'] }
+        let(:rule) { rules.find {|rule| rule['name'] == 'jolokia metrics' } }
+
+        context 'by default' do
+          it { expect(rule).to be_nil }
+        end
+
+        context 'when set' do
+          let(:params) { super().merge(server_jolokia_metrics_whitelist: ['localhost', 'host.example.com']) }
+
+          it { expect(rule['match-request']['path']).to eq('/metrics/v2') }
+          it { expect(rule['allow']).to eq(['localhost', 'host.example.com']) }
+        end
+      end
     end
   end
 end

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -357,6 +357,21 @@ authorization: {
             name: "puppetlabs experimental"
         },
 <%- end -%>
+<%- unless @jolokia_metrics_whitelist.empty? -%>
+        {
+            match-request: {
+                path: "/metrics/v2"
+                type: path
+            }
+            allow: [
+<%- @jolokia_metrics_whitelist.each do |client| -%>
+                "<%= client %>",
+<%- end -%>
+            ]
+            sort-order: 500
+            name: "jolokia metrics"
+        },
+<%- end -%>
         {
             # Deny everything else. This ACL is not strictly
             # necessary, but illustrates the default policy


### PR DESCRIPTION
When set, allows listed clients access to the V2 (jolokia) metrics
endpoint.

See https://puppet.com/docs/puppet/7/server/metrics-api/v2/metrics_api.html