### PR TITLE
Permit setting `default_schedules` to `true`

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -3,8 +3,8 @@
 class puppet::agent::config inherits puppet::config {
   puppet::config::agent{
     'classfile':         value => $puppet::classfile;
-    'localconfig':       value => '$vardir/localconfig';
-    'default_schedules': value => false;
+    'localconfig':       value => $puppet::localconfig;
+    'default_schedules': value => $puppet::agent_default_schedules;
     'report':            value => $puppet::report;
     'masterport':        value => $puppet::port;
     'environment':       value => $puppet::environment;

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,8 @@
 #
 # $hiera_config::                           The hiera configuration file.
 #
+# $localconfig::                            The localconfig setting.
+#
 # $syslogfacility::                         Facility name to use when logging to syslog
 #
 # $use_srv_records::                        Whether DNS SRV records will be used to resolve
@@ -174,6 +176,8 @@
 # $postrun_command::                        A command which gets excuted after each Puppet run
 #
 # $environment::                            Default environment of the Puppet agent
+#
+# $agent_default_schedules::                A boolean to enable/disable the default schedules
 #
 # $agent_additional_settings::              A hash of additional agent settings.
 #                                           Example: {stringify_facts => true}
@@ -600,6 +604,7 @@ class puppet (
   Optional[String] $systemd_cmd = $puppet::params::systemd_cmd,
   Integer[0] $systemd_randomizeddelaysec = $puppet::params::systemd_randomizeddelaysec,
   Boolean $agent_noop = $puppet::params::agent_noop,
+  Boolean $agent_default_schedules = $puppet::params::agent_default_schedules,
   Boolean $show_diff = $puppet::params::show_diff,
   Optional[Stdlib::HTTPUrl] $module_repository = $puppet::params::module_repository,
   Optional[Integer[0]] $http_connect_timeout = $puppet::params::http_connect_timeout,
@@ -619,6 +624,7 @@ class puppet (
   Optional[String] $agent_restart_command = $puppet::params::agent_restart_command,
   String $classfile = $puppet::params::classfile,
   String $hiera_config = $puppet::params::hiera_config,
+  String $localconfig = $puppet::params::localconfig,
   String $auth_template = $puppet::params::auth_template,
   Boolean $allow_any_crl_auth = $puppet::params::allow_any_crl_auth,
   Array[String] $auth_allowed = $puppet::params::auth_allowed,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class puppet::params {
   $show_diff           = false
   $module_repository   = undef
   $hiera_config        = '$confdir/hiera.yaml'
+  $localconfig         = '$vardir/localconfig'
   $usecacheonfailure   = true
   $ca_server           = undef
   $ca_port             = undef
@@ -33,6 +34,7 @@ class puppet::params {
   $server_compile_mode = undef
   $dns_alt_names       = []
   $use_srv_records     = false
+  $agent_default_schedules = false
 
   if defined('$::domain') {
     $srv_domain = $facts['networking']['domain']


### PR DESCRIPTION
Also allow override for `localconfig`, but I don't know why someone would change it....

I've been using the default schedules for a few things and, while I get not everyone likes them, I'd like to be able to keep using them.

Without this flag, this module is mostly useless for my environment.