### PR TITLE
Refs #36573 - Drop default value for foreman_url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -693,7 +693,7 @@ class puppet (
   Boolean $server_strict_variables = $puppet::params::server_strict_variables,
   Hash[String, Data] $server_additional_settings = $puppet::params::server_additional_settings,
   Boolean $server_foreman = $puppet::params::server_foreman,
-  Stdlib::HTTPUrl $server_foreman_url = $puppet::params::server_foreman_url,
+  Optional[Stdlib::HTTPUrl] $server_foreman_url = $puppet::params::server_foreman_url,
   Optional[Stdlib::Absolutepath] $server_foreman_ssl_ca = $puppet::params::server_foreman_ssl_ca,
   Optional[Stdlib::Absolutepath] $server_foreman_ssl_cert = $puppet::params::server_foreman_ssl_cert,
   Optional[Stdlib::Absolutepath] $server_foreman_ssl_key = $puppet::params::server_foreman_ssl_key,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -329,7 +329,7 @@ class puppet::params {
     true  => '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet',
     false => undef,
   }
-  $server_foreman_url      = "https://${lower_fqdn}"
+  $server_foreman_url      = undef
   $server_foreman_ssl_ca   = undef
   $server_foreman_ssl_cert = undef
   $server_foreman_ssl_key  = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -404,7 +404,7 @@ class puppet::server (
   Boolean $strict_variables = $puppet::server_strict_variables,
   Hash[String, Data] $additional_settings = $puppet::server_additional_settings,
   Boolean $foreman = $puppet::server_foreman,
-  Stdlib::HTTPUrl $foreman_url = $puppet::server_foreman_url,
+  Optional[Stdlib::HTTPUrl] $foreman_url = $puppet::server_foreman_url,
   Optional[Stdlib::Absolutepath] $foreman_ssl_ca = $puppet::server_foreman_ssl_ca,
   Optional[Stdlib::Absolutepath] $foreman_ssl_cert = $puppet::server_foreman_ssl_cert,
   Optional[Stdlib::Absolutepath] $foreman_ssl_key = $puppet::server_foreman_ssl_key,

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -154,15 +154,11 @@ describe 'puppet' do
         it { should contain_class('puppet::server::puppetserver') }
       end
 
-      describe 'with uppercase hostname' do
-        let(:facts) do
-          override_facts(super(),
-            networking: {fqdn: 'PUPPETSERVER.example.com'},
-          )
-        end
+      describe 'with server_foreman_url' do
+        let(:params) { super().merge(server_foreman_url: 'https://foreman.example.com') }
 
         it { should compile.with_all_deps }
-        it { should contain_class('puppet').with_server_foreman_url('https://puppetserver.example.com') }
+        it { should contain_class('puppet').with_server_foreman_url('https://foreman.example.com') }
       end
 
       describe 'with ip parameter' do


### PR DESCRIPTION
This default matches what's in theforeman/puppetserver_foreman and is not needed. Users can still override it, but the default just duplicates things.