### PR TITLE
CI: update beaker.yml@v3->beaker.yml@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ concurrency:
 jobs:
   puppet:
     name: Puppet
-    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v4
     with:
-      pidfile_workaround: 'true'
       rubocop: false


### PR DESCRIPTION
newer puppet_metadata version don't have the pidfile parameter anymore. In order to update puppet_metadata, we need to update the CI first. This was already fixed in modulesync but not rolled out: https://github.com/theforeman/foreman-installer-modulesync/pull/174