### PR TITLE
Allow overriding hostprivkey

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ class puppet::config (
   $use_srv_records       = $puppet::use_srv_records,
   $additional_settings   = $puppet::additional_settings,
   $client_certname       = $puppet::client_certname,
+  $hostprivkey           = $puppet::hostprivkey,
   # lint:endignore
 ) {
   puppet::config::main {
@@ -26,7 +27,6 @@ class puppet::config (
     'rundir': value => $puppet::rundir;
     'ssldir': value => $puppet::ssldir;
     'privatekeydir': value => '$ssldir/private_keys { group = service }';
-    'hostprivkey': value => '$privatekeydir/$certname.pem { mode = 640 }';
     'show_diff': value => $puppet::show_diff;
     'codedir': value => $puppet::codedir;
   }
@@ -71,6 +71,15 @@ class puppet::config (
   if $client_certname {
     puppet::config::main {
       'certname': value => $client_certname;
+    }
+  }
+  if $hostprivkey {
+    puppet::config::main {
+      'hostprivkey': value => $hostprivkey;
+    }
+  } else {
+    puppet::config::main {
+      'hostprivkey': value => '$privatekeydir/$certname.pem { mode = 640 }';
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -626,6 +626,7 @@ class puppet (
   Optional[Variant[Boolean, Enum['chain', 'leaf']]] $certificate_revocation = $puppet::params::certificate_revocation,
   Optional[String] $prerun_command = $puppet::params::prerun_command,
   Optional[String] $postrun_command = $puppet::params::postrun_command,
+  String $hostprivkey = $puppet::params::hostprivkey,
   Array[String] $dns_alt_names = $puppet::params::dns_alt_names,
   Boolean $use_srv_records = $puppet::params::use_srv_records,
   Optional[String] $srv_domain = $puppet::params::srv_domain,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class puppet::params {
   $prerun_command      = undef
   $postrun_command     = undef
   $server_compile_mode = undef
+  $hostprivkey         = undef
   $dns_alt_names       = []
   $use_srv_records     = false
   $agent_default_schedules = false

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -163,6 +163,14 @@ describe 'puppet' do
         end
       end
 
+      describe 'with custom hostprivkey set' do
+        let :params do
+          super().merge(hostprivkey: 'hostprivkey = $privatekeydir/$certname.pem { mode = 660 }'])
+        end
+
+        it { is_expected.to contain_puppet__config__main('hostprivkey').with_value('$privatekeydir/$certname.pem { mode = 660 }') }
+      end
+
       describe 'with additional settings' do
         let :params do
           super().merge(additional_settings: { disable_warnings: 'deprecations' })


### PR DESCRIPTION
Allow overriding hostprivkey, so that permissions on the private key are not overridden if needed.