### PR TITLE
puppetserver: Dont set PrivateTmp anymore

### DIFF
--- a/manifests/server/puppetserver.pp
+++ b/manifests/server/puppetserver.pp
@@ -237,8 +237,13 @@ class puppet::server::puppetserver (
       }
 
       # https://github.com/puppetlabs/ezbake/pull/623
+      # openvox-server 8.12 sets PrivateTmp automatically
+      $ensure_private_tmp = $server_facts['serverimplementation'] ? {
+        'openvox' => 'absent',
+        default   => 'present',
+      }
       systemd::dropin_file { 'puppetserver.service-privatetmp.conf':
-        ensure   => present,
+        ensure   => $ensure_private_tmp,
         filename => 'privatetmp.conf',
         unit     => 'puppetserver.service',
         content  => "[Service]\nPrivateTmp=true\n",

--- a/spec/classes/puppet_server_puppetserver_spec.rb
+++ b/spec/classes/puppet_server_puppetserver_spec.rb
@@ -381,6 +381,20 @@ describe 'puppet' do
         end
       end
 
+      describe 'PrivateTmp' do
+        context 'on Non-systemd OSes', if facts[:service_provider] != 'systemd' do
+          it { is_expected.not_to contain contain_systemd__dropin_file('puppetserver.service-privatetmp.conf') }
+        end
+        context 'on legacy puppetserver' do
+          pending("rspec-puppet does not allow us to set $server_facts['serverimplementation']")
+          it { is_expected.to contain contain_systemd__dropin_file('puppetserver.service-privatetmp.conf').with_ensure('present') }
+        end
+        context 'on openvox' do
+          pending("rspec-puppet does not allow us to set $server_facts['serverimplementation']")
+          it { is_expected.to contain contain_systemd__dropin_file('puppetserver.service-privatetmp.conf').with_ensure('absent') }
+        end
+      end
+
       describe 'with extra_args parameter' do
         let(:params) { super().merge(server_jvm_extra_args: ['-XX:foo=bar', '-XX:bar=foo']) }
         if facts[:os]['family'] == 'FreeBSD'


### PR DESCRIPTION
Since the openvox-server 8.12 release, the provided unit file already sets PrivateTmp=true.