### PR TITLE
feat(agent::service::cron): add environment parameter

### DIFF
--- a/manifests/agent/service/cron.pp
+++ b/manifests/agent/service/cron.pp
@@ -4,6 +4,7 @@ class puppet::agent::service::cron (
   Boolean                 $enabled                             = false,
   Optional[Integer[0,23]] $hour                                = undef,
   Variant[Integer[0,59], Array[Integer[0,59]], Undef] $minute  = undef,
+  Optional[Array[String]] $environment                         = undef,
 ) {
   unless $puppet::runmode == 'unmanaged' or 'cron' in $puppet::unavailable_runmodes {
     if $enabled {
@@ -14,10 +15,11 @@ class puppet::agent::service::cron (
       $_minute = pick($minute, $times[1])
 
       cron { 'puppet':
-        command => $command,
-        user    => root,
-        hour    => $_hour,
-        minute  => $_minute,
+        command     => $command,
+        user        => root,
+        hour        => $_hour,
+        minute      => $_minute,
+        environment => $environment,
       }
     } else {
       cron { 'puppet':


### PR DESCRIPTION
Allow setting environment variables (e.g. PATH, PERL5LIB) for the puppet agent cron job via the puppet::agent::service::cron::environment hiera key.