### PR TITLE
Fixes #35983 - Permit recursive ownership/permissions for environments

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,6 +235,8 @@
 #
 # $server_environments_mode::               Environments directory mode.
 #
+# $server_environments_recurse::            Should the environments directory be managed recursively
+#
 # $server_common_modules_path::             Common modules paths
 #
 # $server_git_repo_path::                   Git repository path
@@ -671,6 +673,7 @@ class puppet (
   String $server_environments_owner = $puppet::params::server_environments_owner,
   Optional[String] $server_environments_group = $puppet::params::server_environments_group,
   Pattern[/^[0-9]{3,4}$/] $server_environments_mode = $puppet::params::server_environments_mode,
+  Boolean $server_environments_recurse = $puppet::params::server_environments_recurse,
   Array[Stdlib::Absolutepath, 1] $server_envs_dir = $puppet::params::server_envs_dir,
   Optional[Stdlib::Absolutepath] $server_envs_target = $puppet::params::server_envs_target,
   Variant[Undef, String[0], Array[Stdlib::Absolutepath]] $server_common_modules_path = $puppet::params::server_common_modules_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -234,6 +234,7 @@ class puppet::params {
   $server_environments_owner   = $user
   $server_environments_group   = $root_group
   $server_environments_mode    = '0755'
+  $server_environments_recurse = false
   # Where we store our puppet environments
   $server_envs_dir             = ["${codedir}/environments"]
   $server_envs_target          = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -70,6 +70,8 @@
 #
 # $environments_mode::                 Environments directory mode.
 #
+# $environments_recurse::              Should the environments directory be managed recursively
+#
 # $envs_dir::                          List of directories that hold puppet environments
 #                                      All listed directories will be created and attributes managed,
 #                                      but only the first listed path will be used to populate
@@ -381,6 +383,7 @@ class puppet::server (
   String $environments_owner = $puppet::server_environments_owner,
   Optional[String] $environments_group = $puppet::server_environments_group,
   Pattern[/^[0-9]{3,4}$/] $environments_mode = $puppet::server_environments_mode,
+  Boolean $environments_recurse = $puppet::server_environments_recurse,
   Array[Stdlib::Absolutepath, 1] $envs_dir = $puppet::server_envs_dir,
   Optional[Stdlib::Absolutepath] $envs_target = $puppet::server_envs_target,
   Variant[Undef, String[0], Array[Stdlib::Absolutepath]] $common_modules_path = $puppet::server_common_modules_path,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -232,12 +232,13 @@ class puppet::server::config inherits puppet::config {
   }
 
   file { $puppet::server::envs_dir:
-    ensure => $ensure,
-    owner  => $puppet::server::environments_owner,
-    group  => $puppet::server::environments_group,
-    mode   => $puppet::server::environments_mode,
-    target => $puppet::server::envs_target,
-    force  => true,
+    ensure  => $ensure,
+    owner   => $puppet::server::environments_owner,
+    group   => $puppet::server::environments_group,
+    mode    => $puppet::server::environments_mode,
+    target  => $puppet::server::envs_target,
+    recurse => $puppet::server::environments_recurse,
+    force   => true,
   }
 
   if $puppet::server::git_repo {

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -124,6 +124,7 @@ describe 'puppet' do
             .with_ensure('directory')
             .with_owner('puppet')
             .with_group(nil)
+            .with_recurse(false)
             .with_mode('0755')
 
           should contain_file(sharedir).with_ensure('directory')
@@ -403,6 +404,11 @@ describe 'puppet' do
       context 'with directory environments owner' do
         let(:params) { super().merge(server_environments_owner: 'apache') }
         it { should contain_file(environments_dir).with_owner('apache') }
+      end
+
+      context 'with directory environments recursive mangement' do
+        let(:params) { super().merge(server_environments_recurse: true) }
+        it { should contain_file(environments_dir).with_recurse(true) }
       end
 
       context 'with no common modules directory' do


### PR DESCRIPTION
This lets folks easily set owner/group/mode for the content of /etc/puppetlabs/code/environments.

There is a performance cost, but folks opting into this should know that already.