### PR TITLE
Allow setting cron target

### DIFF
--- a/manifests/agent/service/cron.pp
+++ b/manifests/agent/service/cron.pp
@@ -8,6 +8,7 @@ class puppet::agent::service::cron (
   unless $puppet::runmode == 'unmanaged' or 'cron' in $puppet::unavailable_runmodes {
     if $enabled {
       $command = pick($puppet::cron_cmd, "${puppet::puppet_cmd} agent --config ${puppet::dir}/puppet.conf --onetime --no-daemonize")
+      $target = $puppet::cron_target
       $times = extlib::ip_to_cron($puppet::runinterval)
 
       $_hour = pick($hour, $times[0])
@@ -18,6 +19,7 @@ class puppet::agent::service::cron (
         user    => root,
         hour    => $_hour,
         minute  => $_minute,
+        target  => $target,
       }
     } else{
       cron { 'puppet':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,9 @@
 # $cron_cmd::                               Specify command to launch when runmode is
 #                                           set 'cron'.
 #
+# $cron_target::                            Specify the target crontab file when runmode is
+#                                           set 'cron'.
+#
 # $systemd_cmd::                            Specify command to launch when runmode is
 #                                           set 'systemd.timer'.
 #
@@ -597,6 +600,7 @@ class puppet (
   Variant[Integer[0,59], Array[Integer[0,59]], Undef] $run_minute = undef,
   Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,
   Optional[String] $cron_cmd = $puppet::params::cron_cmd,
+  Optional[String] $cron_target = $puppet::params::cron_target,
   Optional[String] $systemd_cmd = $puppet::params::systemd_cmd,
   Integer[0] $systemd_randomizeddelaysec = $puppet::params::systemd_randomizeddelaysec,
   Boolean $agent_noop = $puppet::params::agent_noop,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class puppet::params {
 
   # Not defined here as the commands depend on module parameter "dir"
   $cron_cmd            = undef
+  $cron_target         = undef
   $systemd_cmd         = undef
 
   $agent_noop          = false

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -185,7 +185,7 @@ class puppet::server::config inherits puppet::config {
         owner   => $puppet::server::user,
         group   => $puppet::server::group,
         mode    => '0644',
-        content => file($::settings::cacrl, $::settings::hostcrl, '/dev/null'),
+        content => file($settings::cacrl, $settings::hostcrl, '/dev/null'),
       }
     }
   }


### PR DESCRIPTION
For example, this is useful if you have `/var/spool/cron` mounted over NFS and use the `-c` option which would mean Puppet cronjobs would not run on other machines.