### PR TITLE
Allow to set node_terminus variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -225,6 +225,8 @@
 #
 # $server_reports::                         List of report types to include on the puppetserver
 #
+# $server_node_terminus::                   Node data plugin for catalog compiling
+#
 # $server_external_nodes::                  External nodes classifier executable
 #
 # $server_trusted_external_command::        The external trusted facts script to use.
@@ -665,6 +667,7 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_puppetserver_rundir = $puppet::params::server_puppetserver_rundir,
   Optional[Stdlib::Absolutepath] $server_puppetserver_logdir = $puppet::params::server_puppetserver_logdir,
   Optional[Pattern[/^[\d]\.[\d]+\.[\d]+$/]] $server_puppetserver_version = $puppet::params::server_puppetserver_version,
+  Enum['plain', 'exec', 'classifier'] $server_node_terminus = $puppet::params::server_node_terminus,
   Variant[Undef, String[0], Stdlib::Absolutepath] $server_external_nodes = $puppet::params::server_external_nodes,
   Optional[Stdlib::Absolutepath] $server_trusted_external_command = $puppet::params::server_trusted_external_command,
   Array[String] $server_cipher_suites = $puppet::params::server_cipher_suites,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -221,6 +221,7 @@ class puppet::params {
   $server_ca                       = true
   $server_ca_crl_sync              = false
   $server_reports                  = 'foreman'
+  $server_node_terminus            = 'exec'
   $server_external_nodes           = "${dir}/node.rb"
   $server_trusted_external_command = undef
   $server_request_timeout          = 60

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -58,6 +58,8 @@
 #
 # $reports::                           List of report types to include on the puppetserver
 #
+# $node_terminus::                     Node data plugin for catalog compiling
+#
 # $external_nodes::                    External nodes classifier executable
 #
 # $trusted_external_command::          The external trusted facts script to use.
@@ -373,6 +375,7 @@ class puppet::server (
   Optional[Stdlib::Absolutepath] $puppetserver_logdir = $puppet::server_puppetserver_logdir,
   Stdlib::Absolutepath $puppetserver_dir = $puppet::server_puppetserver_dir,
   Optional[Pattern[/^[\d]\.[\d]+\.[\d]+$/]] $puppetserver_version = $puppet::server_puppetserver_version,
+  Enum['plain', 'exec', 'classifier'] $node_terminus = $puppet::server_node_terminus,
   Variant[Undef, String[0], Stdlib::Absolutepath] $external_nodes = $puppet::server_external_nodes,
   Optional[Stdlib::Absolutepath] $trusted_external_command = $puppet::server_trusted_external_command,
   Array[String] $cipher_suites = $puppet::server_cipher_suites,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -33,6 +33,7 @@ class puppet::server::config inherits puppet::config {
   ## General configuration
   $ca_server                   = $puppet::ca_server
   $ca_port                     = $puppet::ca_port
+  $server_node_terminus        = $puppet::server::node_terminus
   $server_external_nodes       = $puppet::server::external_nodes
   $server_environment_timeout  = $puppet::server::environment_timeout
   $trusted_external_command    = $puppet::server::trusted_external_command
@@ -40,7 +41,13 @@ class puppet::server::config inherits puppet::config {
 
   if $server_external_nodes and $server_external_nodes != '' {
     class { 'puppet::server::enc':
-      enc_path => $server_external_nodes,
+      node_terminus => $server_node_terminus,
+      enc_path      => $server_external_nodes,
+    }
+  }
+  else {
+    class { 'puppet::server::enc':
+      node_terminus => $server_node_terminus,
     }
   }
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -44,8 +44,7 @@ class puppet::server::config inherits puppet::config {
       node_terminus => $server_node_terminus,
       enc_path      => $server_external_nodes,
     }
-  }
-  else {
+  } else {
     class { 'puppet::server::enc':
       node_terminus => $server_node_terminus,
     }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -39,6 +39,24 @@ class puppet::server::config inherits puppet::config {
   $trusted_external_command    = $puppet::server::trusted_external_command
   $primary_envs_dir            = $puppet::server::envs_dir[0]
 
+  case $server_node_terminus {
+    'plain': {}
+    'exec': {
+      class { 'puppet::server::enc':
+        node_terminus => $server_node_terminus,
+        enc_path      => $server_external_nodes,
+      }
+    }
+    'console': {
+      class { 'puppet::server::enc':
+        node_terminus => $server_node_terminus,
+      }
+    }
+    default: {
+      fail('Invalid value of $server_node_terminus')
+    }
+  }
+
   if $server_external_nodes and $server_external_nodes != '' {
     class { 'puppet::server::enc':
       node_terminus => $server_node_terminus,

--- a/manifests/server/enc.pp
+++ b/manifests/server/enc.pp
@@ -1,10 +1,18 @@
 # Set up the ENC config
 # @api private
 class puppet::server::enc (
-  Variant[Undef, String[0], Stdlib::Absolutepath] $enc_path = $puppet::server::external_nodes
+  Variant[Undef, String[0], Stdlib::Absolutepath] $enc_path = $puppet::server::external_nodes,
+  Enum['plain', 'exec', 'classifier'] $node_terminus = $puppet::server::node_terminus,
 ) {
-  puppet::config::server {
-    'external_nodes':     value => $enc_path;
-    'node_terminus':      value => 'exec';
+  if $enc_path and $enc_path != '' {
+    puppet::config::server {
+      'external_nodes':     value => $enc_path;
+      'node_terminus':      value => $node_terminus;
+    }
+  }
+  else {
+    puppet::config::server {
+      'node_terminus':      value => $node_terminus;
+    }
   }
 }

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -293,7 +293,19 @@ describe 'puppet' do
         end
 
         it { should_not contain_class('puppetserver_foreman') }
-        it { should_not contain_puppet__config__server('node_terminus') }
+        it { should contain_puppet__config__server('node_terminus').with_value('plain') }
+        it { should_not contain_puppet__config__server('external_nodes') }
+      end
+
+      describe 'with explicit plain terminus' do
+        let(:params) do
+          super().merge(
+            server_node_terminus: 'plain',
+            server_external_nodes: ''
+          )
+        end
+
+        it { should contain_puppet__config__server('node_terminus').with_value('plain') }
         it { should_not contain_puppet__config__server('external_nodes') }
       end
 

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -283,30 +283,41 @@ describe 'puppet' do
         it { should contain_puppet__config__main('hiera_config').with_value('/etc/puppet/hiera/production/hiera.yaml') }
       end
 
-      describe 'without foreman' do
+      describe 'without foreman, default external ENC' do
         let(:params) do
           super().merge(
             server_foreman: false,
             server_reports: 'store',
-            server_external_nodes: ''
           )
         end
 
         it { should_not contain_class('puppetserver_foreman') }
-        it { should contain_puppet__config__server('node_terminus').with_value('plain') }
-        it { should_not contain_puppet__config__server('external_nodes') }
+        it { should contain_puppet__config__server('node_terminus').with_value('exec') }
+        it { should contain_puppet__config__server('external_nodes').with_value('/etc/puppetlabs/puppet/node.rb') }
       end
 
-      describe 'with explicit plain terminus' do
+      describe 'without foreman, plain ENC' do
         let(:params) do
           super().merge(
-            server_node_terminus: 'plain',
-            server_external_nodes: ''
+            server_foreman: false,
+            server_reports: 'store',
+            node_terminus: 'plain'
           )
         end
 
-        it { should contain_puppet__config__server('node_terminus').with_value('plain') }
+        it { should_not contain_class('puppetserver_foreman') }
+        it { should_not contain_puppet__config__server('node_terminus') }
         it { should_not contain_puppet__config__server('external_nodes') }
+      end
+
+      describe 'invalid node_terminus' do
+        let(:params) do
+          super().merge(
+            server_node_terminus: 'loremIpsum',
+          )
+        end
+
+        it { should raise_error(Puppet::Error, %r{Invalid value of $server_node_terminus}) }
       end
 
       describe 'with server_default_manifest => true and undef content' do


### PR DESCRIPTION
Allow to override default value of [server]/node_terminus in puppet.conf.
Useful in case of standalone (non-Foreman) Puppet Server installs without an ENC.