### PR TITLE
Puppet 7 no longer ships with a cron built-in

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,10 @@
       "version_requirement": ">= 4.18.0 < 9.0.0"
     },
     {
+      "name": "puppetlabs/cron_core",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
+    },
+    {
       "name": "puppet/extlib",
       "version_requirement": ">= 3.0.0 < 7.0.0"
     },


### PR DESCRIPTION
It now requires `cron_core` and seems like it won't work with any other module that provides the `cron` type (like `puppet-cron` which defines a different type with the same name)