### PR TITLE
consistently use stdlib::ensure_packages()

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -11,7 +11,7 @@ class puppet::server::install {
   }
 
   if $puppet::server::git_repo {
-    ensure_packages(['git'])
+    stdlib::ensure_packages(['git'])
   }
 
   if $puppet::server::manage_user {


### PR DESCRIPTION
In b6088261c08ddfa8d3426ba01c6b35a3d1b1d3a2 ewoud already introduced `stdlib::ensure_packages()`. There's another place that used the legacy `ensure_packages()` function. It's deprecated since stdlib 9. This commit updates the old code to also use `stdlib::ensure_packages()`