### PR TITLE
feat: allow to set node_terminus variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -233,6 +233,8 @@
 #
 # $server_reports::                         List of report types to include on the puppetserver
 #
+# $server_node_terminus::                   Node data plugin for catalog compiling
+#
 # $server_external_nodes::                  External nodes classifier executable
 #
 # $server_trusted_external_command::        The external trusted facts script to use.
@@ -683,6 +685,7 @@ class puppet (
   Optional[Stdlib::Absolutepath] $server_puppetserver_rundir = $puppet::params::server_puppetserver_rundir,
   Optional[Stdlib::Absolutepath] $server_puppetserver_logdir = $puppet::params::server_puppetserver_logdir,
   Optional[Pattern[/^[\d]\.[\d]+\.[\d]+$/]] $server_puppetserver_version = $puppet::params::server_puppetserver_version,
+  Enum['plain', 'exec', 'classifier'] $server_node_terminus = $puppet::params::server_node_terminus,
   Variant[Undef, String[0], Stdlib::Absolutepath] $server_external_nodes = $puppet::params::server_external_nodes,
   Optional[Stdlib::Absolutepath] $server_trusted_external_command = $puppet::params::server_trusted_external_command,
   Array[String] $server_cipher_suites = $puppet::params::server_cipher_suites,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -220,6 +220,7 @@ class puppet::params {
   $server_ca                       = true
   $server_ca_crl_sync              = false
   $server_reports                  = 'foreman'
+  $server_node_terminus            = 'exec'
   $server_external_nodes           = "${dir}/node.rb"
   $server_trusted_external_command = undef
   $server_request_timeout          = 60

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -58,6 +58,8 @@
 #
 # $reports::                           List of report types to include on the puppetserver
 #
+# $node_terminus::                     Node data plugin for catalog compiling
+#
 # $external_nodes::                    External nodes classifier executable
 #
 # $trusted_external_command::          The external trusted facts script to use.
@@ -376,6 +378,7 @@ class puppet::server (
   Stdlib::Absolutepath $puppetserver_dir = $puppet::server_puppetserver_dir,
   Optional[Stdlib::Absolutepath] $ca_dir = $puppet::server_ca_dir,
   Optional[Pattern[/^[\d]\.[\d]+\.[\d]+$/]] $puppetserver_version = $puppet::server_puppetserver_version,
+  Enum['plain', 'exec', 'classifier'] $node_terminus = $puppet::server_node_terminus,
   Variant[Undef, String[0], Stdlib::Absolutepath] $external_nodes = $puppet::server_external_nodes,
   Optional[Stdlib::Absolutepath] $trusted_external_command = $puppet::server_trusted_external_command,
   Array[String] $cipher_suites = $puppet::server_cipher_suites,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -33,6 +33,7 @@ class puppet::server::config inherits puppet::config {
   ## General configuration
   $ca_server                   = $puppet::ca_server
   $ca_port                     = $puppet::ca_port
+  $server_node_terminus        = $puppet::server::node_terminus
   $server_external_nodes       = $puppet::server::external_nodes
   $server_environment_timeout  = $puppet::server::environment_timeout
   $trusted_external_command    = $puppet::server::trusted_external_command
@@ -40,7 +41,13 @@ class puppet::server::config inherits puppet::config {
 
   if $server_external_nodes and $server_external_nodes != '' {
     class { 'puppet::server::enc':
-      enc_path => $server_external_nodes,
+      node_terminus => $server_node_terminus,
+      enc_path      => $server_external_nodes,
+    }
+  }
+  else {
+    class { 'puppet::server::enc':
+      node_terminus => $server_node_terminus,
     }
   }
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -44,8 +44,7 @@ class puppet::server::config inherits puppet::config {
       node_terminus => $server_node_terminus,
       enc_path      => $server_external_nodes,
     }
-  }
-  else {
+  } else {
     class { 'puppet::server::enc':
       node_terminus => $server_node_terminus,
     }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -39,6 +39,24 @@ class puppet::server::config inherits puppet::config {
   $trusted_external_command    = $puppet::server::trusted_external_command
   $primary_envs_dir            = $puppet::server::envs_dir[0]
 
+  case $server_node_terminus {
+    'plain': {}
+    'exec': {
+      class { 'puppet::server::enc':
+        node_terminus => $server_node_terminus,
+        enc_path      => $server_external_nodes,
+      }
+    }
+    'console': {
+      class { 'puppet::server::enc':
+        node_terminus => $server_node_terminus,
+      }
+    }
+    default: {
+      fail('Invalid value of $server_node_terminus')
+    }
+  }
+
   if $server_external_nodes and $server_external_nodes != '' {
     class { 'puppet::server::enc':
       node_terminus => $server_node_terminus,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -47,7 +47,7 @@ class puppet::server::config inherits puppet::config {
         enc_path      => $server_external_nodes,
       }
     }
-    'console': {
+    'console', 'classifier': {
       class { 'puppet::server::enc':
         node_terminus => 'classifier',
       }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -49,22 +49,11 @@ class puppet::server::config inherits puppet::config {
     }
     'console': {
       class { 'puppet::server::enc':
-        node_terminus => $server_node_terminus,
+        node_terminus => 'classifier',
       }
     }
     default: {
       fail('Invalid value of $server_node_terminus')
-    }
-  }
-
-  if $server_external_nodes and $server_external_nodes != '' {
-    class { 'puppet::server::enc':
-      node_terminus => $server_node_terminus,
-      enc_path      => $server_external_nodes,
-    }
-  } else {
-    class { 'puppet::server::enc':
-      node_terminus => $server_node_terminus,
     }
   }
 

--- a/manifests/server/enc.pp
+++ b/manifests/server/enc.pp
@@ -1,10 +1,18 @@
 # Set up the ENC config
 # @api private
 class puppet::server::enc (
-  Variant[Undef, String[0], Stdlib::Absolutepath] $enc_path = $puppet::server::external_nodes
+  Variant[Undef, String[0], Stdlib::Absolutepath] $enc_path = $puppet::server::external_nodes,
+  Enum['plain', 'exec', 'classifier'] $node_terminus = $puppet::server::node_terminus,
 ) {
-  puppet::config::server {
-    'external_nodes':     value => $enc_path;
-    'node_terminus':      value => 'exec';
+  if $enc_path and $enc_path != '' {
+    puppet::config::server {
+      'external_nodes':     value => $enc_path;
+      'node_terminus':      value => $node_terminus;
+    }
+  }
+  else {
+    puppet::config::server {
+      'node_terminus':      value => $node_terminus;
+    }
   }
 }

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -295,7 +295,19 @@ describe 'puppet' do
         end
 
         it { should_not contain_class('puppetserver_foreman') }
-        it { should_not contain_puppet__config__server('node_terminus') }
+        it { should contain_puppet__config__server('node_terminus').with_value('plain') }
+        it { should_not contain_puppet__config__server('external_nodes') }
+      end
+
+      describe 'with explicit plain terminus' do
+        let(:params) do
+          super().merge(
+            server_node_terminus: 'plain',
+            server_external_nodes: ''
+          )
+        end
+
+        it { should contain_puppet__config__server('node_terminus').with_value('plain') }
         it { should_not contain_puppet__config__server('external_nodes') }
       end
 

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -295,7 +295,7 @@ describe 'puppet' do
 
         it { should_not contain_class('puppetserver_foreman') }
         it { should contain_puppet__config__server('node_terminus').with_value('exec') }
-        it { should contain_puppet__config__server('external_nodes').with_value('/etc/puppetlabs/puppet/node.rb') }
+        it { should contain_puppet__config__server('external_nodes').with_value("#{etcdir}\/node.rb") }
       end
 
       describe 'without foreman, plain ENC' do

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -303,7 +303,7 @@ describe 'puppet' do
           super().merge(
             server_foreman: false,
             server_reports: 'store',
-            node_terminus: 'plain'
+            server_node_terminus: 'plain'
           )
         end
 
@@ -319,7 +319,7 @@ describe 'puppet' do
           )
         end
 
-        it { should raise_error(Puppet::Error, %r{Invalid value of $server_node_terminus}) }
+        it { should raise_error(Puppet::Error, %r{server_node_terminus}) }
       end
 
       describe 'with server_default_manifest => true and undef content' do

--- a/spec/classes/puppet_server_spec.rb
+++ b/spec/classes/puppet_server_spec.rb
@@ -285,30 +285,41 @@ describe 'puppet' do
         it { should contain_puppet__config__main('hiera_config').with_value('/etc/puppet/hiera/production/hiera.yaml') }
       end
 
-      describe 'without foreman' do
+      describe 'without foreman, default external ENC' do
         let(:params) do
           super().merge(
             server_foreman: false,
             server_reports: 'store',
-            server_external_nodes: ''
           )
         end
 
         it { should_not contain_class('puppetserver_foreman') }
-        it { should contain_puppet__config__server('node_terminus').with_value('plain') }
-        it { should_not contain_puppet__config__server('external_nodes') }
+        it { should contain_puppet__config__server('node_terminus').with_value('exec') }
+        it { should contain_puppet__config__server('external_nodes').with_value('/etc/puppetlabs/puppet/node.rb') }
       end
 
-      describe 'with explicit plain terminus' do
+      describe 'without foreman, plain ENC' do
         let(:params) do
           super().merge(
-            server_node_terminus: 'plain',
-            server_external_nodes: ''
+            server_foreman: false,
+            server_reports: 'store',
+            node_terminus: 'plain'
           )
         end
 
-        it { should contain_puppet__config__server('node_terminus').with_value('plain') }
+        it { should_not contain_class('puppetserver_foreman') }
+        it { should_not contain_puppet__config__server('node_terminus') }
         it { should_not contain_puppet__config__server('external_nodes') }
+      end
+
+      describe 'invalid node_terminus' do
+        let(:params) do
+          super().merge(
+            server_node_terminus: 'loremIpsum',
+          )
+        end
+
+        it { should raise_error(Puppet::Error, %r{Invalid value of $server_node_terminus}) }
       end
 
       describe 'with server_default_manifest => true and undef content' do


### PR DESCRIPTION
Allow to override default value of [server]/node_terminus in puppet.conf.
Useful in case of standalone (non-Foreman) Puppet Server installs without an ENC.

Copy of: #921 
Rebased on to master