### PR TITLE
Manage agent environment based on param

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -6,12 +6,14 @@ class puppet::agent::config inherits puppet::config {
     'default_schedules': value => $puppet::agent_default_schedules;
     'report':            value => $puppet::report;
     'masterport':        value => $puppet::agent_server_port;
-    'environment':       value => $puppet::environment;
     'splay':             value => $puppet::splay;
     'splaylimit':        value => $puppet::splaylimit;
     'runinterval':       value => $puppet::runinterval;
     'noop':              value => $puppet::agent_noop;
     'usecacheonfailure': value => $puppet::usecacheonfailure;
+  }
+  if $puppet::agent_manage_environment {
+    puppet::config::agent { 'environment': value => $puppet::environment }
   }
   if $puppet::http_connect_timeout != undef {
     puppet::config::agent {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -185,6 +185,8 @@
 #
 # $agent_default_schedules::                A boolean to enable/disable the default schedules
 #
+# $agent_manage_environment::               A boolean to enable/disable managing the agent environment
+#
 # $agent_additional_settings::              A hash of additional agent settings.
 #                                           Example: {stringify_facts => true}
 #
@@ -616,6 +618,7 @@ class puppet (
   Integer[0] $systemd_randomizeddelaysec = $puppet::params::systemd_randomizeddelaysec,
   Boolean $agent_noop = $puppet::params::agent_noop,
   Boolean $agent_default_schedules = $puppet::params::agent_default_schedules,
+  Boolean $agent_manage_environment = $puppet::params::agent_manage_environment,
   Boolean $show_diff = $puppet::params::show_diff,
   Optional[Stdlib::HTTPUrl] $module_repository = $puppet::params::module_repository,
   Optional[Integer[0]] $http_connect_timeout = $puppet::params::http_connect_timeout,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,7 @@ class puppet::params {
   $dns_alt_names       = []
   $use_srv_records     = false
   $agent_default_schedules = false
+  $agent_manage_environment = true
 
   $srv_domain = fact('networking.domain')
 

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -399,6 +399,14 @@ describe 'puppet' do
 
         it { is_expected.to contain_puppet__config__agent('report').with_value('false') }
       end
+
+      context 'with agent_manage_environment false' do
+        let(:params) { { agent_manage_environment: false } }
+
+        it do
+          is_expected.not_to contain_puppet__config__agent('environment')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Only set the agent environment if `agent_manage_environment` is true

Fixes https://github.com/theforeman/puppet-puppet/issues/593
