### PR TITLE
Add OpenVox support

### DIFF
--- a/lib/facter/puppet_flavor.rb
+++ b/lib/facter/puppet_flavor.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Facter.add('puppet_flavor') do
+  confine { Facter::Core::Execution.which('puppet') }
+  setcode do
+    output = Facter::Core::Execution.execute('puppet --help')
+    output.split[-2] if output
+  end
+end
+

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -263,22 +263,25 @@ class puppet::params {
 
   $puppet_major = regsubst($facts['puppetversion'], '^(\d+)\..*$', '\1')
 
-  if ($facts['os']['family'] =~ /(FreeBSD|DragonFly)/) {
-    $server_package = "puppetserver${puppet_major}"
+  # Add support for OpenVox. Default to puppet if nothing is installed yet
+  $puppet_flavor       = pick($facts['puppet_flavor'], 'puppet').downcase()
+  $puppetserver_flavor = regsubst("${puppet_flavor}server", 'openvox', 'openvox-')
+
+  $server_package = if ($facts['os']['family'] =~ /(FreeBSD|DragonFly)/) {
+    "${puppetserver_flavor}${puppet_major}"
   } else {
-    $server_package = undef
+    $puppetserver_flavor
   }
 
   $server_ssl_dir = $ssldir
   $server_version = undef
 
-  if $aio_package or
-  ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '12') >= 0) {
-    $client_package = ['puppet-agent']
+  $client_package = if $aio_package or ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '12') >= 0) {
+    ["${puppet_flavor}-agent"]
   } elsif ($facts['os']['family'] =~ /(FreeBSD|DragonFly)/) {
-    $client_package = ["puppet${puppet_major}"]
+    ["${puppet_flavor}${puppet_major}"]
   } else {
-    $client_package = ['puppet']
+    [$puppet_flavor]
   }
 
   # Puppet service name


### PR DESCRIPTION
This adds a fact that discovers if the Perforce or OpenVox agent is installed. If none are installed yet, we default to the Perforce package for backwards compatibility.