### PR TITLE
Feature: #947 add facter.conf management of blocklist, cache

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -3,8 +3,9 @@
 class puppet::agent {
   contain puppet::agent::install
   contain puppet::agent::config
+  contain puppet::agent::facter
   contain puppet::agent::service
 
-  Class['puppet::agent::install'] ~> Class['puppet::agent::config', 'puppet::agent::service']
-  Class['puppet::config', 'puppet::agent::config'] ~> Class['puppet::agent::service']
+  Class['puppet::agent::install'] ~> Class['puppet::agent::config', 'puppet::agent::facter', 'puppet::agent::service']
+  Class['puppet::config', 'puppet::agent::config', 'puppet::agent::facter'] ~> Class['puppet::agent::service']
 }

--- a/manifests/agent/facter.pp
+++ b/manifests/agent/facter.pp
@@ -1,0 +1,69 @@
+# Puppet agent facter configuration
+# @api private
+class puppet::agent::facter inherits puppet::config {
+  puppet::config::agent {
+    'blocklist': value => $puppet::facter_blocklist;
+    'cachelist': value => $puppet::facter_cachelist;
+    'cache_ttl': value => $puppet::cache_ttl;
+  }
+
+    if versioncmp(fact('aio_agent_version'),'7') >= 0 {
+    file { '/etc/puppetlabs/facter':
+      ensure => directory,
+    }
+
+        Hocon_setting {
+      path    => '/etc/puppetlabs/facter/facter.conf',
+      require => File['/etc/puppetlabs/facter'],
+    }
+
+
+        if $blocklist {
+      hocon_setting { 'blocklist facts group':
+        ensure  => present,
+        setting => 'fact-groups.blocked-facts',
+        value   => $blocklist,
+        type    => 'array',
+      }
+      -> hocon_setting { 'blocklist facts':
+        ensure  => present,
+        setting => 'facts.blocklist',
+        value   => ['blocked-facts'],
+        type    => 'array',
+      }
+    } else {
+      hocon_setting { 'blocklist facts group':
+        ensure  => absent,
+        setting => 'fact-groups.blocked-facts',
+      }
+      hocon_setting { 'blocklist facts':
+        ensure  => absent,
+        setting => 'facts.blocklist',
+      }
+    }
+    if $cachelist {
+      hocon_setting { 'cachelist facts group':
+        ensure  => present,
+        setting => 'fact-groups.cached-facts',
+        value   => $cachelist,
+        type    => 'array',
+      }
+      -> hocon_setting { 'cachelist facts':
+        ensure  => present,
+        setting => 'facts.ttls',
+        value   => [{'cached-facts' => $cache_ttl }],
+        type    => 'array',
+      }
+    } else {
+      hocon_setting { 'cachelist facts group':
+        ensure  => absent,
+        setting => 'fact-groups.cached-facts',
+      }
+      hocon_setting { 'cachelist facts':
+        ensure  => absent,
+        setting => 'facts.ttls',
+      }
+    }
+  }
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -188,6 +188,12 @@
 # $agent_additional_settings::              A hash of additional agent settings.
 #                                           Example: {stringify_facts => true}
 #
+# $facter_blocklist::                       A hash of facts that puppet agent will block from usage
+#
+# $facter_cachelist::                       A hash of facts that puppet agent will cache
+#
+# $cache_ttl::                              puppet agent fact time to live
+#
 # $client_certname::                        The node's certificate name, and the unique
 #                                           identifier it uses when requesting catalogs.
 #
@@ -616,6 +622,9 @@ class puppet (
   Integer[0] $systemd_randomizeddelaysec = $puppet::params::systemd_randomizeddelaysec,
   Boolean $agent_noop = $puppet::params::agent_noop,
   Boolean $agent_default_schedules = $puppet::params::agent_default_schedules,
+  Optional[Array[String]] $facter_blocklist = undef,
+  Optional[Array[String]] $facter_cachelist = undef,
+  String $cache_ttl = '1 day',
   Boolean $show_diff = $puppet::params::show_diff,
   Optional[Stdlib::HTTPUrl] $module_repository = $puppet::params::module_repository,
   Optional[Integer[0]] $http_connect_timeout = $puppet::params::http_connect_timeout,


### PR DESCRIPTION
adds the ability to manage facter blocklist and cache list for puppet agent by.
%99.99 of this work is credited to @jay7x Yury Bushmelev