### PR TITLE
Respect puppet::server::additional_settings parameter

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -95,7 +95,7 @@ class puppet::server::config inherits puppet::config {
     }
   }
 
-  $puppet::server_additional_settings.each |$key,$value| {
+  $puppet::server::additional_settings.each |$key,$value| {
     puppet::config::server { $key: value => $value }
   }
 


### PR DESCRIPTION
Previously it was read from the main puppet class, instead of puppet::server (which in turn defaulted to the parameter from the main class).

Fixes #810