### PR TITLE
Stop managing services.d dir in /opt/puppetlabs

### DIFF
--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -237,15 +237,6 @@ class puppet::server::puppetserver (
     content => template('puppet/server/puppetserver/services.d/ca.cfg.erb'),
   }
 
-  unless $facts['os']['family'] == 'FreeBSD' {
-    file { '/opt/puppetlabs/server/apps/puppetserver/config':
-      ensure => directory,
-    }
-    file { '/opt/puppetlabs/server/apps/puppetserver/config/services.d':
-      ensure => directory,
-    }
-  }
-
   file { "${server_puppetserver_dir}/conf.d/ca.conf":
     ensure  => file,
     content => template('puppet/server/puppetserver/conf.d/ca.conf.erb'),

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -50,8 +50,6 @@ describe 'puppet' do
               .with_context('/files/etc/rc.conf')
           }
         else
-          it { should contain_file('/opt/puppetlabs/server/apps/puppetserver/config').with_ensure('directory') }
-          it { should contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d').with_ensure('directory') }
           it {
             should contain_augeas('puppet::server::puppetserver::bootstrap')
               .with_changes('set BOOTSTRAP_CONFIG \'"/etc/custom/puppetserver/services.d/,/opt/puppetlabs/server/apps/puppetserver/config/services.d/"\'')


### PR DESCRIPTION
This directory is ensured by the puppetserver package and since puppetserver 2.5 the directory that users are supposed to use is in /etc. This code appears tom be a leftover from when the code supported both < 2.5 and >= 2.5 in 68c2d50eac54de1e21e66a96794eca1d1d51f8af.