### PR TITLE
require puppetlabs/stdlib 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.18.0 < 9.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppet/extlib",

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0 < 9.0.0"
+      "version_requirement": ">= 4.1.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -13,7 +13,7 @@ authorization: {
                 method: [get, post]
             }
 <%= scope.call_function(
-  'to_json_pretty',
+  'stdlib::to_json_pretty',
   [
     {'allow' => @server_trusted_agents + ['$1'] + @server_trusted_certificate_extensions.map { |extension| { 'extensions' => extension } } }
   ]


### PR DESCRIPTION
The `to_json_pretty()` function is deprecated. The successor is `stdlib::to_json_pretty()`.