### PR TITLE
puppet::server::puppetdb: Fix puppet-strings documentation

### DIFF
--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -5,7 +5,7 @@
 #
 # Note that this doesn't manage the server itself.
 #
-# @example
+# @example simple PuppetDB Setup
 #   class { 'puppet':
 #     server              => true,
 #     server_reports      => 'puppetdb,foreman',


### PR DESCRIPTION
Each example needs a title, otherwise the REFERENCE.md is a bit broken