### PR TITLE
Allow permissions change of puppet.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -89,7 +89,7 @@ class puppet::config (
   -> case $facts['os']['family'] {
     'Windows': {
       concat { "${puppet_dir}/puppet.conf":
-        mode  => '0674',
+        mode  => $puppet::puppetconf_mode,
       }
     }
 
@@ -97,7 +97,7 @@ class puppet::config (
       concat { "${puppet_dir}/puppet.conf":
         owner => 'root',
         group => $puppet::params::root_group,
-        mode  => '0644',
+        mode  => $puppet::puppetconf_mode,
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,6 +162,9 @@
 #                                           of the classes associated with the retrieved
 #                                           configuration.
 #
+# $puppetconf_mode::                        The permissions for /etc/puppetlabs/puppet/puppet.conf
+#                                           default to '0644' and '0674' on windows
+#
 # == puppet::agent parameters
 #
 # $agent::                                  Should a puppet agent be installed
@@ -752,6 +755,7 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_versioned_code_id = undef,
   Optional[Stdlib::Absolutepath] $server_versioned_code_content = undef,
   Array[String[1]] $server_jolokia_metrics_whitelist = [],
+  Pattern[/^[0-9]{3,4}$/] $puppetconf_mode = $puppet::params::puppetconf_mode,
 ) inherits puppet::params {
   contain puppet::config
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -755,7 +755,7 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_versioned_code_id = undef,
   Optional[Stdlib::Absolutepath] $server_versioned_code_content = undef,
   Array[String[1]] $server_jolokia_metrics_whitelist = [],
-  Pattern[/^[0-9]{3,4}$/] $puppetconf_mode = $puppet::params::puppetconf_mode,
+  Stdlib::Filemode $puppetconf_mode = $puppet::params::puppetconf_mode,
 ) inherits puppet::params {
   contain puppet::config
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,6 +69,7 @@ class puppet::params {
       $server_puppetserver_logdir = undef
       $server_ruby_load_paths     = []
       $server_jruby_gem_home      = undef
+      $puppetconf_mode            = '0674'
     }
 
     /^(FreeBSD|DragonFly)$/ : {
@@ -96,6 +97,7 @@ class puppet::params {
         # lint:endignore
       }
       $server_jruby_gem_home      = '/var/puppet/server/data/puppetserver/jruby-gems'
+      $puppetconf_mode            = '0644'
     }
 
     'Archlinux' : {
@@ -114,6 +116,7 @@ class puppet::params {
       $server_puppetserver_logdir = undef
       $server_ruby_load_paths     = []
       $server_jruby_gem_home      = undef
+      $puppetconf_mode            = '0644'
     }
 
     default : {
@@ -152,6 +155,7 @@ class puppet::params {
         $server_jruby_gem_home      = '/var/lib/puppet/jruby-gems'
       }
       $root_group = undef
+      $puppetconf_mode = '0644'
     }
   }
 

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -10,18 +10,22 @@ describe 'puppet' do
         puppet_concat    = '/usr/local/etc/puppet/puppet.conf'
         puppet_directory = '/usr/local/etc/puppet'
         puppet_package   = "puppet#{puppet_major}"
+        puppetconf_mode  = '0644'
       when 'windows'
         puppet_concat    = 'C:/ProgramData/PuppetLabs/puppet/etc/puppet.conf'
         puppet_directory = 'C:/ProgramData/PuppetLabs/puppet/etc'
         puppet_package   = 'puppet-agent'
+        puppetconf_mode  = '0674'
       when 'Archlinux'
         puppet_concat    = '/etc/puppetlabs/puppet/puppet.conf'
         puppet_directory = '/etc/puppetlabs/puppet'
         puppet_package   = 'puppet'
+        puppetconf_mode  = '0644'
       else
         puppet_concat    = '/etc/puppetlabs/puppet/puppet.conf'
         puppet_directory = '/etc/puppetlabs/puppet'
         puppet_package   = 'puppet-agent'
+        puppetconf_mode  = '0644'
       end
 
       let :facts do
@@ -34,7 +38,7 @@ describe 'puppet' do
         it { should contain_class('puppet::config') }
         it { should_not contain_class('puppet::server') }
         it { should contain_file(puppet_directory).with_ensure('directory') }
-        it { should contain_concat(puppet_concat) }
+        it { should contain_concat(puppet_concat).with_mode(puppetconf_mode) }
         it { should contain_package(puppet_package)
           .with_ensure('present')
           .with_install_options(nil)
@@ -81,6 +85,14 @@ describe 'puppet' do
         } end
 
         it { should contain_puppet__config__main('ca_port').with_value(8140) }
+      end
+
+      describe 'with puppetconf_mode' do
+        let :params do {
+          :puppetconf_mode => '0640',
+        } end
+
+        it { should contain_concat(puppet_concat).with_mode('0640') }
       end
 
       # compilation is broken due to paths


### PR DESCRIPTION
There is confidential info in my `puppet.conf` (`http_proxy_password` to be precise) that I would like to secure from unprivileged users.