### PR TITLE
Fixes #37291 - Use explicit java on RH with Puppetserver 8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -305,7 +305,7 @@
 # $server_envs_target::                     Indicates that $envs_dir should be
 #                                           a symbolic link to this target
 #
-# $server_jvm_java_bin::                    Set the default java to use.
+# $server_jvm_java_bin::                    Set the default java to use. If unspecified, it will be derived from the Puppet version.
 #
 # $server_jvm_config::                      Specify the puppetserver jvm configuration file.
 #
@@ -714,7 +714,7 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_puppet_basedir = $puppet::params::server_puppet_basedir,
   Enum['current', 'future'] $server_parser = $puppet::params::server_parser,
   Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]] $server_environment_timeout = $puppet::params::server_environment_timeout,
-  String $server_jvm_java_bin = $puppet::params::server_jvm_java_bin,
+  Optional[Stdlib::Absolutepath] $server_jvm_java_bin = undef,
   String $server_jvm_config = $puppet::params::server_jvm_config,
   Pattern[/^[0-9]+[kKmMgG]$/] $server_jvm_min_heap_size = $puppet::params::server_jvm_min_heap_size,
   Pattern[/^[0-9]+[kKmMgG]$/] $server_jvm_max_heap_size = $puppet::params::server_jvm_max_heap_size,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -350,7 +350,6 @@ class puppet::params {
     default  => '/etc/default/puppetserver',
   }
 
-  $server_jvm_java_bin   = '/usr/bin/java'
   $server_jvm_extra_args = undef
   $server_jvm_cli_args   = undef
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -420,7 +420,7 @@ class puppet::server (
   Optional[Stdlib::Absolutepath] $puppet_basedir = $puppet::server_puppet_basedir,
   Enum['current', 'future'] $parser = $puppet::server_parser,
   Variant[Undef, Enum['unlimited'], Pattern[/^\d+[smhdy]?$/]] $environment_timeout = $puppet::server_environment_timeout,
-  String $jvm_java_bin = $puppet::server_jvm_java_bin,
+  Optional[Stdlib::Absolutepath] $jvm_java_bin = $puppet::server_jvm_java_bin,
   String $jvm_config = $puppet::server_jvm_config,
   Pattern[/^[0-9]+[kKmMgG]$/] $jvm_min_heap_size = $puppet::server_jvm_min_heap_size,
   Pattern[/^[0-9]+[kKmMgG]$/] $jvm_max_heap_size = $puppet::server_jvm_max_heap_size,

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -41,6 +41,19 @@ class puppet::server::install {
       install_options => $puppet::package_install_options,
     }
 
+    # Puppetserver 8 on EL 8 relies on JRE 11 or 17. This prefers JRE 17 by installing it first
+    if (
+      !$puppet::server::jvm_java_bin and
+      $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' and
+      # This doesn't use server_version because we have 2 mechanisms to set the version
+      versioncmp(pick($puppet::server::puppetserver_version, $facts['puppetversion']), '8.0.0') >= 0
+    ) {
+      # EL 8 packaging can install either Java 17 or Java 11, but we prefer Java 17
+      stdlib::ensure_packages(['jre-17-headless'])
+
+      Package['jre-17-headless'] -> Package[$server_package]
+    }
+
     if $puppet::server::manage_user {
       Package[$server_package] -> User[$puppet::server::user]
     }

--- a/spec/acceptance/puppetserver_latest_spec.rb
+++ b/spec/acceptance/puppetserver_latest_spec.rb
@@ -25,6 +25,14 @@ describe 'Scenario: install puppetserver (latest):', unless: unsupported_puppets
     end
   end
 
+  if ENV['BEAKER_PUPPET_COLLECTION'] != 'puppet7' && fact('os.family') == 'RedHat' && ['8', '9'].include?(fact('os.release.major'))
+    describe 'JRE version' do
+      it { expect(package('java-17-openjdk-headless')).to be_installed }
+      it { expect(package('java-11-openjdk-headless')).not_to be_installed }
+      it { expect(file('/etc/sysconfig/puppetserver')).to be_file.and(have_attributes(content: include('JAVA_BIN=/usr/lib/jvm/jre-17/bin/java'))) }
+    end
+  end
+
   # This is broken on Ubuntu Focal
   # https://github.com/theforeman/puppet-puppet/issues/832
   describe 'server_max_open_files', unless: unsupported_puppetserver || fact('os.release.major') == '20.04' do

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -8,7 +8,7 @@ describe 'puppet' do
       let(:facts) do
         facts
       end
-
+      let(:java_bin) { %r{^set JAVA_BIN /usr/(lib/jvm/jre-1[17]/)?bin/java$} }
       let(:auth_conf) { '/etc/custom/puppetserver/conf.d/auth.conf' }
       let(:puppetserver_conf) { '/etc/custom/puppetserver/conf.d/puppetserver.conf' }
 
@@ -58,7 +58,7 @@ describe 'puppet' do
           if facts[:os]['family'] == 'RedHat' and facts[:os]['release']['major'] != '7'
             it {
               should contain_augeas('puppet::server::puppetserver::jvm')
-                .with_changes(['set JAVA_ARGS \'"-Xms2G -Xmx2G -Dcom.redhat.fips=false"\'', 'set JAVA_BIN /usr/bin/java'])
+                .with_changes(['set JAVA_ARGS \'"-Xms2G -Xmx2G -Dcom.redhat.fips=false"\'', java_bin])
                 .with_context('/files/etc/default/puppetserver')
                 .with_incl('/etc/default/puppetserver')
                 .with_lens('Shellvars.lns')
@@ -66,7 +66,7 @@ describe 'puppet' do
           else
             it {
               should contain_augeas('puppet::server::puppetserver::jvm')
-                .with_changes(['set JAVA_ARGS \'"-Xms2G -Xmx2G"\'', 'set JAVA_BIN /usr/bin/java'])
+                .with_changes(['set JAVA_ARGS \'"-Xms2G -Xmx2G"\'', java_bin])
                 .with_context('/files/etc/default/puppetserver')
                 .with_incl('/etc/default/puppetserver')
                 .with_lens('Shellvars.lns')
@@ -390,7 +390,7 @@ describe 'puppet' do
             should contain_augeas('puppet::server::puppetserver::jvm')
               .with_changes([
                               'set JAVA_ARGS \'"-Xms2G -Xmx2G -Dcom.redhat.fips=false -XX:foo=bar -XX:bar=foo"\'',
-                              'set JAVA_BIN /usr/bin/java'
+                              java_bin
                             ])
               .with_context('/files/etc/default/puppetserver')
               .with_incl('/etc/default/puppetserver')
@@ -401,7 +401,7 @@ describe 'puppet' do
             should contain_augeas('puppet::server::puppetserver::jvm')
               .with_changes([
                               'set JAVA_ARGS \'"-Xms2G -Xmx2G -XX:foo=bar -XX:bar=foo"\'',
-                              'set JAVA_BIN /usr/bin/java'
+                              java_bin
                             ])
               .with_context('/files/etc/default/puppetserver')
               .with_incl('/etc/default/puppetserver')
@@ -417,7 +417,7 @@ describe 'puppet' do
             should contain_augeas('puppet::server::puppetserver::jvm')
               .with_changes([
                               'set JAVA_ARGS \'"-Xms2G -Xmx2G -Dcom.redhat.fips=false"\'',
-                              'set JAVA_BIN /usr/bin/java',
+                              java_bin,
                               'set JAVA_ARGS_CLI \'"-Djava.io.tmpdir=/var/puppettmp"\''
                             ])
               .with_context('/files/etc/default/puppetserver')
@@ -429,7 +429,7 @@ describe 'puppet' do
             should contain_augeas('puppet::server::puppetserver::jvm')
               .with_changes([
                               'set JAVA_ARGS \'"-Xms2G -Xmx2G"\'',
-                              'set JAVA_BIN /usr/bin/java',
+                              java_bin,
                               'set JAVA_ARGS_CLI \'"-Djava.io.tmpdir=/var/puppettmp"\''
                             ])
               .with_context('/files/etc/default/puppetserver')


### PR DESCRIPTION
The /usr/bin/java file may point to any version. This changes the logic to determine the java version (unless explicitly specified) dynamically based on the puppetserver version and the OS.