### PR TITLE
Refs #35985 - Implement optional Katello integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Since version 15.0.0 the integration bits depend on the standalone module where
 previously it depended on
 [theforeman/foreman](https://forge.puppetlabs.com/theforeman/foreman)
 
+There is also optional integration for [katello/certs](https://forge.puppetlabs.com/katello/certs).
+This can be enabled via Hiera:
+
+```yaml
+puppet::server::foreman::katello: true
+```
+
+Then the `foreman_ssl_{ca,cert,key}` parameters are ignored and `certs::puppet` is used as a source.
+
 ## PuppetDB integration
 
 The Puppet master can be configured to export catalogs and reports to a

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -286,21 +286,7 @@ class puppet::server::config inherits puppet::config {
     }
   }
 
-  ## Foreman
   if $puppet::server::foreman {
-    # Include foreman components for the puppetmaster
-    # ENC script, reporting script etc.
-    class { 'puppetserver_foreman':
-      foreman_url      => $puppet::server::foreman_url,
-      enc_upload_facts => $puppet::server::server_foreman_facts,
-      enc_timeout      => $puppet::server::request_timeout,
-      puppet_home      => $puppet::server::puppetserver_vardir,
-      puppet_basedir   => $puppet::server::puppet_basedir,
-      puppet_etcdir    => $puppet::dir,
-      ssl_ca           => pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert),
-      ssl_cert         => pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert),
-      ssl_key          => pick($puppet::server::foreman_ssl_key, $puppet::server::ssl_cert_key),
-    }
-    contain puppetserver_foreman
+    contain puppet::server::foreman
   }
 }

--- a/manifests/server/foreman.pp
+++ b/manifests/server/foreman.pp
@@ -1,6 +1,21 @@
 # @summary Set up Foreman integration
 # @api private
-class puppet::server::foreman {
+class puppet::server::foreman (
+  Boolean $katello = false,
+) {
+  if $katello {
+    include certs::puppet
+    Class['certs::puppet'] -> Class['puppetserver_foreman']
+
+    $ssl_ca = $certs::puppet::ssl_ca_cert
+    $ssl_cert = $certs::puppet::client_cert
+    $ssl_key = $certs::puppet::client_key
+  } else {
+    $ssl_ca = pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert)
+    $ssl_cert = pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert)
+    $ssl_key = pick($puppet::server::foreman_ssl_key, $puppet::server::ssl_cert_key)
+  }
+
   # Include foreman components for the puppetmaster
   # ENC script, reporting script etc.
   class { 'puppetserver_foreman':
@@ -10,9 +25,9 @@ class puppet::server::foreman {
     puppet_home      => $puppet::server::puppetserver_vardir,
     puppet_basedir   => $puppet::server::puppet_basedir,
     puppet_etcdir    => $puppet::dir,
-    ssl_ca           => pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert),
-    ssl_cert         => pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert),
-    ssl_key          => pick($puppet::server::foreman_ssl_key, $puppet::server::ssl_cert_key),
+    ssl_ca           => $ssl_ca,
+    ssl_cert         => $ssl_cert,
+    ssl_key          => $ssl_key,
   }
   contain puppetserver_foreman
 }

--- a/manifests/server/foreman.pp
+++ b/manifests/server/foreman.pp
@@ -1,0 +1,18 @@
+# @summary Set up Foreman integration
+# @api private
+class puppet::server::foreman {
+  # Include foreman components for the puppetmaster
+  # ENC script, reporting script etc.
+  class { 'puppetserver_foreman':
+    foreman_url      => $puppet::server::foreman_url,
+    enc_upload_facts => $puppet::server::server_foreman_facts,
+    enc_timeout      => $puppet::server::request_timeout,
+    puppet_home      => $puppet::server::puppetserver_vardir,
+    puppet_basedir   => $puppet::server::puppet_basedir,
+    puppet_etcdir    => $puppet::dir,
+    ssl_ca           => pick($puppet::server::foreman_ssl_ca, $puppet::server::ssl_ca_cert),
+    ssl_cert         => pick($puppet::server::foreman_ssl_cert, $puppet::server::ssl_cert),
+    ssl_key          => pick($puppet::server::foreman_ssl_key, $puppet::server::ssl_cert_key),
+  }
+  contain puppetserver_foreman
+}


### PR DESCRIPTION
This is https://github.com/theforeman/puppet-puppet/pull/801 reopened. The whole effort to build PSF ended up going nowhere for various reasons. This revives the previous effort to it it more user friendly. We can remove the need to pass various parameters for end users, which makes life easier.

Additional PRs will be needed to make use of this.