### PR TITLE
Add Array of Integers as valid type for run_minute

### DIFF
--- a/manifests/agent/service/cron.pp
+++ b/manifests/agent/service/cron.pp
@@ -1,9 +1,9 @@
 # Set up running the agent via cron
 # @api private
 class puppet::agent::service::cron (
-  Boolean                 $enabled = false,
-  Optional[Integer[0,23]] $hour    = undef,
-  Optional[Integer[0,59]] $minute  = undef,
+  Boolean                 $enabled                             = false,
+  Optional[Integer[0,23]] $hour                                = undef,
+  Variant[Integer[0,59], Array[Integer[0,59]], Undef] $minute  = undef,
 ) {
   unless $puppet::runmode == 'unmanaged' or 'cron' in $puppet::unavailable_runmodes {
     if $enabled {

--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -1,9 +1,9 @@
 # Set up running the agent via a systemd timer
 # @api private
 class puppet::agent::service::systemd (
-  Boolean                 $enabled = false,
-  Optional[Integer[0,23]] $hour    = undef,
-  Optional[Integer[0,59]] $minute  = undef,
+  Boolean                 $enabled                             = false,
+  Optional[Integer[0,23]] $hour                                = undef,
+  Variant[Integer[0,59], Array[Integer[0,59]], Undef] $minute  = undef,
 ) {
   unless $puppet::runmode == 'unmanaged' or 'systemd.timer' in $puppet::unavailable_runmodes {
     # Use the same times as for cron

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -589,7 +589,7 @@ class puppet (
   Boolean $usecacheonfailure = $puppet::params::usecacheonfailure,
   Enum['cron', 'service', 'systemd.timer', 'none', 'unmanaged'] $runmode = $puppet::params::runmode,
   Optional[Integer[0,23]] $run_hour = undef,
-  Optional[Integer[0,59]] $run_minute = undef,
+  Variant[Integer[0,59], Array[Integer[0,59]], Undef] $run_minute = undef,
   Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,
   Optional[String] $cron_cmd = $puppet::params::cron_cmd,
   Optional[String] $systemd_cmd = $puppet::params::systemd_cmd,


### PR DESCRIPTION
If no value for `run_minute` is specified the module internally uses https://forge.puppet.com/modules/puppet/extlib/reference#extlibip_to_cron
This function returns an array of integers as values that then are passed to the cron/systemd timer resources.
Having a list of values is not currently possible if you set the value of `run_minute` via the class.

This change allows specifying the minute you want as an Array of integers.