### PR TITLE
Test puppetserver on Debian 11

### DIFF
--- a/spec/acceptance/puppetserver_upgrade_spec.rb
+++ b/spec/acceptance/puppetserver_upgrade_spec.rb
@@ -16,8 +16,8 @@ unless unsupported_puppetserver
 
     case ENV['BEAKER_PUPPET_COLLECTION']
     when 'puppet7'
-      from_version = '7.0.0'
-      to_version = '7.2.0'
+      from_version = '7.6.0'
+      to_version = '7.13.0'
     else
       raise 'Unsupported Puppet collection'
     end

--- a/spec/support/acceptance/puppetserver.rb
+++ b/spec/support/acceptance/puppetserver.rb
@@ -4,7 +4,5 @@ def unsupported_puppetserver
     true
   when 'Fedora'
     true
-  when 'Debian'
-    host_inventory['facter']['os']['release']['major'] == '11'
   end
 end


### PR DESCRIPTION
These days the package is delivered, so it should be verified.