### PR TITLE
Add option to allow unauthenticated access to metrics, and for generic additions to auth

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -543,8 +543,14 @@
 #                                           invokes when on static_file_content requests.
 #                                           Defaults to undef
 #
+# $server_jolokia_allow_unauthenticated::   Whether to allow unauthenticated access to metrics
+#                                           Defaults to false
+#
 # $server_jolokia_metrics_whitelist::       The whitelist of clients that
 #                                           can query the jolokia /metrics/v2 endpoint
+#
+# $server_auth_extra::                      Additional rules for auth.conf
+#                                           Defaults to undef
 #
 # === Usage:
 #
@@ -743,6 +749,8 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_versioned_code_id = undef,
   Optional[Stdlib::Absolutepath] $server_versioned_code_content = undef,
   Array[String[1]] $server_jolokia_metrics_whitelist = [],
+  Optional[Boolean] $server_jolokia_allow_unauthenticated = false,
+  Optional[String] $server_auth_extra = undef,
 ) inherits puppet::params {
   contain puppet::config
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -338,6 +338,11 @@
 #
 # $jolokia_metrics_whitelist::         The whitelist of clients that
 #                                      can query the jolokia /metrics/v2 endpoint
+#
+# $jolokia_allow_unauthenticated::     Should we disable authentication for the metrics
+#
+# $auth_extra::                        Additional rules for the auth.conf
+
 class puppet::server(
   Variant[Boolean, Stdlib::Absolutepath] $autosign = $puppet::autosign,
   Array[String] $autosign_entries = $puppet::autosign_entries,
@@ -458,6 +463,8 @@ class puppet::server(
   Optional[Stdlib::Absolutepath] $versioned_code_id = $puppet::server_versioned_code_id,
   Optional[Stdlib::Absolutepath] $versioned_code_content = $puppet::server_versioned_code_content,
   Array[String[1]] $jolokia_metrics_whitelist = $puppet::server_jolokia_metrics_whitelist,
+  Optional[Boolean] $jolokia_allow_unauthenticated = $puppet::server_jolokia_allow_unauthenticated,
+  Optional[String] $auth_extra = $puppet::server_auth_extra,
 ) {
   # For Puppetserver, certain configuration parameters are version specific. We
   # assume a particular version here.

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -146,6 +146,8 @@ class puppet::server::puppetserver (
   $versioned_code_content                 = $puppet::server::versioned_code_content,
   $disable_fips                           = $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8',
   $jolokia_metrics_whitelist              = $puppet::server::jolokia_metrics_whitelist,
+  $jolokia_allow_unauthenticated          = $puppet::server::jolokia_allow_unauthenticated,
+  $auth_extra                             = $puppet::server::auth_extra,
 ) {
   include puppet::server
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -613,6 +613,33 @@ describe 'puppet' do
           it { expect(rule['allow']).to eq(['localhost', 'host.example.com']) }
         end
       end
+
+      describe 'jolokia_allow_unauthenticated' do
+        let(:content) { catalogue.resource('file', auth_conf).send(:parameters)[:content] }
+        let(:rules) { Hocon.parse(content)['authorization']['rules'] }
+        let(:rule) { rules.find {|rule| rule['name'] == 'jolokia metrics' } }
+
+        context 'by default' do
+          it { expect(rule).to be_nil }
+        end
+
+        context 'when set' do
+          let(:params) { super().merge(server_jolokia_allow_unauthenticated: true) }
+
+          it { expect(rule['match-request']['path']).to eq('/metrics/v2') }
+          it { expect(rule['allow-unauthenticated']).to eq(true) }
+        end
+      end
+
+      describe 'auth_extra' do
+        let(:content) { catalogue.resource('file', auth_conf).send(:parameters)[:content] }
+
+        context 'when set' do
+          let(:params) { super().merge(server_auth_extra: "# test-content-string" ) }
+
+          it { should contain_file(auth_conf).with_content(%r{^# test-content-string$}) }
+        end
+      end
     end
   end
 end

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -357,6 +357,17 @@ authorization: {
             name: "puppetlabs experimental"
         },
 <%- end -%>
+<%- if @jolokia_allow_unauthenticated -%>
+        {
+            match-request: {
+                path: "/metrics/v2"
+                type: path
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "jolokia metrics"
+        },
+<%- else -%>
 <%- unless @jolokia_metrics_whitelist.empty? -%>
         {
             match-request: {
@@ -371,6 +382,10 @@ authorization: {
             sort-order: 500
             name: "jolokia metrics"
         },
+<%- end -%>
+<%- end -%>
+<%- if @auth_extra -%>
+<%= @auth_extra %>
 <%- end -%>
         {
             # Deny everything else. This ACL is not strictly


### PR DESCRIPTION
This minor change allows generic control of the auth.conf file, and permitting unauthenticated retrieval of metrics (as is required by our monitoring system)
* 2 new parameters to server class
* Usage comments added
* Spec tests added and run successfully