### PR TITLE
Include Puppet CRL update API auth

### DIFF
--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -102,6 +102,20 @@ authorization: {
             name: "puppetlabs cert status"
         },
         {
+            match-request: {
+                path: "^/puppet-ca/v1/certificate_revocation_list$"
+                type: regex
+                method: put
+            }
+            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }
+            sort-order: 500
+            name: "puppetlabs CRL update"
+        },
+        {
             # Allow the CA CLI to access the certificate_statuses endpoint
             match-request: {
                 path: "/puppet-ca/v1/certificate_statuses"


### PR DESCRIPTION
This was added to puppetserver 6.16.1 and 7.2.1 via two commits (https://github.com/puppetlabs/puppetserver/commit/22ac4e5de772f57df561dbdc46c96daf4c14397f & https://github.com/puppetlabs/puppetserver/commit/d9bf097e0c0ee8a9df54490824016da1a2f07467).