### PR TITLE
Keep ruby's system Gem.dir in gem-path on FreeBSD

### DIFF
--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -164,7 +164,7 @@ class puppet::server::puppetserver (
   $jvm_cmd = strip(join(flatten($jvm_cmd_arr), ' '))
 
   if $facts['os']['family'] == 'FreeBSD' {
-    $server_gem_paths = ['${jruby-puppet.gem-home}', "\"${server_puppetserver_vardir}/vendored-jruby-gems\"",] # lint:ignore:single_quote_string_with_variables
+    $server_gem_paths = ['${jruby-puppet.gem-home}', "\"${server_puppetserver_vardir}/vendored-jruby-gems\"", sprintf('"%s"', regsubst($facts['ruby']['sitedir'], 'site_ruby', 'gems'))] # lint:ignore:single_quote_string_with_variables
     augeas { 'puppet::server::puppetserver::jvm':
       context => '/files/etc/rc.conf',
       changes => ["set puppetserver_java_opts '\"${jvm_cmd}\"'"],

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -494,7 +494,7 @@ describe 'puppet' do
         if ['FreeBSD', 'DragonFly'].include?(facts[:osfamily])
           it do
             should contain_file(puppetserver_conf)
-              .with_content(%r{^    gem-path: \[\$\{jruby-puppet.gem-home\}, "#{server_vardir}/vendored-jruby-gems"\]$})
+              .with_content(%r{^    gem-path: \[\$\{jruby-puppet.gem-home\}, "#{server_vardir}/vendored-jruby-gems", "#{facts[:ruby]['sitedir'].sub(/site_ruby/,'gems')}"\]$})
           end
         else
           it do


### PR DESCRIPTION
without it puppetserver will not successfully start.

Fixes: https://github.com/theforeman/puppet-puppet/issues/842