### PR TITLE
Fixes #35943 - Switch to puppetlabs vcsrepo for gitrepo tracking

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,3 +14,4 @@ fixtures:
     puppetserver_foreman: 'https://github.com/theforeman/puppet-puppetserver_foreman.git'
     stdlib:               'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     systemd:              'https://github.com/voxpupuli/puppet-systemd.git'
+    vcsrepo:              'https://github.com/puppetlabs/puppetlabs-vcsrepo.git'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ sets up `/var/lib/puppet/puppet.git` where each branch maps to one environment.
 Avoid using 'master' as this name isn't permitted.  On each push to the repo, a
 hook updates `/etc/puppet/environments` with the contents of the branch.
 
-Requires [theforeman/git](https://forge.puppetlabs.com/theforeman/git).
+Permissions can be controlled via the `git_repo_{user,group,hook_mode,umask}`
+parameters.
+
+Requires [puppetlabs/vcsrepo](https://forge.puppetlabs.com/puppetlabs/vcsrepo) >= 5.2.0.
 
 ## Foreman integration
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -237,9 +237,11 @@
 #
 # $server_common_modules_path::             Common modules paths
 #
-# $server_git_repo_path::                   Git repository path
+# $server_git_repo_path::                   Git repository path on disk
 #
-# $server_git_repo_mode::                   Git repository mode
+# $server_git_repo_umask::                  Umask used during git operations
+#
+# $server_git_repo_hook_mode::              Git repository hook mode
 #
 # $server_git_repo_group::                  Git repository group
 #
@@ -674,8 +676,9 @@ class puppet (
   Array[Stdlib::Absolutepath, 1] $server_envs_dir = $puppet::params::server_envs_dir,
   Optional[Stdlib::Absolutepath] $server_envs_target = $puppet::params::server_envs_target,
   Variant[Undef, String[0], Array[Stdlib::Absolutepath]] $server_common_modules_path = $puppet::params::server_common_modules_path,
-  Pattern[/^[0-9]{3,4}$/] $server_git_repo_mode = $puppet::params::server_git_repo_mode,
+  Pattern[/^[0-9]{3,4}$/] $server_git_repo_hook_mode = $puppet::params::server_git_repo_hook_mode,
   Stdlib::Absolutepath $server_git_repo_path = $puppet::params::server_git_repo_path,
+  Pattern[/^[0-9]{3,4}$/] $server_git_repo_umask = $puppet::params::server_git_repo_umask,
   String $server_git_repo_group = $puppet::params::server_git_repo_group,
   String $server_git_repo_user = $puppet::params::server_git_repo_user,
   Hash[String, String] $server_git_branch_map = $puppet::params::server_git_branch_map,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -241,10 +241,12 @@ class puppet::params {
   $server_common_modules_path  = unique(["${server_envs_dir[0]}/common", "${codedir}/modules", "${sharedir}/modules", '/usr/share/puppet/modules'])
 
   # Dynamic environments config, ignore if the git_repo is 'false'
-  # Path to the repository
+  # Path to the repository on disk
   $server_git_repo_path       = "${vardir}/puppet.git"
-  # mode of the repository
-  $server_git_repo_mode       = '0755'
+  # Umask for vcsrepo operations
+  $server_git_repo_umask      = '0022'
+  # mode of the repository hooks
+  $server_git_repo_hook_mode  = '0755'
   # user of the repository
   $server_git_repo_user       = $user
   # group of the repository

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -80,9 +80,11 @@
 #
 # $common_modules_path::               Common modules paths
 #
-# $git_repo_path::                     Git repository path
+# $git_repo_path::                     Git repository path on disk
 #
-# $git_repo_mode::                     Git repository mode
+# $git_repo_umask::                    Umask used during git operations
+#
+# $git_repo_hook_mode::                Git repository hook mode
 #
 # $git_repo_group::                    Git repository group
 #
@@ -384,8 +386,9 @@ class puppet::server (
   Array[Stdlib::Absolutepath, 1] $envs_dir = $puppet::server_envs_dir,
   Optional[Stdlib::Absolutepath] $envs_target = $puppet::server_envs_target,
   Variant[Undef, String[0], Array[Stdlib::Absolutepath]] $common_modules_path = $puppet::server_common_modules_path,
-  Pattern[/^[0-9]{3,4}$/] $git_repo_mode = $puppet::server_git_repo_mode,
+  Pattern[/^[0-9]{3,4}$/] $git_repo_hook_mode = $puppet::server_git_repo_hook_mode,
   Stdlib::Absolutepath $git_repo_path = $puppet::server_git_repo_path,
+  Pattern[/^[0-9]{3,4}$/] $git_repo_umask = $puppet::server_git_repo_umask,
   String $git_repo_group = $puppet::server_git_repo_group,
   String $git_repo_user = $puppet::server_git_repo_user,
   Hash[String, String] $git_branch_map = $puppet::server_git_branch_map,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -241,25 +241,20 @@ class puppet::server::config inherits puppet::config {
   }
 
   if $puppet::server::git_repo {
-    include git
-
-    if $puppet::server::manage_user {
-      Class['git'] -> User[$puppet::server::user]
-    }
-
     file { $puppet::vardir:
       ensure => directory,
       owner  => 'root',
       group  => 'root',
     }
 
-    git::repo { 'puppet_repo':
-      bare    => true,
-      target  => $puppet::server::git_repo_path,
-      mode    => $puppet::server::git_repo_mode,
-      user    => $puppet::server::git_repo_user,
-      group   => $puppet::server::git_repo_group,
-      require => File[$puppet::vardir, $primary_envs_dir],
+    vcsrepo { 'puppet_repo':
+      ensure   => 'bare',
+      provider => 'git',
+      path     => $puppet::server::git_repo_path,
+      user     => $puppet::server::git_repo_user,
+      group    => $puppet::server::git_repo_group,
+      umask    => $puppet::server::git_repo_umask,
+      require  => File[$puppet::vardir, $primary_envs_dir],
     }
 
     $git_branch_map = $puppet::server::git_branch_map
@@ -268,8 +263,8 @@ class puppet::server::config inherits puppet::config {
       content => template($puppet::server::post_hook_content),
       owner   => $puppet::server::git_repo_user,
       group   => $puppet::server::git_repo_group,
-      mode    => $puppet::server::git_repo_mode,
-      require => Git::Repo['puppet_repo'],
+      mode    => $puppet::server::git_repo_hook_mode,
+      require => Vcsrepo['puppet_repo'],
     }
   }
 

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -10,6 +10,10 @@ class puppet::server::install {
     Class['puppet::server::install'] -> Class['foreman::config']
   }
 
+  if $puppet::server::git_repo {
+    ensure_packages(['git'])
+  }
+
   if $puppet::server::manage_user {
     $shell = $puppet::server::git_repo ? {
       true    => $facts['os']['family'] ? {
@@ -21,6 +25,10 @@ class puppet::server::install {
 
     user { $puppet::server::user:
       shell => $shell,
+    }
+
+    if $puppet::server::git_repo {
+      Package['git'] -> User[$puppet::server::user]
     }
   }
 

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -363,7 +363,7 @@ describe 'puppet' do
                   end
           should contain_user('puppet')
             .with_shell(shell)
-            .that_requires('Class[git]')
+            .that_requires('Package[git]')
         end
 
         it do
@@ -373,9 +373,9 @@ describe 'puppet' do
         end
 
         it do
-          should contain_git__repo('puppet_repo')
-            .with_bare(true)
-            .with_target("#{vardir}/puppet.git")
+          should contain_vcsrepo('puppet_repo')
+            .with_ensure('bare')
+            .with_path("#{vardir}/puppet.git")
             .with_user('puppet')
             .that_requires("File[#{environments_dir}]")
         end
@@ -384,7 +384,7 @@ describe 'puppet' do
           should contain_file("#{vardir}/puppet.git/hooks/post-receive")
             .with_owner('puppet') \
             .with_mode('0755') \
-            .that_requires('Git::Repo[puppet_repo]') \
+            .that_requires('Vcsrepo[puppet_repo]') \
             .with_content(/BRANCH_MAP = \{[^a-zA-Z=>]\}/)
         end
 
@@ -683,7 +683,7 @@ describe 'puppet' do
         it { should contain_puppet__config__main('environmentpath').with_value('/etc/puppetlabs/code/environments/:/etc/puppetlabs/code/unmanaged-environments/') }
         it { should contain_file('/etc/puppetlabs/code/environments/') }
         it { should contain_file('/etc/puppetlabs/code/unmanaged-environments/') }
-        it { should contain_git__repo('puppet_repo').that_requires('File[/etc/puppetlabs/code/environments/]') }
+        it { should contain_vcsrepo('puppet_repo').that_requires('File[/etc/puppetlabs/code/environments/]') }
         it { should contain_file('/test/puppet/hooks/post-receive').with_content(/ENVIRONMENT_BASEDIR\s=\s"\/etc\/puppetlabs\/code\/environments\/"/) }
       end
     end


### PR DESCRIPTION
This PR switches to using the `puppetlabs/vcsrepo` module.  In theory this should reduce the maintenance overhead of this module for `git` related issues.