### PR TITLE
Default to TLS1.3 or TLS1.2 by default since puppet supports both

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -386,7 +386,7 @@
 # $server_connect_timeout::                 How long the server will wait for a response to a connection attempt
 #
 # $server_ssl_protocols::                   Array of SSL protocols to use.
-#                                           Defaults to [ 'TLSv1.2' ]
+#                                           Defaults to [ 'TLSv1.3', 'TLSv1.2' ]
 #
 # $server_ssl_chain_filepath::              Path to certificate chain for puppetserver
 #                                           Only used when $ca is true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -379,7 +379,7 @@ class puppet::params {
     'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',
     'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
   ]
-  $server_ssl_protocols                   = ['TLSv1.2']
+  $server_ssl_protocols                   = ['TLSv1.3', 'TLSv1.2']
   $server_ssl_chain_filepath              = undef
   $server_check_for_updates               = true
   $server_environment_class_cache_enabled = false

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -217,7 +217,7 @@
 #                                      Defaults to the Jetty default of 30s
 #
 # $ssl_protocols::                     Array of SSL protocols to use.
-#                                      Defaults to [ 'TLSv1.2' ]
+#                                      Defaults to [ 'TLSv1.3', 'TLSv1.2' ]
 #
 # $ssl_chain_filepath::                Path to certificate chain for puppetserver
 #                                      Defaults to "${ssl_dir}/ca/ca_crt.pem"


### PR DESCRIPTION
TLSv 1.3 support has been in puppetserver since 2019, should be safe to start defaulting to that on.