### PR TITLE
Do not restart agent service on package changes

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -10,6 +10,6 @@ class puppet::agent {
     Class['puppet::agent::install'] -> Class['puppet::agent::facter']
   }
 
-  Class['puppet::agent::install'] ~> Class['puppet::agent::config', 'puppet::agent::service']
+  Class['puppet::agent::install'] -> Class['puppet::agent::config', 'puppet::agent::service']
   Class['puppet::config', 'puppet::agent::config'] ~> Class['puppet::agent::service']
 }

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -57,7 +57,7 @@ describe 'puppet' do
             .with_package_version('present')
             .with_package_provider(package_provider)
             .with_package_source(nil)
-            .that_notifies(['Class[puppet::agent::config]', 'Class[puppet::agent::service]'])
+            .that_comes_before(['Class[puppet::agent::config]', 'Class[puppet::agent::service]'])
         end
 
         it do


### PR DESCRIPTION
Change the relationship between puppet::agent::install and puppet::agent::config/puppet::agent::service from notification (~>) to ordering-only (->). The notification caused a reload-or-restart of the agent service immediately after a package upgrade, which killed the newly started service and left it in a failed state.

When upgrading the openvox-agent package (e.g. 8.23.1 → 8.24.1 or later), the following race condition occurs:

1. The running puppet agent (PID A) applies the package resource, spawning apt-get/dpkg as child processes.

2. The package's postinst script calls systemctl try-restart puppet. systemd stops the service and sends SIGTERM to the main service PID.

3. PID A and its children (apt-get, dpkg) survive as orphan processes in the cgroup because they are child processes, not the main PID tracked by systemd.

4. The postinst script starts a new puppet service (PID B). The service is now healthy.

5. The orphaned PID A finishes the package resource and, due to the ~> (notification) relationship, triggers reload-or-restart on the puppet service. This sends SIGHUP to PID B — the service that was just started in step 4.

6. PID B exits, the service enters the dead state, and no puppet agent is running.

Changing ~> to -> between puppet::agent::install and puppet::agent::service preserves ordering but removes the redundant notification. The package postinst already handles the service restart during upgrades.