### PR TITLE
puppet-lint: fix space_before_arrow

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,7 +27,7 @@ class puppet::config (
     'ssldir': value => $puppet::ssldir;
     'privatekeydir': value => '$ssldir/private_keys { group = service }';
     'hostprivkey': value => '$privatekeydir/$certname.pem { mode = 640 }';
-    'show_diff': value  => $puppet::show_diff;
+    'show_diff': value => $puppet::show_diff;
     'codedir': value => $puppet::codedir;
   }
 
@@ -92,7 +92,7 @@ class puppet::config (
   -> case $facts['os']['family'] {
     'Windows': {
       concat { "${puppet_dir}/puppet.conf":
-        mode  => $puppet::puppetconf_mode,
+        mode => $puppet::puppetconf_mode,
       }
     }
 


### PR DESCRIPTION
There was a bug in puppet-lint < 4.3 which didn't detect this previously.

https://github.com/puppetlabs/puppet-lint/commit/0e8da67124f293208928a86775bc6f07af28faa4