### PR TITLE
Support new non-AIO puppet Debian packages

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -282,7 +282,7 @@ class puppet::params {
   $server_version = undef
 
   if $aio_package or
-    ($facts['os']['name'] == 'Debian' and Integer($facts['os']['release']['major']) >= 12) {
+    ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '12') >= 0) {
     $client_package = ['puppet-agent']
   } elsif ($facts['os']['family'] =~ /(FreeBSD|DragonFly)/) {
     $client_package = ["puppet${puppet_major}"]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -282,7 +282,7 @@ class puppet::params {
   $server_version = undef
 
   if $aio_package or
-    ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '12') >= 0) {
+  ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '12') >= 0) {
     $client_package = ['puppet-agent']
   } elsif ($facts['os']['family'] =~ /(FreeBSD|DragonFly)/) {
     $client_package = ["puppet${puppet_major}"]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -147,12 +147,21 @@ class puppet::params {
         $vardir                     = '/var/lib/puppet'
         $sharedir                   = '/usr/share/puppet'
         $bindir                     = '/usr/bin'
-        $server_puppetserver_dir    = '/etc/puppetserver'
-        $server_puppetserver_vardir = $vardir
-        $server_puppetserver_rundir = undef
-        $server_puppetserver_logdir = undef
-        $server_ruby_load_paths     = []
-        $server_jruby_gem_home      = '/var/lib/puppet/jruby-gems'
+        if $facts['os']['family'] == 'Debian' {
+          $server_puppetserver_dir    = '/etc/puppet/puppetserver'
+          $server_puppetserver_vardir = '/var/lib/puppetserver'
+          $server_puppetserver_rundir = '/run/puppetserver'
+          $server_puppetserver_logdir = '/var/log/puppetserver'
+          $server_ruby_load_paths     = ['/usr/lib/puppetserver/ruby/vendor_ruby']
+          $server_jruby_gem_home      = '/var/lib/puppetserver/jruby-gems'
+        } else {
+          $server_puppetserver_dir    = '/etc/puppetserver'
+          $server_puppetserver_vardir = $vardir
+          $server_puppetserver_rundir = undef
+          $server_puppetserver_logdir = undef
+          $server_ruby_load_paths     = []
+          $server_jruby_gem_home      = '/var/lib/puppet/jruby-gems'
+        }
       }
       $root_group = undef
       $puppetconf_mode = '0644'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -281,7 +281,8 @@ class puppet::params {
   $server_ssl_dir = $ssldir
   $server_version = undef
 
-  if $aio_package {
+  if $aio_package or
+    ($facts['os']['name'] == 'Debian' and Integer($facts['os']['release']['major']) >= 12) {
     $client_package = ['puppet-agent']
   } elsif ($facts['os']['family'] =~ /(FreeBSD|DragonFly)/) {
     $client_package = ["puppet${puppet_major}"]

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -169,6 +169,8 @@ class puppet::server::puppetserver (
       context => '/files/etc/rc.conf',
       changes => ["set puppetserver_java_opts '\"${jvm_cmd}\"'"],
     }
+  } elsif $facts['os']['family'] == 'Debian' and !$puppet::params::aio_package {
+    $server_gem_paths = ['${jruby-puppet.gem-home}', '/usr/lib/puppetserver/vendored-jruby-gems'] # lint:ignore:single_quote_string_with_variables
   } else {
     if $jvm_cli_args {
       $changes = [


### PR DESCRIPTION
The upcoming release of Debian will ship with a new non-AIO puppetserver package, and these configuration tweaks are needed to make the module compatible with it.

https://packages.debian.org/search?keywords=puppetserver