### PR TITLE
Switch puppetdb->openvoxdb module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,7 @@ fixtures:
     extlib:               'https://github.com/voxpupuli/puppet-extlib.git'
     git:                  'https://github.com/theforeman/puppet-git.git'
     inifile:              'https://github.com/puppetlabs/puppetlabs-inifile.git'
-    puppetdb:             'https://github.com/puppetlabs/puppetlabs-puppetdb.git'
+    openvoxdb:            'https://github.com/voxpupuli/puppet-openvoxdb.git'
     puppetserver_foreman: 'https://github.com/theforeman/puppet-puppetserver_foreman.git'
     stdlib:               'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     systemd:              'https://github.com/voxpupuli/puppet-systemd.git'

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Then the `foreman_ssl_{ca,cert,key}` parameters are ignored and `certs::puppet` 
 
 ## PuppetDB integration
 
-The Puppet server can be configured to export catalogs and reports to a PuppetDB instance, using the puppetlabs/puppetdb module.
-Use its `puppetdb::server` class to install the PuppetDB server and this module to configure the Puppet server to connect to PuppetDB.
+The OpenVox-Server can be configured to export catalogs and reports to a OpenVoxDB instance, using the [puppet/openboxdb](https://forge.puppet.com/modules/puppet/openvoxdb/readme) module.
+Use its `openvoxdb::server` class to install the OpenVoxDB server and this module to configure the OpenVox-Server to connect to OpenVoxDB.
 
-Requires [puppetlabs/puppetdb](https://forge.puppetlabs.com/puppetlabs/puppetdb)
+**OpenVoxDB is the Open-Source PuppetDB successor, so some places still reference puppetdb**
 
 ```puppet
 class { 'puppet':
@@ -72,9 +72,9 @@ class { 'puppet::server::puppetdb':
 }
 ```
 
-Above example manages Puppetserver + PuppetDB integration.
-It won't install the PuppetDB.
-To do so, you also need the `puppetdb` class
+Above example manages Puppetserver + OpenVoxDB integration.
+It won't install the OpenVoxDB.
+To do so, you also need the `openvoxdb` module
 
 ```puppet
 class { 'puppet':
@@ -82,13 +82,13 @@ class { 'puppet':
   server_reports      => 'puppetdb,foreman',
   server_storeconfigs => true,
 }
-include puppetdb
+include openvoxdb
 class { 'puppet::server::puppetdb':
-  server => 'mypuppetdb.example.com',
+  server => 'myopenvoxdb.example.com',
 }
 ```
 
-Then the PuppetDB module will also configure postgresql and setup the database.
+Then the OpenVoxDB module will also configure postgresql and setup the database.
 If you want to manage postgresql installation on your own:
 
 ```puppet
@@ -106,11 +106,11 @@ postgresql::server::extension { 'pg_trgm':
   require  => Postgresql::Server::Db['puppetdb'],
   before   => Service['puppetdb'],
 }
-class { 'puppetdb':
+class { 'openvoxdb':
   manage_dbserver => false,
 }
 class { 'puppet::server::puppetdb':
-  server => 'mypuppetdb.example.com',
+  server => 'myopenvoxdb.example.com',
 }
 ```
 
@@ -118,11 +118,11 @@ Above code will install Puppetserver/PuppetDB/PostgreSQL on a single server.
 It will use the upstream postgresql repositories.
 It was tested on Ubuntu.
 
-Please also make sure your puppetdb ciphers are compatible with your puppet server ciphers, ie that the two following parameters match:
+Please also make sure your OpenVoxDB ciphers are compatible with your puppet server ciphers, ie that the two following parameters match:
 
 ```
 puppet::server::cipher_suites
-puppetdb::server::cipher_suites
+openvoxdb::server::cipher_suites
 ```
 
 By default, the Perforce packages are used.

--- a/manifests/server/puppetdb.pp
+++ b/manifests/server/puppetdb.pp
@@ -1,7 +1,7 @@
 # @summary PuppetDB integration
 #
-# This class relies on the puppetlabs/puppetdb and essentially wraps
-# puppetdb::master::config with the proper resource chaining.
+# This class relies on the puppet/openvoxdb and essentially wraps
+# openvoxdb::master::config with the proper resource chaining.
 #
 # Note that this doesn't manage the server itself.
 #
@@ -33,7 +33,7 @@ class puppet::server::puppetdb (
   Boolean $soft_write_failure = false,
   Optional[String[1]] $terminus_package = undef,
 ) {
-  class { 'puppetdb::master::config':
+  class { 'openvoxdb::master::config':
     puppetdb_server             => $server,
     puppetdb_port               => $port,
     puppetdb_soft_write_failure => $soft_write_failure,
@@ -41,5 +41,5 @@ class puppet::server::puppetdb (
     restart_puppet              => false,
     terminus_package            => $terminus_package,
   }
-  Class['puppetdb::master::puppetdb_conf'] ~> Class['puppet::server::service']
+  Class['openvoxdb::master::puppetdb_conf'] ~> Class['puppet::server::service']
 }

--- a/spec/classes/puppet_server_puppetdb_spec.rb
+++ b/spec/classes/puppet_server_puppetdb_spec.rb
@@ -17,8 +17,8 @@ describe 'puppet::server::puppetdb' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_puppet__config__server('storeconfigs').with_value(true) }
-      it 'configures PuppetDB' do
-        is_expected.to contain_class('puppetdb::master::config')
+      it 'configures OpenVoxDB' do
+        is_expected.to contain_class('openvoxdb::master::config')
           .with_puppetdb_server('mypuppetdb.example.com')
           .with_puppetdb_port(8081)
           .with_puppetdb_soft_write_failure(false)


### PR DESCRIPTION
Vox Pupuli provides their own module to manage openvoxdb. Also openvox-server has the privatetmp setting that was explicitly configred.

---

This is still work in progress and we need to figure out a migration path.