### PR TITLE
Gemfile: Add Ruby 3.4 support & update gems

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,4 @@
 ---
-.github/workflows/ci.yml:
-  pidfile_workaround: true
 Gemfile:
   extra:
     - gem: hocon

--- a/Gemfile
+++ b/Gemfile
@@ -7,13 +7,12 @@ gem 'puppet', ENV.fetch('PUPPET_GEM_VERSION', '>= 8'), groups: ['development', '
 gem 'rake'
 
 gem 'kafo_module_lint', {"groups"=>["test"]}
-gem 'puppet-lint-spaceship_operator_without_tag-check', '~> 1.0', {"groups"=>["test"]}
-gem 'voxpupuli-test', '~> 9.0', {"groups"=>["test"]}
+gem 'puppet-lint-spaceship_operator_without_tag-check', '~> 2.0', {"groups"=>["test"]}
+gem 'voxpupuli-test', '~> 14.0', {"groups"=>["test"]}
 gem 'github_changelog_generator', '>= 1.15.0', {"groups"=>["development"]}
-gem 'puppet_metadata', '~> 5.3'
+gem 'puppet_metadata', '~> 6.2'
 gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
 gem 'voxpupuli-acceptance', '~> 4.1', {"groups"=>["system_tests"]}
-gem 'puppetlabs_spec_helper', {"groups"=>["system_tests"]}
 gem 'hocon'
 
 # vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ begin
 rescue LoadError
 else
   # We use fixtures in our modules, which is not the default
-  task :beaker => 'spec_prep'
+  task :beaker => 'fixtures:prep'
 end
 
 # blacksmith isn't always present, e.g. on Travis with --without development

--- a/manifests/agent/service/cron.pp
+++ b/manifests/agent/service/cron.pp
@@ -3,7 +3,7 @@
 class puppet::agent::service::cron (
   Boolean                 $enabled                             = false,
   Optional[Integer[0,23]] $hour                                = undef,
-  Variant[Integer[0,59], Array[Integer[0,59]], Undef] $minute  = undef,
+  Optional[Variant[Integer[0,59], Array[Integer[0,59]]]] $minute  = undef,
 ) {
   unless $puppet::runmode == 'unmanaged' or 'cron' in $puppet::unavailable_runmodes {
     if $enabled {

--- a/manifests/agent/service/systemd.pp
+++ b/manifests/agent/service/systemd.pp
@@ -3,7 +3,7 @@
 class puppet::agent::service::systemd (
   Boolean                 $enabled                             = false,
   Optional[Integer[0,23]] $hour                                = undef,
-  Variant[Integer[0,59], Array[Integer[0,59]], Undef] $minute  = undef,
+  Optional[Variant[Integer[0,59], Array[Integer[0,59]]]] $minute = undef,
   Optional[String[1]] $timezone                                = undef,
 ) {
   unless $puppet::runmode == 'unmanaged' or 'systemd.timer' in $puppet::unavailable_runmodes {

--- a/manifests/config/entry.pp
+++ b/manifests/config/entry.pp
@@ -29,14 +29,14 @@ define puppet::config::entry (
   # note the spaces at he end of the 'order' parameters,
   # they make sure that '1_main ' is ordered before '1_main_*'
   ensure_resource('concat::fragment', "puppet.conf_${section}", {
-      target  => "${puppet::dir}/puppet.conf",
-      content => "\n[${section}]",
-      order   => "${sectionorder}_${section} ",
+    target  => "${puppet::dir}/puppet.conf",
+    content => "\n[${section}]",
+    order   => "${sectionorder}_${section} ",
   })
   ensure_resource('concat::fragment', "puppet.conf_${section}_end", {
-      target  => "${puppet::dir}/puppet.conf",
-      content => "\n",
-      order   => "${sectionorder}_${section}~end",
+    target  => "${puppet::dir}/puppet.conf",
+    content => "\n",
+    order   => "${sectionorder}_${section}~end",
   })
 
   # this adds the '$key =' for the first value,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -618,7 +618,7 @@ class puppet (
   Boolean $usecacheonfailure = $puppet::params::usecacheonfailure,
   Enum['cron', 'service', 'systemd.timer', 'none', 'unmanaged'] $runmode = $puppet::params::runmode,
   Optional[Integer[0,23]] $run_hour = undef,
-  Variant[Integer[0,59], Array[Integer[0,59]], Undef] $run_minute = undef,
+  Optional[Variant[Integer[0,59], Array[Integer[0,59]]]] $run_minute = undef,
   Optional[String[1]] $run_timezone = undef,
   Array[Enum['cron', 'service', 'systemd.timer', 'none']] $unavailable_runmodes = $puppet::params::unavailable_runmodes,
   Optional[String] $cron_cmd = $puppet::params::cron_cmd,

--- a/types/facter/config.pp
+++ b/types/facter/config.pp
@@ -1,7 +1,7 @@
 # @summary Facter configuration type
 type Puppet::Facter::Config = Struct[{
-    Optional['facts']       => Puppet::Facter::Config::Facts,
-    Optional['global']      => Puppet::Facter::Config::Global,
-    Optional['cli']         => Puppet::Facter::Config::CLI,
-    Optional['fact-groups'] => Hash[String[1], Array[String[1]]],
+  Optional['facts']       => Puppet::Facter::Config::Facts,
+  Optional['global']      => Puppet::Facter::Config::Global,
+  Optional['cli']         => Puppet::Facter::Config::CLI,
+  Optional['fact-groups'] => Hash[String[1], Array[String[1]]],
 }]

--- a/types/facter/config/cli.pp
+++ b/types/facter/config/cli.pp
@@ -2,8 +2,8 @@
 #
 # @note All these settings are ignored when called from the Ruby API (by Puppet/OpenVox)
 type Puppet::Facter::Config::CLI = Struct[{
-    Optional['debug']     => Boolean,
-    Optional['trace']     => Boolean,
-    Optional['verbose']   => Boolean,
-    Optional['log-level'] => Enum['none','trace','debug','info','warn','error','fatal'],
+  Optional['debug']     => Boolean,
+  Optional['trace']     => Boolean,
+  Optional['verbose']   => Boolean,
+  Optional['log-level'] => Enum['none','trace','debug','info','warn','error','fatal'],
 }]

--- a/types/facter/config/facts.pp
+++ b/types/facter/config/facts.pp
@@ -1,5 +1,5 @@
 # @summary Facter `facts` configuration type
 type Puppet::Facter::Config::Facts = Struct[{
-    Optional['blocklist'] => Array[String[1]],
-    Optional['ttls'] => Array[Hash[String[1], Puppet::Facter::Config::TTL]],
+  Optional['blocklist'] => Array[String[1]],
+  Optional['ttls'] => Array[Hash[String[1], Puppet::Facter::Config::TTL]],
 }]

--- a/types/facter/config/global.pp
+++ b/types/facter/config/global.pp
@@ -4,9 +4,9 @@
 #   * `no-custom-facts`
 #   * `no-ruby`
 type Puppet::Facter::Config::Global = Struct[{
-    Optional['external-dir']      => Array[Stdlib::Absolutepath],
-    Optional['custom-dir']        => Array[Stdlib::Absolutepath],
-    Optional['no-external-facts'] => Boolean,
-    Optional['no-custom-facts']   => Boolean[false], # Cannot be true
-    Optional['no-ruby']           => Boolean[false], # Cannot be true
+  Optional['external-dir']      => Array[Stdlib::Absolutepath],
+  Optional['custom-dir']        => Array[Stdlib::Absolutepath],
+  Optional['no-external-facts'] => Boolean,
+  Optional['no-custom-facts']   => Boolean[false], # Cannot be true
+  Optional['no-ruby']           => Boolean[false], # Cannot be true
 }]


### PR DESCRIPTION
The older versions were only working on Ruby 3.2. That made it challenging to run the tests locally on a modern operating system. This PR updates all dependencies and aligns them with the Vox Pupuli setup.