### PR TITLE
puppet agent timer: depend on network/start it if offline

### DIFF
--- a/templates/agent/systemd.puppet-run.service.erb
+++ b/templates/agent/systemd.puppet-run.service.erb
@@ -3,7 +3,8 @@
 #
 [Unit]
 Description=Systemd Timer Service for Puppet Agent
-After=network.target
+Wants=network.target network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Two changes: With adding network-online.target as dependency we ensure
that the network is really available. That might not be the case for the
network.target. In case the system has no proper network manager,
network-online.target isn't available. For that situation we still
depend on network.target. Also we now have Wants= defined. That will
start the targets if the agent is started.

We had a similar discussion upstream:
https://github.com/puppetlabs/puppet/pull/8893