### PR TITLE
Add TLS1.3 ciphers to default server_cipher_suites

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -400,8 +400,10 @@
 #                                           Defaults to "${ssl_dir}/ca/ca_crt.pem"
 #
 # $server_cipher_suites::                   List of SSL ciphers to use in negotiation
-#                                           Defaults to [ 'TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA',
-#                                           'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA', ]
+#                                           Defaults to ['TLS_AES_128_GCM_SHA256', 'TLS_AES_256_GCM_SHA384',
+#                                           'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256', 'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+#                                           'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
+#                                           'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256', 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384']
 #
 # $server_ruby_load_paths::                 List of ruby paths
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -386,6 +386,8 @@ class puppet::params {
   $server_admin_api_whitelist             = ['localhost', $lower_fqdn]
   $server_ca_client_whitelist             = ['localhost', $lower_fqdn]
   $server_cipher_suites                   = [
+    'TLS_AES_128_GCM_SHA256',
+    'TLS_AES_256_GCM_SHA384',
     'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
     'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
     'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',


### PR DESCRIPTION
In 2835ba227d5be98d6d7118883c77e7fe9fdd8299 the default `server_ssl_protocols` was expanded to include TLS 1.3.  This had no affect for users not overriding `server_cipher_suites` though as no TLS 1.3 cipher suites were included by default.

This commit adds `TLS_AES_128_GCM_SHA256` and `TLS_AES_256_GCM_SHA384` which are both NIST approved.