### PR TITLE
Allow puppet/systemd 5.x and 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 2.9.0 < 5.0.0"
+      "version_requirement": ">= 2.9.0 < 7.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
5.x dropped Puppet 6 support, which we don't support anyway
6.x dropped Ubuntu 18.04 support, which we should drop soon