### PR TITLE
Allow disabling CRL checking on agent

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@ class puppet::config (
   $auth_allowed          = $puppet::auth_allowed,
   $ca_server             = $puppet::ca_server,
   $ca_port               = $puppet::ca_port,
+  $certificate_revocation = $puppet::certificate_revocation,
   $dns_alt_names         = $puppet::dns_alt_names,
   $module_repository     = $puppet::module_repository,
   $pluginsource          = $puppet::pluginsource,
@@ -38,6 +39,9 @@ class puppet::config (
   }
   if $ca_port {
     puppet::config::main { 'ca_port': value => $ca_port; }
+  }
+  if $certificate_revocation != undef {
+    puppet::config::main { 'certificate_revocation': value => $certificate_revocation; }
   }
   if $dns_alt_names and !empty($dns_alt_names) {
     puppet::config::main { 'dns_alt_names': value => $dns_alt_names; }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,9 @@
 # $ca_crl_filepath::                        Path to CA CRL file, dynamically resolves based on
 #                                           $::server_ca status.
 #
+# $certificate_revocation::                 Whether certificate revocation checking should be
+#                                           enabled, and what level of checking should be performed
+#
 # $dns_alt_names::                          Use additional DNS names when generating a
 #                                           certificate.  Defaults to an empty Array.
 #
@@ -611,6 +614,7 @@ class puppet (
   Optional[Variant[String, Boolean]] $ca_server = $puppet::params::ca_server,
   Optional[Stdlib::Port] $ca_port = $puppet::params::ca_port,
   Optional[String] $ca_crl_filepath = $puppet::params::ca_crl_filepath,
+  Optional[Variant[Boolean, Enum['chain', 'leaf']]] $certificate_revocation = $puppet::params::certificate_revocation,
   Optional[String] $prerun_command = $puppet::params::prerun_command,
   Optional[String] $postrun_command = $puppet::params::postrun_command,
   Array[String] $dns_alt_names = $puppet::params::dns_alt_names,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class puppet::params {
   $ca_server           = undef
   $ca_port             = undef
   $ca_crl_filepath     = undef
+  $certificate_revocation = undef
   $server_crl_enable   = undef
   $prerun_command      = undef
   $postrun_command     = undef

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -87,6 +87,22 @@ describe 'puppet' do
         it { should contain_puppet__config__main('ca_port').with_value(8140) }
       end
 
+      describe 'with undef certificate_revocation' do
+        let :params do {
+          :certificate_revocation => :undef,
+        } end
+
+        it { should_not contain_puppet__config__main('certificate_revocation') }
+      end
+
+      describe 'with certificate_revocation' do
+        let :params do {
+          :certificate_revocation => 'leaf',
+        } end
+
+        it { should contain_puppet__config__main('certificate_revocation').with_value('leaf') }
+      end
+
       describe 'with puppetconf_mode' do
         let :params do {
           :puppetconf_mode => '0640',


### PR DESCRIPTION
In extrernal CA configurations, it is possible that a CRL is not present on the server. This allows to tell the agent to skip downloading it and checking it.