### PR TITLE
Add option to allow unauthenticated access to metrics, and for generic additions to auth

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -563,12 +563,18 @@
 #                                           invokes when on static_file_content requests.
 #                                           Defaults to undef
 #
+# $server_jolokia_allow_unauthenticated::   Whether to allow unauthenticated access to metrics
+#                                           Defaults to false
+#
 # $server_jolokia_metrics_allowlist::       The allowlist of clients that
 #                                           can query the jolokia /metrics/v2 endpoint
 #
 # $facter_config_dir::                      Override Facter/Openfact configuration directory
 #
 # $facter_config::                          A hash representing Facter/Openfact configuration.
+#
+# $server_auth_extra::                      Additional rules for auth.conf
+#                                           Defaults to undef
 #
 # === Usage:
 #
@@ -775,6 +781,8 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_versioned_code_id = undef,
   Optional[Stdlib::Absolutepath] $server_versioned_code_content = undef,
   Array[String[1]] $server_jolokia_metrics_allowlist = [],
+  Optional[Boolean] $server_jolokia_allow_unauthenticated = undef,
+  Optional[String] $server_auth_extra = undef,
   Stdlib::Filemode $puppetconf_mode = $puppet::params::puppetconf_mode,
   Stdlib::Absolutepath $facter_config_dir = $puppet::params::facter_config_dir,
   Puppet::Facter::Config $facter_config = {},

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -342,8 +342,12 @@
 #                                      a static_file_content API request for the contents of a file resource that
 #                                      has a source attribute with a puppet:/// URI value.
 #
+# $jolokia_allow_unauthenticated::     Should we disable authentication for the metrics
+#
 # $jolokia_metrics_allowlist::         The allowlist of clients that
 #                                      can query the jolokia /metrics/v2 endpoint
+#
+# $auth_extra::                        Additional rules for the auth.conf
 class puppet::server (
   Variant[Boolean, Stdlib::Absolutepath] $autosign = $puppet::autosign,
   Array[String] $autosign_entries = $puppet::autosign_entries,
@@ -468,6 +472,8 @@ class puppet::server (
   Optional[Stdlib::Absolutepath] $versioned_code_id = $puppet::server_versioned_code_id,
   Optional[Stdlib::Absolutepath] $versioned_code_content = $puppet::server_versioned_code_content,
   Array[String[1]] $jolokia_metrics_allowlist = $puppet::server_jolokia_metrics_allowlist,
+  Optional[Boolean] $jolokia_allow_unauthenticated = $puppet::server_jolokia_allow_unauthenticated,
+  Optional[String] $auth_extra = $puppet::server_auth_extra,
 ) {
   if $ca {
     $cadir           = pick($ca_dir, "${puppetserver_dir}/ca")

--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -145,6 +145,8 @@ class puppet::server::puppetserver (
   Optional[Stdlib::Absolutepath] $versioned_code_content = $puppet::server::versioned_code_content,
   Boolean $disable_fips = $facts['os']['family'] == 'RedHat',
   Array[String[1]] $jolokia_metrics_allowlist = $puppet::server::jolokia_metrics_allowlist,
+  Optional[Boolean] $jolokia_allow_unauthenticated = $puppet::server::jolokia_allow_unauthenticated,
+  Optional[String] $auth_extra = $puppet::server::auth_extra,
 ) {
   include puppet::server
 

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -623,6 +623,33 @@ describe 'puppet' do
           it { expect(rule['allow']).to eq(['puppetserver.example.com', 'admin.example.com', {'extensions' => {'pp_cli_auth' => 'true'}}]) }
         end
       end
+
+      describe 'jolokia_allow_unauthenticated' do
+        let(:content) { catalogue.resource('file', auth_conf).send(:parameters)[:content] }
+        let(:rules) { Hocon.parse(content)['authorization']['rules'] }
+        let(:rule) { rules.find {|rule| rule['name'] == 'jolokia metrics' } }
+
+        context 'by default' do
+          it { expect(rule).to be_nil }
+        end
+
+        context 'when set' do
+          let(:params) { super().merge(server_jolokia_allow_unauthenticated: true) }
+
+          it { expect(rule['match-request']['path']).to eq('/metrics/v2') }
+          it { expect(rule['allow-unauthenticated']).to eq(true) }
+        end
+      end
+
+      describe 'auth_extra' do
+        let(:content) { catalogue.resource('file', auth_conf).send(:parameters)[:content] }
+
+        context 'when set' do
+          let(:params) { super().merge(server_auth_extra: "# test-content-string" ) }
+
+          it { should contain_file(auth_conf).with_content(%r{^# test-content-string$}) }
+        end
+      end
     end
   end
 end

--- a/templates/server/puppetserver/conf.d/auth.conf.erb
+++ b/templates/server/puppetserver/conf.d/auth.conf.erb
@@ -415,7 +415,17 @@ authorization: {
             name: "puppetlabs experimental"
         },
 <%- end -%>
-<%- unless @jolokia_metrics_allowlist.empty? -%>
+<%- if @jolokia_allow_unauthenticated -%>
+        {
+            match-request: {
+                path: "/metrics/v2"
+                type: path
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "jolokia metrics"
+        },
+<%- elsif !@jolokia_metrics_allowlist.empty? -%>
         {
             match-request: {
                 path: "/metrics/v2"
@@ -429,6 +439,9 @@ authorization: {
             sort-order: 500
             name: "jolokia metrics"
         },
+<%- end -%>
+<%- if @auth_extra -%>
+<%= @auth_extra %>
 <%- end -%>
         {
             # Deny everything else. This ACL is not strictly


### PR DESCRIPTION
**NOTE:** This is a resubmission of #849, rebased against current master branch to resolve conflicts. Fixes #850. Credits to @sshipway.

This minor change allows generic control of the auth.conf file, and permitting unauthenticated retrieval of metrics (as is required by our monitoring system)

* 2 new parameters to server class
* Usage comments added
* Spec tests added and run successfully



