### PR TITLE
Drop support for puppetserver on non-systemd

### DIFF
--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -241,28 +241,19 @@ class puppet::server::puppetserver (
       undef   => 'absent',
       default => 'present',
     }
-    if $facts['service_provider'] == 'systemd' {
-      systemd::dropin_file { 'puppetserver.service-limits.conf':
-        ensure   => $ensure_max_open_files,
-        filename => 'limits.conf',
-        unit     => 'puppetserver.service',
-        content  => "[Service]\nLimitNOFILE=${max_open_files}\n",
-      }
+    systemd::dropin_file { 'puppetserver.service-limits.conf':
+      ensure   => $ensure_max_open_files,
+      filename => 'limits.conf',
+      unit     => 'puppetserver.service',
+      content  => "[Service]\nLimitNOFILE=${max_open_files}\n",
+    }
 
-      # https://github.com/puppetlabs/ezbake/pull/623
-      systemd::dropin_file { 'puppetserver.service-privatetmp.conf':
-        ensure   => present,
-        filename => 'privatetmp.conf',
-        unit     => 'puppetserver.service',
-        content  => "[Service]\nPrivateTmp=true\n",
-      }
-    } else {
-      file_line { 'puppet::server::puppetserver::max_open_files':
-        ensure => $ensure_max_open_files,
-        path   => $config,
-        line   => "ulimit -n ${max_open_files}",
-        match  => '^ulimit\ -n',
-      }
+    # https://github.com/puppetlabs/ezbake/pull/623
+    systemd::dropin_file { 'puppetserver.service-privatetmp.conf':
+      ensure   => present,
+      filename => 'privatetmp.conf',
+      unit     => 'puppetserver.service',
+      content  => "[Service]\nPrivateTmp=true\n",
     }
   }
 


### PR DESCRIPTION
Foreman doesn't support operatingsystems for puppetserver without systemd anymore, so we can remove the logic.