### PR TITLE
Revert "Allow any Boolean for no-custom-facts and no-ruby"

### DIFF
--- a/types/facter/config/global.pp
+++ b/types/facter/config/global.pp
@@ -7,6 +7,6 @@ type Puppet::Facter::Config::Global = Struct[{
     Optional['external-dir']      => Array[Stdlib::Absolutepath],
     Optional['custom-dir']        => Array[Stdlib::Absolutepath],
     Optional['no-external-facts'] => Boolean,
-    Optional['no-custom-facts']   => Boolean, # Should be Boolean[false], as it cannot be true, but that breaks kafo
-    Optional['no-ruby']           => Boolean, # Should be Boolean[false], as it cannot be true, but that breaks kafo
+    Optional['no-custom-facts']   => Boolean[false], # Cannot be true
+    Optional['no-ruby']           => Boolean[false], # Cannot be true
 }]


### PR DESCRIPTION
This reverts commit 7015fcdb8ccb6d67b5fa66ae45ed2f72e375effb as kafo now can parse `Boolean[false]`